### PR TITLE
fix(aita): allow shorter flight number and longer airline code

### DIFF
--- a/src/lib/import/aita.ts
+++ b/src/lib/import/aita.ts
@@ -7,7 +7,7 @@ import { page } from '$app/stores';
 
 export const processAITAFile = (input: string) => {
   const flightPattern =
-    /^.*?;(\w{2};\d{3,4});(\w*);(\w{3});(\w{3});([\d\-T:]+);([\d\-T:]+);([\d\-T:]+);([\d\-T:]+);(.*)/gm;
+    /^.*?;(\w{2,4};\d{2,4});(\w*);(\w{3});(\w{3});([\d\-T:]+);([\d\-T:]+);([\d\-T:]+);([\d\-T:]+);(.*)/gm;
 
   const flights: CreateFlight[] = [];
   let match;


### PR DESCRIPTION
🪄 What this MR does:  
-

This MR addresses an import issue caused by short flight number and longer airline code.

Here you have my AITA flight causing this issue:


```
None;None;None;None;None;None;search;EK;92;388;MXP;DXB;2023-02-18T20:35:00;2023-02-19T02:50:00;2023-02-18T21:35:00;2023-02-19T06:50:00;2022-12-19T11:17:35.226515


None;None;None;None;None;None;search;VOE;1474;320;LIN;SUF;2021-07-16T09:10:00;2021-07-16T10:55:00;2021-07-16T11:10:00;2021-07-16T12:55:00;2021-05-16T20:50:45
```
