### PR TITLE
fix: prevent possible date mismatches due to timezone conversions

### DIFF
--- a/src/lib/utils/datetime/parse.test.ts
+++ b/src/lib/utils/datetime/parse.test.ts
@@ -6,6 +6,9 @@ describe('mergeTimeWithDate', () => {
   it('should merge date and time correctly for 24-hour format', () => {
     const result = mergeTimeWithDate('2023-10-10', '9:30', 'America/New_York');
     expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(9);
     expect(result.getMinutes()).toBe(30);
   });
@@ -13,6 +16,9 @@ describe('mergeTimeWithDate', () => {
   it('should merge date and time correctly at 00:30', () => {
     const result = mergeTimeWithDate('2023-10-10', '00:30', 'America/New_York');
     expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(0);
     expect(result.getMinutes()).toBe(30);
   });
@@ -24,6 +30,9 @@ describe('mergeTimeWithDate', () => {
       'America/New_York',
     );
     expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(10);
     expect(result.getMinutes()).toBe(30);
   });
@@ -35,6 +44,9 @@ describe('mergeTimeWithDate', () => {
       'America/New_York',
     );
     expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(14);
     expect(result.getMinutes()).toBe(45);
   });
@@ -46,6 +58,9 @@ describe('mergeTimeWithDate', () => {
       'America/New_York',
     );
     expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(0);
     expect(result.getMinutes()).toBe(0);
   });
@@ -57,6 +72,9 @@ describe('mergeTimeWithDate', () => {
       'America/New_York',
     );
     expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(12);
     expect(result.getMinutes()).toBe(0);
   });

--- a/src/lib/utils/datetime/parse.ts
+++ b/src/lib/utils/datetime/parse.ts
@@ -21,7 +21,7 @@ export const mergeTimeWithDate = (
   time: string,
   tzId: string,
 ): TZDate => {
-  const date = parseISO(dateString);
+  const date = parseLocalISO(dateString, tzId);
   const match = time.match(timePartsRegex);
   if (!match) {
     throw new Error('Invalid format');


### PR DESCRIPTION
When editing a flight whose date in UTC is different from its local date, it could in some rare cases confuse the program into giving an "Arrival must be after departure" error. 
Closes #105 