### PR TITLE
fix: ignore duration provided by JetLog export

### DIFF
--- a/src/lib/import/jetlog.ts
+++ b/src/lib/import/jetlog.ts
@@ -104,9 +104,10 @@ export const processJetLogFile = async (
               ),
             )
           : null;
-    const duration = row.duration
-      ? +row.duration * 60
-      : departure && arrival
+
+    // We ignore the duration provided by JetLog and calculate it ourselves, as theirs is at best just as good as our calculation
+    const duration =
+      departure && arrival
         ? differenceInSeconds(arrival, departure)
         : estimateFlightDuration(
             { lng: from.lon, lat: from.lat },


### PR DESCRIPTION
JetLog's calculated duration is incorrect when the local arrival time is before the local departure time. 
As duration is just the difference between departure and arrival, AirTrail now calculates the duration itself (without the aforementioned issue). 