### PR TITLE
fix: show full aircraft names in statistics

### DIFF
--- a/src/lib/components/modals/statistics/charts/PieCharts.svelte
+++ b/src/lib/components/modals/statistics/charts/PieCharts.svelte
@@ -4,8 +4,8 @@
   import { page } from '$app/state';
   import { ContinentMap } from '$lib/db/types';
   import { type FlightData, toTitleCase } from '$lib/utils';
-  import { getAircraftLabel } from '$lib/utils/data/aircraft';
   import { airlineFromICAO } from '$lib/utils/data/airlines';
+  import { aircraftFromICAO } from '$lib/utils/data/aircraft';
 
   let { flights }: { flights: FlightData[] } = $props();
 
@@ -87,10 +87,12 @@
   const topAirlineDistribution = $derived.by(() => {
     const counts = flights.reduce<Record<string, number>>((acc, flight) => {
       if (!flight.airline) return acc;
+
       const label = airlineFromICAO(flight.airline)?.name;
       if (label) {
         acc[label] = (acc[label] || 0) + 1;
       }
+
       return acc;
     }, {});
 
@@ -108,10 +110,12 @@
   const topAircraftDistribution = $derived.by(() => {
     const counts = flights.reduce<Record<string, number>>((acc, flight) => {
       if (!flight.aircraft) return acc;
-      const label = getAircraftLabel(flight.aircraft);
+
+      const label = aircraftFromICAO(flight.aircraft)?.name;
       if (label) {
         acc[label] = (acc[label] || 0) + 1;
       }
+
       return acc;
     }, {});
 

--- a/src/lib/utils/data/aircraft.ts
+++ b/src/lib/utils/data/aircraft.ts
@@ -1,8 +1,4 @@
-import { toTitleCase } from '../string';
-
 import { AIRCRAFT } from '$lib/data/aircraft';
-
-const labelCache = new Map<string, string | null>();
 
 export type Aircraft = (typeof AIRCRAFT)[number];
 
@@ -15,20 +11,4 @@ export const WTC_TO_LABEL = {
 
 export const aircraftFromICAO = (icao: string): Aircraft | null => {
   return AIRCRAFT.find((aircraft) => aircraft.icao === icao) ?? null;
-};
-
-export const getAircraftLabel = (icao: string): string | null => {
-  if (labelCache.has(icao)) return labelCache.get(icao)!;
-
-  const aircraft = aircraftFromICAO(icao);
-  if (!aircraft || !aircraft.name) {
-    labelCache.set(icao, null);
-    return null;
-  }
-  const parts = aircraft.name.split(' ');
-  const manufacturer = parts[0]!;
-  const model = parts[1]!;
-  const label = `${toTitleCase(manufacturer)} ${toTitleCase(model)}`;
-  labelCache.set(icao, label);
-  return label;
 };


### PR DESCRIPTION
The previous parsing of aircraft manufacturer and model also had some unaccounted-for edgecases. 