### PR TITLE
docs: update examples for multiple origins in environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Your domain, e.g https://example.com
 # You might have to add :443 if you are using https through a reverse proxy
-# If you need to provide multiple domains, pass a comma-separated list to ORIGINS instead (replace ORIGIN)
 ORIGIN=http://localhost:3000
+# If you need to provide multiple domains, uncomment and pass a comma-separated list to ORIGINS instead (replace ORIGIN)
+# ORIGINS=http://localhost:3000,https://flights.example.com
 
 # The database URL used by the application.
 # If you are using the provided docker-compose file, you should only change the "password" part of the URL

--- a/docs/content/docs/install/docker-compose.mdx
+++ b/docs/content/docs/install/docker-compose.mdx
@@ -32,7 +32,7 @@ AirTrail requires Docker Compose version 2.x or higher.
   <div className="step">
     **Configure the environment variables**
 
-    - Set the `ORIGIN` variable to the domain name or IP address that the application will be accessed from.
+    - Set the `ORIGIN` variable to the domain name or IP address that the application will be accessed from. For multiple domain names or IP addresses, use the `ORIGINS` variable instead and pass a comma-separated list.
     - Populate custom database information if necessary.
     - Consider changing DB_PASSWORD to a custom value. Postgres is not publicly exposed, so this password is only used for
       local authentication. To avoid issues with Docker parsing this value, it is best to use only the characters A-Za-z0-9.

--- a/docs/content/docs/install/portainer.mdx
+++ b/docs/content/docs/install/portainer.mdx
@@ -20,7 +20,7 @@ To install Portainer, you can follow the [Official documentation](https://docs.p
       - Replace all instances of `.env` with `stack.env`
         ![Replace .env with stack.env](./img/portainer-stack-env.png)
     - **Environment variables**: Go into "Advanced mode" and copy-paste the contents of [.env](https://raw.githubusercontent.com/JohanOhly/AirTrail/main/.env.example) into the text area.
-      - Change the `ORIGIN` to the URL that you will be accessing your AirTrail instance from.
+      - Change the `ORIGIN` to the URL that you will be accessing your AirTrail instance from. Or use `ORIGINS` for passing multiple URLs in a comma-separated list.
       - Change the `DB_PASSWORD` to a secure password. Optionally, change other database settings.
 
   </div>


### PR DESCRIPTION
Updates to include `ORIGINS` environment variable from #241 in `env.example` and documentation.