### PR TITLE
feat: add Sukhoi Superjet 100 to aircraft list

### DIFF
--- a/src/lib/data/aircraft.ts
+++ b/src/lib/data/aircraft.ts
@@ -629,4 +629,9 @@ export const AIRCRAFT = [
     icao: 'AC90',
     wtc: 'L',
   },
+  {
+    name: 'Sukhoi Superjet 100',
+    icao: 'SU95',
+    wtc: 'M',
+  },
 ] as const;


### PR DESCRIPTION
This PR adds the Sukhoi Superjet 100 to the aircraft list in `aircraft.ts`:

```ts
{
  name: 'Sukhoi Superjet 100',
  icao: 'SU95',
  wtc: 'M',
}
```

- ICAO code: SU95
- Wake Turbulence Category (WTC): M (Medium)

The [Sukhoi Superjet 100](https://en.wikipedia.org/wiki/Sukhoi_Superjet_100) is a regional jet commonly used by airlines in Russia and other countries. Adding it helps improve completeness of the aircraft dataset for users who have flown on this type.