### PR TITLE
fix: when editing flight time, always display time in latin format * as our validator only supports latin time input so would prevent you from saving the flight

### DIFF
--- a/src/lib/components/modals/edit-flight/EditFlightModal.svelte
+++ b/src/lib/components/modals/edit-flight/EditFlightModal.svelte
@@ -13,7 +13,7 @@
   import * as Form from '$lib/components/ui/form';
   import { trpc } from '$lib/trpc';
   import type { FlightData } from '$lib/utils';
-  import { formatAsTime } from '$lib/utils/datetime';
+  import { formatAsTime, isUsingAmPm } from '$lib/utils/datetime';
   import { flightSchema } from '$lib/zod/flight';
 
   let {
@@ -24,6 +24,9 @@
     triggerDisabled: boolean;
   } = $props();
 
+  // If their language uses 12-hour time format, we display the time in *a* 12-hour format
+  // (not necessarily the user's locale, because our time validator doesn't support all languages).
+  const displayLocale = isUsingAmPm() ? 'en-US' : 'fr-FR';
   const schemaFlight = {
     ...(flight.raw as unknown as Omit<
       typeof flight.raw,
@@ -33,8 +36,12 @@
       ? flight.departure.toISOString()
       : flight.date.toISOString(),
     arrival: flight.arrival ? flight.arrival.toISOString() : null,
-    departureTime: flight.departure ? formatAsTime(flight.departure) : null,
-    arrivalTime: flight.arrival ? formatAsTime(flight.arrival) : null,
+    departureTime: flight.departure
+      ? formatAsTime(flight.departure, displayLocale)
+      : null,
+    arrivalTime: flight.arrival
+      ? formatAsTime(flight.arrival, displayLocale)
+      : null,
   };
 
   let open = $state(false);

--- a/src/lib/utils/datetime/format.ts
+++ b/src/lib/utils/datetime/format.ts
@@ -24,8 +24,8 @@ export const formatAsDateTime = (date: TZDate) =>
     hour: 'numeric',
     minute: 'numeric',
   }).format(date);
-export const formatAsTime = (date: TZDate) =>
-  new Intl.DateTimeFormat(undefined, {
+export const formatAsTime = (date: TZDate, overrideLocale?: string) =>
+  new Intl.DateTimeFormat(overrideLocale, {
     timeZone: date.timeZone,
     hour: 'numeric',
     minute: 'numeric',

--- a/src/lib/utils/datetime/helpers.ts
+++ b/src/lib/utils/datetime/helpers.ts
@@ -19,7 +19,15 @@ export const isSameLocalDay = (date1: TZDate, date2: TZDate) => {
 };
 
 export const isUsingAmPm = () => {
-  return new Date().toLocaleTimeString().match(/am|pm/i) !== null;
+  const test = new Date(Date.UTC(2025, 0, 1, 13, 0, 0)); // 13:00 UTC
+  const formatted = test.toLocaleTimeString(undefined, { hour: 'numeric' });
+
+  // Extract the first number from the string
+  const match = formatted.match(/\d+/);
+  const hour = match ? parseInt(match[0], 10) : NaN;
+
+  // If the hour is <= 12, user is on 12h clock; if > 12, user is on 24h clock
+  return hour <= 12;
 };
 
 export const getStartOfWeekDay = () => {


### PR DESCRIPTION
Closes #265