### PR TITLE
feat: Allow specifying only ICAO codes for Airlines and Aircraft when creating/updating a Flight via the API.

### DIFF
--- a/src/routes/api/flight/save/+server.ts
+++ b/src/routes/api/flight/save/+server.ts
@@ -32,18 +32,26 @@ const defaultSeat = {
   seatClass: null,
 };
 
-const saveApiFlightSchema = flightSchema.merge(
-  z.object({
-    from: z.string(),
-    to: z.string(),
-  }),
-).omit({ aircraft: true, airline: true })
-.merge(z.object({
-    aircraft: aircraftSchema.omit({ id: true, name: true }).nullable()
-  }))
-  .merge(z.object({
-    airline: airlineSchema.omit({ id: true, iata: true, name: true }).nullable()
-  }));
+const saveApiFlightSchema = flightSchema
+  .merge(
+    z.object({
+      from: z.string(),
+      to: z.string(),
+    }),
+  )
+  .omit({ aircraft: true, airline: true })
+  .merge(
+    z.object({
+      aircraft: aircraftSchema.omit({ id: true, name: true }).nullable(),
+    }),
+  )
+  .merge(
+    z.object({
+      airline: airlineSchema
+        .omit({ id: true, iata: true, name: true })
+        .nullable(),
+    }),
+  );
 
 const dateTimeSchema = z.string().datetime({ offset: true });
 
@@ -91,14 +99,14 @@ export const POST: RequestHandler = async ({ request }) => {
     return apiError('Invalid arrival airport');
   }
 
-  let aircraft
+  let aircraft;
   if (parsed.data.aircraft && parsed.data.aircraft.icao) {
-    aircraft = await getAircraftByIcao(parsed.data.aircraft.icao)
+    aircraft = await getAircraftByIcao(parsed.data.aircraft.icao);
   }
 
-  let airline
+  let airline;
   if (parsed.data.airline && parsed.data.airline.icao) {
-    airline = await getAirlineByIcao(parsed.data.airline.icao)
+    airline = await getAirlineByIcao(parsed.data.airline.icao);
   }
 
   const data = {
@@ -106,7 +114,7 @@ export const POST: RequestHandler = async ({ request }) => {
     from,
     to,
     aircraft,
-    airline
+    airline,
   };
 
   if (data.seats[0]?.userId === '<USER_ID>') {

--- a/src/routes/api/flight/save/+server.ts
+++ b/src/routes/api/flight/save/+server.ts
@@ -39,17 +39,14 @@ const saveApiFlightSchema = flightSchema
       to: z.string(),
     }),
   )
-  .omit({ aircraft: true, airline: true })
   .merge(
     z.object({
-      aircraft: aircraftSchema.omit({ id: true, name: true }).nullable(),
+      aircraft: aircraftSchema.shape.icao,
     }),
   )
   .merge(
     z.object({
-      airline: airlineSchema
-        .omit({ id: true, iata: true, name: true })
-        .nullable(),
+      airline: airlineSchema.shape.icao,
     }),
   );
 
@@ -100,13 +97,19 @@ export const POST: RequestHandler = async ({ request }) => {
   }
 
   let aircraft;
-  if (parsed.data.aircraft && parsed.data.aircraft.icao) {
-    aircraft = await getAircraftByIcao(parsed.data.aircraft.icao);
+  if (parsed.data.aircraft) {
+    aircraft = await getAircraftByIcao(parsed.data.aircraft);
+    if (!aircraft) {
+      return apiError('Invalid aircraft');
+    }
   }
 
   let airline;
-  if (parsed.data.airline && parsed.data.airline.icao) {
-    airline = await getAirlineByIcao(parsed.data.airline.icao);
+  if (parsed.data.airline) {
+    airline = await getAirlineByIcao(parsed.data.airline);
+    if (!airline) {
+      return apiError('Invalid airline');
+    }
   }
 
   const data = {


### PR DESCRIPTION
This closes #329.

Adds support for specifying aircraft and airline information in POST requests to `/api/flight/save` without knowing the ID of the aircraft or airline.

```
aircraft: {
  icao: "XYZ"
}
```
and
```
airline: {
  icao: "ABC"
}
```
I've never written Typescript, so here we are. Let me know how this needs to be modified.