### PR TITLE
fix: allow scrolling in settings on mobile

### DIFF
--- a/src/lib/components/modals/settings/SettingsModal.svelte
+++ b/src/lib/components/modals/settings/SettingsModal.svelte
@@ -76,7 +76,7 @@
     </div>
     <Separator />
     <div class="flex flex-col gap-8 md:flex-row md:gap-16">
-      <aside class="flex md:flex-col md:-mx-4 md:w-1/5 overflow-auto">
+      <aside class="flex md:flex-col md:-mx-4 md:w-1/5 overflow-x-auto">
         <SettingsTabContainer>
           {#each ACCOUNT_SETTINGS as setting}
             {@const isActive = activeTab === setting.id}

--- a/src/lib/components/ui/drawer/drawer-content.svelte
+++ b/src/lib/components/ui/drawer/drawer-content.svelte
@@ -18,12 +18,16 @@
   <DrawerPrimitive.Content
     bind:ref
     class={cn(
-      'bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border',
+      'z-50 bg-background mt-24 fixed bottom-0 left-0 right-0 flex max-h-[90%] flex-col rounded-t-[10px] border',
       className,
     )}
     {...restProps}
   >
-    <div class="bg-muted mx-auto mt-4 h-2 w-[100px] rounded-full"></div>
-    {@render children?.()}
+    <div class="flex flex-col overflow-y-auto rounded-t-[10px] p-4">
+      <div
+        class="bg-muted mx-auto mb-4 h-1.5 w-[100px] shrink-0 rounded-full"
+      ></div>
+      {@render children?.()}
+    </div>
   </DrawerPrimitive.Content>
 </DrawerPrimitive.Portal>

--- a/src/lib/components/ui/modal/Modal.svelte
+++ b/src/lib/components/ui/modal/Modal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
-  import * as Dialog from '$lib/components/ui/dialog/index.js';
-  import * as Drawer from '$lib/components/ui/drawer/index.js';
+  import * as Dialog from '$lib/components/ui/dialog';
+  import * as Drawer from '$lib/components/ui/drawer';
   import { cn } from '$lib/utils';
   import { isMediumScreen } from '$lib/utils/size';
 
@@ -41,9 +41,7 @@
 {:else}
   <Drawer.Root bind:open>
     <Drawer.Content>
-      <div class="mx-4 mb-4 overflow-y-auto">
-        {@render children()}
-      </div>
+      {@render children()}
     </Drawer.Content>
   </Drawer.Root>
 {/if}


### PR DESCRIPTION
Previously, if the settings were higher than the phone screen, it would just cut off part of the settings. Now it lets you scroll in those cases. 