### PR TITLE
fix: prevent date shift when updating flight with no time

### DIFF
--- a/src/lib/components/modals/edit-flight/EditFlightModal.svelte
+++ b/src/lib/components/modals/edit-flight/EditFlightModal.svelte
@@ -34,7 +34,9 @@
     >),
     departure: flight.departure
       ? flight.departure.toISOString()
-      : flight.date?.toISOString(),
+      : flight.raw.date
+        ? new Date(flight.raw.date + 'T00:00:00Z').toISOString()
+        : null,
     arrival: flight.arrival ? flight.arrival.toISOString() : null,
     departureTime: flight.departure
       ? formatAsTime(flight.departure, displayLocale)


### PR DESCRIPTION
Previously, updating a flight that had no time set would convert the date to UTC based on the user's local timezone, potentially shifting the date by one day. This change uses the raw date string to construct a UTC midnight date, ensuring the date remains consistent regardless of the local timezone.

Fixes #359