### PR TITLE
feat: re-add close button on stats page

### DIFF
--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -11,11 +11,12 @@
   import PieCharts from './charts/PieCharts.svelte';
   import StatsCard from './StatsCard.svelte';
 
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { Button } from '$lib/components/ui/button';
   import { Modal } from '$lib/components/ui/modal';
-  import { type VisitedCountry, wasVisited } from '$lib/db/types';
   import * as Select from '$lib/components/ui/select';
+  import { type VisitedCountry, wasVisited } from '$lib/db/types';
   import {
     COUNTRY_BAR_CHARTS,
     COUNTRY_CHARTS,
@@ -25,7 +26,6 @@
   import { type FlightData, kmToMiles } from '$lib/utils';
   import { Duration, nowIn } from '$lib/utils/datetime';
   import { round } from '$lib/utils/number';
-  import { resolve } from '$app/paths';
 
   let {
     open = $bindable<boolean>(),
@@ -170,7 +170,7 @@
   bind:open
   class="max-w-full h-full overflow-y-auto rounded-none!"
   dialogOnly
-  closeOnEscape={true}
+  closeOnEscape={false}
   closeButton={true}
 >
   {#if activeChart}
@@ -182,7 +182,9 @@
     />
   {:else}
     <div class="space-y-4">
-      <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between pr-2 sm:pr-4 md:pr-8">
+      <div
+        class="flex flex-col sm:flex-row items-start sm:items-center justify-between pr-2 sm:pr-4 md:pr-8"
+      >
         <h2 class="text-3xl font-bold tracking-tight">Statistics</h2>
         <div class="mt-3 sm:mt-0">
           <Select.Root type="single" bind:value={selectedYear}>


### PR DESCRIPTION
Issue #388 points out that the close button was removed when the select by year was added. Personally, I think that removing this button leads to a worse users experience so this PR adds it back. The design is responsive so that the year select gets stacked vertically on mobile.

**Desktop:**
<img width="715" height="719" alt="Screenshot_20260109_094232" src="https://github.com/user-attachments/assets/3ab52bf4-52dd-4130-9c5b-90ca4083bfb2" />

**Mobile:**
<img width="596" height="601" alt="Screenshot_20260109_094344" src="https://github.com/user-attachments/assets/09dffcb5-ad62-439f-b82f-8ba8df95a8cc" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings back the close button and restores Escape to exit drilldown charts. Adjusts the header layout so the year selector stacks under the title on small screens.

<sup>Written for commit d364fe12333afaed96ae0bcc96516a9a6cd9b8aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

