### PR TITLE
fix: filter icon for departure and arrival filters

### DIFF
--- a/src/lib/components/flight-filters/Filters.svelte
+++ b/src/lib/components/flight-filters/Filters.svelte
@@ -159,7 +159,7 @@
     bind:filterValues={filters.departureAirports}
     title="Departure Airport"
     placeholder="Search departure airports"
-    icon="depart"
+    triggerIcon="depart"
     disabled={flights.length === 0}
     options={departureAirports}
   />
@@ -167,7 +167,7 @@
     bind:filterValues={filters.arrivalAirports}
     title="Arrival Airport"
     placeholder="Search arrival airports"
-    icon="arrive"
+    triggerIcon="arrive"
     disabled={flights.length === 0}
     options={arrivalAirports}
   />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the icons in the Departure and Arrival filters by using the correct SelectFilter prop (triggerIcon instead of icon). Icons now render properly in the trigger, restoring the expected UI.

<sup>Written for commit 3f6259eb04bf63837160632065d450e16070180a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

