### PR TITLE
docs: update for compose file

### DIFF
--- a/docker/production/compose.yml
+++ b/docker/production/compose.yml
@@ -27,8 +27,11 @@ services:
     volumes:
       # Required for file uploads (e.g., airline icons)
       # The path to the right of the colon needs to match UPLOAD_LOCATION in your .env file
-      # It needs to be writable for UID/GID 1000/1000
+      # It needs to be writable for UID:GID 1000:1000
       - uploads:/app/uploads
+      # If docker isn't running as UID 1000 on your host, consider using a bind mount volume instead, such as:
+      # - ./data/uploads:/app/uploads
+      # and create the folder ./data/uploads with UID:GID 1000:1000
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
See discussions in #398 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified upload volume permissions in production Docker Compose to prevent write errors. Added guidance on UID:GID 1000:1000 and a bind mount example for hosts not running Docker as UID 1000.

<sup>Written for commit 10cd696600f69eba3918c2cfd46bcd01235f3f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

