### PR TITLE
feat: add flight duration warning to flights exceeding 24h

### DIFF
--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -95,15 +95,9 @@ export const validateAndSaveFlight = async (
     return pathError('arrival', 'Arrival must be after departure');
   }
 
-  const maxDuration = 24 * 60 * 60;
-
   let duration: number | null = null;
   if (departure && arrival) {
     duration = differenceInSeconds(arrival, departure);
-    if (duration > maxDuration)
-    {
-      return pathError('arrival', 'Flight duration cannot be longer than 24 hours');
-    }
   } else if (from.id !== to.id) {
     // if the airports are the same, the duration can't be calculated
     const fromLonLat = { lon: from.lon, lat: from.lat };


### PR DESCRIPTION
Fixes https://github.com/johanohly/AirTrail/issues/402

The general intent here is to prevent accidental duration errors when recording flights, as right now it is possible to add infinitely long flights which can cause accidental errors. 

This PR adds a 24h limit to the flight duration, which I think should honestly cover pretty much 99.99% of all the needs and keeps the code clean.

As discussed in the linked issue, a soft warning might be a different approach, but I do think that this is still a valid and neat improvement that could be iterated on later.  


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a soft warning when flight duration exceeds 24 hours during validation to catch unrealistic flights. If arrival minus departure is over 24 hours, we display a warning and still allow saving.

<sup>Written for commit 601f7949c46ebe7b66fb8a3e6165f0fbd7eeb1ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



