### PR TITLE
feat: add aircrafts

### DIFF
--- a/data/aircraft.json
+++ b/data/aircraft.json
@@ -730,11 +730,6 @@
     "icao": "C680"
   },
   {
-    "id": "daher-kodiak-100",
-    "name": "Daher Kodiak 100",
-    "icao": "K100"
-  },
-  {
     "id": "cessna-citation-cj2",
     "name": "Cessna Citation CJ2",
     "icao": "C25A"
@@ -798,6 +793,11 @@
     "id": "convair-cv-580-convair-cv-600-convair-cv-640",
     "name": "Convair CV-580, Convair CV-600, Convair CV-640",
     "icao": "CVLT"
+  },
+  {
+    "id": "daher-kodiak-100",
+    "name": "Daher Kodiak 100",
+    "icao": "K100"
   },
   {
     "id": "dassault-falcon-2000",


### PR DESCRIPTION
This PR adds all missing aircrafts from Wikipedia's list (https://en.wikipedia.org/wiki/List_of_aircraft_type_designators), namely Airbus A330-900neo (A339, https://github.com/johanohly/AirTrail/issues/410), but also many many others.

It does _not_ include F50 and K100 (https://github.com/johanohly/AirTrail/pull/414).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 685 missing aircraft type designators to data/aircraft.json to expand aircraft recognition across the app. Includes Airbus A330-900neo (A339) requested in #410.

- **New Features**
  - Added ICAO-coded entries from Wikipedia’s aircraft type designators list.
  - Notable additions: A330-900neo (A339), A330-700 BelugaXL (A337), A400M (A400), 747-400 LCF (BLCF), 777-8/-9 (B778/B779), C919, ARJ21 (AJ27), SSJ100 (SU95), ATR 72-600 (AT76), Gulfstream G650/G700 (GLF6/GA7C).

<sup>Written for commit 2d8e1c15f5aa6d738cbb5a4f784b1ea11d196e89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

