### PR TITLE
fix: correct aircraft information

### DIFF
--- a/data/aircraft.json
+++ b/data/aircraft.json
@@ -61,7 +61,7 @@
   },
   {
     "id": "airbus-a319-2",
-    "name": "Airbus A319",
+    "name": "Airbus A319neo",
     "icao": "A19N"
   },
   {
@@ -297,7 +297,7 @@
   {
     "id": "beechcraft-1900",
     "name": "Beechcraft 1900",
-    "icao": "BE19"
+    "icao": "B190"
   },
   {
     "id": "beechcraft-baron",
@@ -457,7 +457,7 @@
   {
     "id": "boeing-747sp",
     "name": "Boeing 747SP",
-    "icao": "N74S"
+    "icao": "B74S"
   },
   {
     "id": "boeing-747sr",


### PR DESCRIPTION
While working on #415, I noticed some errors in the existing aircrafts data:

- the `A19N` should be called `Airbus A319neo` and not just `Airbus A319`, which already exists in the file as `A319`. This matches the existing `A20N`, `A21N`, and https://skybrary.aero/aircraft/a19n and https://doc8643.com/aircraft/A19N
- The `Beechcraft 1900` has the ICAO code `B190` and not `BE19`. `BE19` seems to be a smaller, older plane, Beechcraft 19 Musketeer Sport (https://doc8643.com/aircraft/B190, https://doc8643.com/aircraft/BE19).
- The `Boeing 747SP` is `B74S` and not `N74S`. There is an edit on German Wikipedia replacing `N` with `B` in December 2025 on ICAO-List (https://de.wikipedia.org/w/index.php?title=Liste_der_Flugzeugtypencodes&diff=262446352&oldid=258914880). On the English Wikipedia, the change was already done in October 2015 (!) (https://en.wikipedia.org/w/index.php?title=List_of_aircraft_type_designators&diff=prev&oldid=685646920).

While digging through the data, I found the website https://doc8643.com, and an official ICAO document https://cfapps.icao.int/doc8643/reports/Part2-By%20Type%20Designator%28Decode%29.pdf (from 2016), which might be useful for future reference.

**Note:** I'm not exactly sure how changes in Aircraft identifiers / names are handled by AirTrail when users update the data, and already have a flight with a `N74S` in their database. It looks like the `flight` tables only uses the numeric index of the `aircraft` table. The `aircraft` table is updated using:
https://github.com/johanohly/AirTrail/blob/b6e7b1d783759e2fc6b31b1ddf82f9419e639964/src/lib/server/utils/sync.ts#L141-L164
where `sourceID` is the `"id": "boeing-747sp"` from the json file. So as long as the `id` does not change, the `name` and `icao` fields can be freely modified, and will just update in the UI, am I correct?

The `id` of the `A19N` could also be changed from `airbus-a319-2` to `airbus-a319neo` to match the 320 and 321, but that would lead to two "Airbus A319neo" in the database/list for users who upgrade, correct?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected aircraft names and ICAO codes to match official ICAO designators, improving data accuracy and display.

- **Bug Fixes**
  - A19N: name updated to Airbus A319neo (was Airbus A319).
  - Beechcraft 1900: ICAO updated to B190 (was BE19).
  - Boeing 747SP: ICAO updated to B74S (was N74S).

- **Migration**
  - No migration needed. IDs unchanged, existing flights remain linked.

<sup>Written for commit 75c5ebb9b029b20da7e2644b9bb198108ba8669a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

