### PR TITLE
fix: avoid month offset in some Flighty imports

### DIFF
--- a/src/lib/import/flighty.ts
+++ b/src/lib/import/flighty.ts
@@ -1,5 +1,5 @@
 import { tz, TZDate } from '@date-fns/tz';
-import { addDays, differenceInSeconds, isBefore, parse } from 'date-fns';
+import { addDays, differenceInSeconds, isBefore } from 'date-fns';
 import { z } from 'zod';
 
 import { page } from '$app/state';
@@ -7,7 +7,7 @@ import type { PlatformOptions } from '$lib/components/modals/settings/pages/impo
 import type { CreateFlight, Seat } from '$lib/db/types';
 import { api } from '$lib/trpc';
 import { parseCsv } from '$lib/utils';
-import { toUtc } from '$lib/utils/datetime';
+import { parseLocalISO, toUtc } from '$lib/utils/datetime';
 
 const nullTransformer = (v: string) => (v === '' ? null : v);
 
@@ -38,9 +38,7 @@ const parseFlightyDateTime = (
   const dateTimeStr = actual || scheduled;
   if (!dateTimeStr) return null;
 
-  const parsed = parse(dateTimeStr, "yyyy-MM-dd'T'HH:mm", new Date(), {
-    in: tz(airportTz),
-  });
+  const parsed = parseLocalISO(dateTimeStr, airportTz);
 
   if (isNaN(parsed.getTime())) return null;
 


### PR DESCRIPTION
Fixes #419 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect month values in some Flighty imports by parsing local ISO datetimes in the airport’s timezone before converting to UTC. This ensures imported flights use the correct calendar date.

- **Bug Fixes**
  - Replace date-fns parse(...) with parseLocalISO(dateTimeStr, airportTz) in parseFlightyDateTime.
  - Prevents month-shift errors caused by timezone parsing.

<sup>Written for commit b34d8a446bdce92254620be8b904d6a19bb757c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

