### PR TITLE
fix: avoid month shifts in local datetime parsing

### DIFF
--- a/src/lib/utils/data/data.ts
+++ b/src/lib/utils/data/data.ts
@@ -4,7 +4,7 @@ import { isAfter } from 'date-fns';
 import { page } from '$app/state';
 import type { Airport, Flight } from '$lib/db/types';
 import { distanceBetween, toTitleCase } from '$lib/utils';
-import { nowIn, parseLocal, parseLocalizeISO } from '$lib/utils/datetime';
+import { nowIn, parseLocalISO, parseLocalizeISO } from '$lib/utils/datetime';
 
 type ExcludedType<T, U> = {
   [P in keyof T as P extends keyof U ? never : P]: T[P];
@@ -37,9 +37,9 @@ export const prepareFlightData = (data: Flight[]): FlightData[] => {
         date:
           departure ??
           (flight.date && flight.from
-            ? parseLocal(flight.date, 'yyyy-MM-dd', flight.from.tz)
+            ? parseLocalISO(`${flight.date}T00:00`, flight.from.tz)
             : flight.date
-              ? parseLocal(flight.date, 'yyyy-MM-dd', 'UTC')
+              ? parseLocalISO(`${flight.date}T00:00`, 'UTC')
               : null),
         departure,
         arrival:

--- a/src/lib/utils/datetime/parse.test.ts
+++ b/src/lib/utils/datetime/parse.test.ts
@@ -94,6 +94,23 @@ describe('mergeTimeWithDate', () => {
     expect(result.getMinutes()).toBe(59);
   });
 
+  it('should not shift months for Asia/Amman dates', () => {
+    // Regression: date-fns parse with tz() can shift some Asia/Amman
+    // dates (e.g. 2016-04-30) into March, making arrivals appear
+    // earlier than departures in UTC.
+    const result = mergeTimeWithDate(
+      '2016-04-30T00:00:00.000Z',
+      '2:00 am',
+      'Asia/Amman',
+    );
+    expect(result).toBeInstanceOf(TZDate);
+    expect(result.getFullYear()).toBe(2016);
+    expect(result.getMonth() + 1).toBe(4);
+    expect(result.getDate()).toBe(30);
+    expect(result.getHours()).toBe(2);
+    expect(result.getMinutes()).toBe(0);
+  });
+
   it('should throw an error for invalid date format', () => {
     expect(() =>
       mergeTimeWithDate('10-10-2023', '10:30', 'America/New_York'),

--- a/src/lib/utils/datetime/parse.ts
+++ b/src/lib/utils/datetime/parse.ts
@@ -43,12 +43,9 @@ export const mergeTimeWithDate = (
     }
   }
 
-  const result = parse(
-    `${year}-${month}-${day} ${hours}:${minutes}`,
-    'yyyy-M-d H:m',
-    new Date(),
-    { in: tz(tzId) },
-  );
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  const iso = `${year}-${pad(month)}-${pad(day)}T${pad(hours)}:${pad(minutes)}`;
+  const result = parseLocalISO(iso, tzId);
   if (!isValid(result)) {
     throw new Error('Invalid format');
   }


### PR DESCRIPTION
Fixes #419

Some timezone/date combinations (notably Asia/Amman around late April 2016) were parsed with `date-fns parse()` + `{ in: tz(...) }`, which can shift the month backward when the TZDate is constructed. That caused valid local times to become earlier in UTC, producing negative durations and the “Arrival must be after departure” error.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix local datetime parsing to prevent month shifts (notably in Asia/Amman), so arrivals no longer appear before departures after UTC conversion. Updated imports to parse ISO strings in the correct timezone and added a regression test.

- **Bug Fixes**
  - Switched FR24, JetLog, and data utils to parseLocalISO instead of date-fns parse+tz/parseLocal.
  - Updated mergeTimeWithDate to build a zero-padded local ISO string before parsing.
  - Added a regression test for Asia/Amman (2016-04-30 02:00) to ensure stable parsing.
  - Only estimate duration when both airports are known; otherwise return null.

<sup>Written for commit 71fb707e1a26c99acd63b098732d429109d94253. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

