### PR TITLE
fix: remove unnecessary sticky header in statistics drill-down

### DIFF
--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -179,6 +179,8 @@
   bind:open
   class="max-w-full h-full overflow-y-auto rounded-none!"
   dialogOnly
+  dialogNoPadding={Boolean(activeChart || activeContinent)}
+  drawerNoPadding={Boolean(activeChart || activeContinent)}
   closeOnEscape={false}
   closeButton={true}
 >

--- a/src/lib/components/modals/statistics/charts/ChartDrillDown.svelte
+++ b/src/lib/components/modals/statistics/charts/ChartDrillDown.svelte
@@ -55,9 +55,7 @@
 
 <div class="min-h-[80vh]">
   <!-- Header -->
-  <div
-    class="border-b border-zinc-200 dark:border-zinc-700 backdrop-blur-sm sticky top-0 z-10"
-  >
+  <div class="border-b border-zinc-200 dark:border-zinc-700">
     <div class="flex flex-col justify-center p-6">
       <Button
         variant="link"


### PR DESCRIPTION
Fixes #427

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the sticky header in the statistics drill-down so the modal close button stays visible, and applied conditional no-padding to the statistics modal during drill-downs for correct layout (fixes #427).

<sup>Written for commit 5fc55b098e68b80b236a6648153fa3d11a6decc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

