### PR TITLE
feat: guided onboarding

### DIFF
--- a/src/lib/components/NavigationDock.svelte
+++ b/src/lib/components/NavigationDock.svelte
@@ -48,6 +48,7 @@
     icon: Settings,
     id: 'settings-button',
     onClick: () => {
+      openModalsState.settingsTab = 'general';
       openModalsState.settings = true;
     },
   };

--- a/src/lib/components/modals/settings/SettingsModal.svelte
+++ b/src/lib/components/modals/settings/SettingsModal.svelte
@@ -21,7 +21,7 @@
   import { Button } from '$lib/components/ui/button';
   import { Modal } from '$lib/components/ui/modal';
   import { Separator } from '$lib/components/ui/separator';
-  import { versionState } from '$lib/state.svelte';
+  import { openModalsState, versionState } from '$lib/state.svelte';
   import { cn } from '$lib/utils';
   import { isMediumScreen } from '$lib/utils/size';
   import { checkForNewVersions } from '$lib/utils/version';
@@ -40,7 +40,7 @@
     { title: 'Users', id: 'users' },
     { title: 'OAuth', id: 'oauth' },
   ] as const;
-  type TabId =
+  type SettingsTabId =
     | (typeof ACCOUNT_SETTINGS)[number]['id']
     | (typeof ADMIN_SETTINGS)[number]['id'];
 
@@ -50,10 +50,17 @@
     open: boolean;
   } = $props();
 
-  let activeTab: TabId = $state('general');
+  let activeTab: SettingsTabId = $state('general');
   $effect(() => {
     if (!open) {
       activeTab = 'general';
+      openModalsState.settingsTab = 'general';
+    }
+  });
+
+  $effect(() => {
+    if (open) {
+      activeTab = openModalsState.settingsTab;
     }
   });
 

--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -29,6 +29,11 @@
   import { Duration, nowIn } from '$lib/utils/datetime';
   import { round } from '$lib/utils/number';
 
+  type VisitedCountryList = VisitedCountry & {
+    numeric: number;
+    alpha3: string;
+  };
+
   let {
     open = $bindable<boolean>(),
     allFlights,
@@ -37,7 +42,7 @@
   }: {
     open?: boolean;
     allFlights: FlightData[];
-    visitedCountries?: VisitedCountry[];
+    visitedCountries?: VisitedCountryList[];
     disableUserSeatFiltering?: boolean;
   } = $props();
 
@@ -109,9 +114,12 @@
     if (!activeChart) return {} as Record<string, number>;
     if (activeChart in COUNTRY_CHARTS) {
       return countryStatusData;
-    } else {
-      return FLIGHT_CHARTS[activeChart].aggregate(flights, ctx);
     }
+    if (activeChart in FLIGHT_CHARTS) {
+      const flightChartKey = activeChart as keyof typeof FLIGHT_CHARTS;
+      return FLIGHT_CHARTS[flightChartKey].aggregate(flights, ctx);
+    }
+    return {} as Record<string, number>;
   });
 
   // Country statistics

--- a/src/lib/components/onboarding/FlightsOnboarding.svelte
+++ b/src/lib/components/onboarding/FlightsOnboarding.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { PlaneTakeoff, Upload } from '@o7/icon/lucide';
+
+  import { browser } from '$app/environment';
+  import { page } from '$app/state';
+  import { Button } from '$lib/components/ui/button';
+  import { Card } from '$lib/components/ui/card';
+  import { Modal } from '$lib/components/ui/modal';
+  import { platforms } from '$lib/components/modals/settings/pages/import-page';
+  import { openModalsState } from '$lib/state.svelte';
+
+  let { flightsCount = 0 }: { flightsCount?: number } = $props();
+
+  const isAutomation = navigator.webdriver;
+
+  const importSources = $derived(
+    platforms
+      .map((platform) => platform.name)
+      .filter((name) => !name.startsWith('AirTrail'))
+      .map((name) => name.replace(' (ICS)', ''))
+      .join(', '),
+  );
+
+  let dismissed = $state(false);
+  let open = $state(false);
+
+  $effect(() => {
+    // By default, onboarding is disabled when E2E tests are running as to not disturb unrelated tests.
+    // Tests can explicitly enable it by adding ?onboarding to the URL.
+    const allowAutomation = page.url.searchParams.has('onboarding');
+    open =
+      !dismissed && flightsCount === 0 && (!isAutomation || allowAutomation);
+  });
+
+  const startImport = () => {
+    dismissed = true;
+    open = false;
+    openModalsState.settingsTab = 'import';
+    openModalsState.settings = true;
+  };
+
+  const addFirstFlight = () => {
+    dismissed = true;
+    open = false;
+    openModalsState.addFlight = true;
+  };
+
+  const skip = () => {
+    dismissed = true;
+    open = false;
+  };
+</script>
+
+<Modal
+  bind:open
+  class="max-w-2xl"
+  closeButton={false}
+  closeOnOutsideClick={false}
+  handleBackButton={false}
+  dialogNoPadding
+>
+  <div class="p-6 md:p-8 space-y-6">
+    <div class="space-y-2">
+      <p
+        class="text-xs font-semibold tracking-[0.2em] text-muted-foreground uppercase"
+      >
+        First flight
+      </p>
+      <h2 class="text-2xl font-bold tracking-tight">
+        Bring your flights into AirTrail
+      </h2>
+      <p class="text-muted-foreground text-sm">
+        Import your history or add a single flight to begin your personal map.
+      </p>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <Card class="p-4 flex flex-col gap-4">
+        <div class="flex items-start gap-3">
+          <div
+            class="size-10 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0"
+          >
+            <Upload size={18} />
+          </div>
+          <div>
+            <p class="font-semibold">Import flights</p>
+            <p class="text-xs text-muted-foreground">
+              {importSources}.
+            </p>
+          </div>
+        </div>
+        <Button onclick={startImport} class="w-full mt-auto"
+          >Start import</Button
+        >
+      </Card>
+      <Card class="p-4 flex flex-col gap-4">
+        <div class="flex items-start gap-3">
+          <div
+            class="size-10 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0"
+          >
+            <PlaneTakeoff size={18} />
+          </div>
+          <div>
+            <p class="font-semibold">Add your first flight</p>
+            <p class="text-xs text-muted-foreground">
+              Quick manual entry for one flight.
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          onclick={addFirstFlight}
+          class="w-full mt-auto"
+        >
+          Add flight
+        </Button>
+      </Card>
+    </div>
+    <div
+      class="flex items-center justify-between text-xs text-muted-foreground"
+    >
+      <span>Tip: you can always import later in Settings > Import.</span>
+      <Button variant="ghost" size="sm" onclick={skip}>Not now</Button>
+    </div>
+  </div>
+</Modal>

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -40,7 +40,7 @@ export type CreateFlight = Omit<Flight, 'id' | 'seats'> & {
 export type PublicShare = Selectable<public_share>;
 export type VisitedCountry = Selectable<visited_country>;
 
-export function wasVisited(country: VisitedCountry): boolean {
+export function wasVisited(country: Pick<VisitedCountry, 'status'>): boolean {
   return country.status === 'visited' || country.status === 'lived';
 }
 

--- a/src/lib/server/routes/visited-countries.ts
+++ b/src/lib/server/routes/visited-countries.ts
@@ -20,7 +20,7 @@ export const visitedCountriesRouter = router({
   list: authedProcedure.query(async ({ ctx }) => {
     const list = await db
       .selectFrom('visitedCountry')
-      .select(['note', 'code', 'status'])
+      .select(['id', 'userId', 'note', 'code', 'status'])
       .where('userId', '=', ctx.user.id)
       .execute();
 

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -5,11 +5,32 @@ export const flightAddedState = $state({
   added: false,
 });
 
-export const openModalsState = $state({
+export type SettingsTabId =
+  | 'general'
+  | 'security'
+  | 'appearance'
+  | 'share'
+  | 'import'
+  | 'export'
+  | 'data'
+  | 'integrations'
+  | 'users'
+  | 'oauth';
+
+export type OpenModalsState = {
+  addFlight: boolean;
+  listFlights: boolean;
+  statistics: boolean;
+  settings: boolean;
+  settingsTab: SettingsTabId;
+};
+
+export const openModalsState = $state<OpenModalsState>({
   addFlight: false,
   listFlights: false,
   statistics: false,
   settings: false,
+  settingsTab: 'general',
 });
 
 export const appConfig = $state<{

--- a/src/lib/stats/aggregations.ts
+++ b/src/lib/stats/aggregations.ts
@@ -33,8 +33,13 @@ export type AggregationOptions = {
   limit?: number; // if provided, return top N
 };
 
+export type VisitedCountryStats = Pick<
+  VisitedCountry,
+  'code' | 'status' | 'note'
+>;
+
 export function visitedCountryStatusDistribution(
-  visitedCountries: VisitedCountry[],
+  visitedCountries: VisitedCountryStats[],
 ): Record<string, number> {
   const counts = VisitedCountryStatus.reduce<Record<string, number>>(
     (acc, status) => {
@@ -49,7 +54,7 @@ export function visitedCountryStatusDistribution(
 }
 
 export function countriesByContinentDistribution(
-  visitedCountries: VisitedCountry[],
+  visitedCountries: VisitedCountryStats[],
 ): Record<string, { visited: number; total: number }> {
   const continentByNumeric = new Map<number, string>();
   const result: Record<string, { visited: number; total: number }> = {};
@@ -61,7 +66,7 @@ export function countriesByContinentDistribution(
       if (!result[country.continent]) {
         result[country.continent] = { visited: 0, total: 0 };
       }
-      result[country.continent].total++;
+      result[country.continent]!.total++;
     }
   }
 
@@ -84,7 +89,7 @@ export type CountryDetail = {
 };
 
 export function countriesByContinentDetails(
-  visitedCountries: VisitedCountry[],
+  visitedCountries: VisitedCountryStats[],
 ): Record<string, CountryDetail[]> {
   const visitedCodes: Set<number> = new Set();
   for (const country of visitedCountries) {
@@ -102,7 +107,7 @@ export function countriesByContinentDetails(
       result[country.continent] = [];
     }
 
-    result[country.continent].push({
+    result[country.continent]!.push({
       name: country.name,
       numeric: country.numeric,
       visited: visitedCodes.has(country.numeric),
@@ -110,7 +115,7 @@ export function countriesByContinentDetails(
   }
 
   for (const continent in result) {
-    result[continent].sort((a, b) => {
+    result[continent]!.sort((a, b) => {
       if (a.visited !== b.visited) {
         return a.visited ? -1 : 1; // visited first
       }
@@ -351,7 +356,9 @@ export const COUNTRY_CHARTS: Record<
   CountryChartKey,
   {
     title: string;
-    aggregate: (visitedCountries: VisitedCountry[]) => Record<string, number>;
+    aggregate: (
+      visitedCountries: VisitedCountryStats[],
+    ) => Record<string, number>;
   }
 > = {
   'visited-country-status': {
@@ -365,7 +372,7 @@ export const COUNTRY_BAR_CHARTS: Record<
   {
     title: string;
     aggregate: (
-      visitedCountries: VisitedCountry[],
+      visitedCountries: VisitedCountryStats[],
     ) => Record<string, { visited: number; total: number }>;
   }
 > = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
     type TempFilters,
     type Route,
   } from '$lib/components/flight-filters/types';
+  import FlightsOnboarding from '$lib/components/onboarding/FlightsOnboarding.svelte';
   import { Map } from '$lib/components/map';
   import { ListFlightsModal, StatisticsModal } from '$lib/components/modals';
   import { openModalsState } from '$lib/state.svelte';
@@ -157,6 +158,7 @@
   };
 </script>
 
+<FlightsOnboarding flightsCount={flights.length} />
 <ListFlightsModal
   bind:open={openModalsState.listFlights}
   bind:filters

--- a/tests/e2e/tests/onboarding/first-flight.spec.ts
+++ b/tests/e2e/tests/onboarding/first-flight.spec.ts
@@ -1,0 +1,45 @@
+import { usersFactory } from '@test/factories/users';
+import { login } from '@test/helpers/auth';
+import { expect, test } from '@test/index';
+
+test.describe('Onboarding', () => {
+  test('opens import flow from onboarding', async ({ page }) => {
+    const { user } = await usersFactory.create();
+    await login(page, user);
+
+    await page.goto('/?onboarding');
+
+    const onboardingHeading = page.getByRole('heading', {
+      level: 2,
+      name: /bring your flights into airtrail/i,
+    });
+    await expect(onboardingHeading).toBeVisible();
+
+    await page.getByRole('button', { name: /start import/i }).click();
+
+    await expect(onboardingHeading).not.toBeVisible();
+    await expect(
+      page.getByRole('heading', { level: 3, name: /import/i }),
+    ).toBeVisible();
+  });
+
+  test('opens add flight modal from onboarding', async ({ page }) => {
+    const { user } = await usersFactory.create();
+    await login(page, user);
+
+    await page.goto('/?onboarding');
+
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: /bring your flights into airtrail/i,
+      }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: /add flight/i }).click();
+
+    await expect(
+      page.getByRole('heading', { level: 3, name: /new flight/i }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a guided onboarding modal for new users to add their first flight or import history, improving the first-run experience. Also adds deep-linking to the Settings modal to open the Import tab directly.

- **New Features**
  - Onboarding modal appears when a user has 0 flights (suppressed in automation unless ?onboarding is set).
  - “Start import” opens Settings > Import; “Add flight” opens the New Flight modal; includes “Not now” to dismiss.
  - Added E2E tests covering both onboarding paths.

- **Refactors**
  - Introduced openModalsState.settingsTab and synced it with SettingsModal; NavigationDock sets the tab to “general” on open.
  - Tightened stats types (VisitedCountryStats), updated wasVisited signature, and expanded visited-countries API fields for future use.
  - Minor robustness fixes in StatisticsModal aggregation key handling.

<sup>Written for commit da69cda07922700092f182c963067b1ab0bd5597. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

