### PR TITLE
fix: remount mobile swipe rows after modal closes

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -126,6 +126,9 @@
   let mobileEditFlight = $state<FlightData | null>(null);
   let mobileEditOpen = $state(false);
 
+  let modalResetToken = $state(0);
+  let lastMobileModalOpen = $state(false);
+
   const handleMobileEdit = (flight: { id: number }) => {
     const originalFlight = filteredFlights.find((f) => f.id === flight.id);
     if (originalFlight) {
@@ -143,6 +146,14 @@
   };
   let deleteFlightData = $state<DeleteFlight | null>(null);
   let deleteModalOpen = $state(false);
+
+  $effect(() => {
+    const isOpen = mobileEditOpen || deleteModalOpen;
+    if (lastMobileModalOpen && !isOpen) {
+      modalResetToken += 1;
+    }
+    lastMobileModalOpen = isOpen;
+  });
 
   const handleDelete = (flight: { id: number }) => {
     const originalFlight = filteredFlights.find((f) => f.id === flight.id);
@@ -270,6 +281,7 @@
         {flightsByYear}
         {selecting}
         bind:selectedFlights
+        resetToken={modalResetToken}
         onEdit={readonly ? undefined : handleMobileEdit}
         onDelete={readonly ? undefined : handleDelete}
       />

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -28,12 +28,14 @@
     flightsByYear,
     selecting = false,
     selectedFlights = $bindable<number[]>([]),
+    resetToken = 0,
     onEdit,
     onDelete,
   }: {
     flightsByYear: YearGroup[];
     selecting?: boolean;
     selectedFlights?: number[];
+    resetToken?: number;
     onEdit?: (flight: Flight) => void;
     onDelete?: (flight: Flight) => void;
   } = $props();
@@ -60,30 +62,32 @@
           {@const isLastFlight = index === flights.length - 1}
           {@const isSelected = selecting && selectedFlights.includes(flight.id)}
           <div class="isolate">
-            <SwipeableFlightRow
-              disabled={selecting}
-              onEdit={() => onEdit?.(flight)}
-              onDelete={() => onDelete?.(flight)}
-            >
-              {#snippet children({ isInteracting })}
-                <button
-                  type="button"
-                  class={cn(
-                    'w-full px-4 py-4 transition-colors',
-                    isSelected
-                      ? 'bg-destructive/10 hover:bg-destructive/15'
-                      : !isInteracting && 'hover:bg-hover active:bg-hover',
-                  )}
-                  onclick={() => {
-                    if (selecting) {
-                      toggleSelection(flight.id);
-                    }
-                  }}
-                >
-                  <FlightCard {flight} />
-                </button>
-              {/snippet}
-            </SwipeableFlightRow>
+            {#key `${flight.id}-${resetToken}`}
+              <SwipeableFlightRow
+                disabled={selecting}
+                onEdit={() => onEdit?.(flight)}
+                onDelete={() => onDelete?.(flight)}
+              >
+                {#snippet children({ isInteracting })}
+                  <button
+                    type="button"
+                    class={cn(
+                      'w-full px-4 py-4 transition-colors',
+                      isSelected
+                        ? 'bg-destructive/10 hover:bg-destructive/15'
+                        : !isInteracting && 'hover:bg-hover active:bg-hover',
+                    )}
+                    onclick={() => {
+                      if (selecting) {
+                        toggleSelection(flight.id);
+                      }
+                    }}
+                  >
+                    <FlightCard {flight} />
+                  </button>
+                {/snippet}
+              </SwipeableFlightRow>
+            {/key}
             <!-- Separator outside swipeable content with its own stacking context -->
             {#if !(isLastFlight && isLastYear)}
               <div class="relative z-10 h-px bg-border"></div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remount mobile swipeable flight rows when edit/delete modals close to reset swipe state and prevent stuck interactions.

- **Bug Fixes**
  - Added a modalResetToken in ListFlightsModal that increments when mobile modals close.
  - Passed resetToken to MobileFlightList and keyed SwipeableFlightRow by `${flight.id}-${resetToken}` to force remount and clear interaction state.

<sup>Written for commit 8e0ae2acfaddc59208860b0854d19be10cceee5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

