### PR TITLE
fix: wait for map and flights before fitting

### DIFF
--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -82,10 +82,15 @@
   );
 
   $effect(() => {
-    if (flightAddedState.added) {
+    if (!flightAddedState.added) return;
+    if (!map) return;
+    if (!flights.length) return;
+
+    if (filteredFlights.length) {
       fitFlights();
-      flightAddedState.added = false;
     }
+
+    flightAddedState.added = false;
   });
 
   $effect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Delay auto-fit until the map is initialized and flights are loaded. Prevents premature fitting on flight create and removes flicker.

- **Bug Fixes**
  - Added guards for map readiness and flights presence before calling fitFlights.
  - Only fit when filteredFlights has items.
  - Reset flightAddedState after handling to avoid repeated triggers.

<sup>Written for commit fd2e48aba5aa00f517b20bcdb6bed01b84449f77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

