### PR TITLE
fix: simplify config migration to prevent PostgreSQL crash

### DIFF
--- a/src/lib/server/utils/config.ts
+++ b/src/lib/server/utils/config.ts
@@ -74,8 +74,25 @@ export class AppConfig {
 
     if (!parsed.success) {
       // Config is missing some fields - merge with defaults
-      // Create a config with all defaults by parsing an empty object
-      const defaultConfig = appConfigSchema.parse({});
+      const defaultConfig: FullAppConfig = {
+        oauth: {
+          enabled: false,
+          issuerUrl: null,
+          clientId: null,
+          clientSecret: null,
+          scope: null,
+          autoRegister: true,
+          autoLogin: false,
+          hidePasswordForm: false,
+          buttonText: 'Log in with SSO',
+        },
+        integrations: {
+          aeroDataBoxKey: null,
+        },
+        data: {
+          lastSynced: null,
+        },
+      };
 
       // Merge: defaults first, then overlay existing values
       const rawConfig = result.config as Record<string, any>;


### PR DESCRIPTION
Fixes #437

When the stored config is missing fields (e.g., after a schema update), the migration now:
1. Reads the current config from the database
2. Deep merges with an explicit default config in TypeScript
3. Writes the complete merged config back

This eliminates the `buildFillMissingNullsExpr` function which generated SQL with 14+ levels of nesting that exceeded PostgreSQL's expression depth limits.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch config migration from nested jsonb_set SQL to an application-side merge with explicit defaults. This prevents PostgreSQL expression-depth crashes and simplifies config handling.

- **Bug Fixes**
  - Load current config, merge missing fields with an explicit default object, write merged config back.
  - Remove buildFillMissingNullsExpr and nested CASE/jsonb_set SQL.

<sup>Written for commit 317e552bf7f00b2d3b53c5621f059237a014b5dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



