### PR TITLE
fix: resolve SwipeableFlightRow state corruption after modal dismiss

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -126,8 +126,8 @@
   let mobileEditFlight = $state<FlightData | null>(null);
   let mobileEditOpen = $state(false);
 
-  let modalResetToken = $state(0);
-  let lastMobileModalOpen = $state(false);
+  // Reference to MobileFlightList for resetting swipeable rows
+  let mobileFlightListRef: MobileFlightList | undefined = $state();
 
   const handleMobileEdit = (flight: { id: number }) => {
     const originalFlight = filteredFlights.find((f) => f.id === flight.id);
@@ -147,12 +147,16 @@
   let deleteFlightData = $state<DeleteFlight | null>(null);
   let deleteModalOpen = $state(false);
 
+  // Track previous modal state to detect close transitions
+  let prevModalOpen = $state(false);
+
+  // Reset swipeable rows when modals close (transition from open -> closed)
   $effect(() => {
     const isOpen = mobileEditOpen || deleteModalOpen;
-    if (lastMobileModalOpen && !isOpen) {
-      modalResetToken += 1;
+    if (prevModalOpen && !isOpen) {
+      mobileFlightListRef?.resetAllRows();
     }
-    lastMobileModalOpen = isOpen;
+    prevModalOpen = isOpen;
   });
 
   const handleDelete = (flight: { id: number }) => {
@@ -278,10 +282,10 @@
       </div>
     {:else if !$isMediumScreen}
       <MobileFlightList
+        bind:this={mobileFlightListRef}
         {flightsByYear}
         {selecting}
         bind:selectedFlights
-        resetToken={modalResetToken}
         onEdit={readonly ? undefined : handleMobileEdit}
         onDelete={readonly ? undefined : handleDelete}
       />
@@ -410,11 +414,13 @@
 
   <!-- Mobile Edit Modal -->
   {#if mobileEditFlight}
-    <EditFlightModal
-      flight={mobileEditFlight}
-      bind:open={mobileEditOpen}
-      showTrigger={false}
-    />
+    {#key mobileEditFlight.id}
+      <EditFlightModal
+        flight={mobileEditFlight}
+        bind:open={mobileEditOpen}
+        showTrigger={false}
+      />
+    {/key}
   {/if}
 
   <!-- Delete Confirmation -->

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -28,17 +28,25 @@
     flightsByYear,
     selecting = false,
     selectedFlights = $bindable<number[]>([]),
-    resetToken = 0,
     onEdit,
     onDelete,
   }: {
     flightsByYear: YearGroup[];
     selecting?: boolean;
     selectedFlights?: number[];
-    resetToken?: number;
     onEdit?: (flight: Flight) => void;
     onDelete?: (flight: Flight) => void;
   } = $props();
+
+  // Store refs to SwipeableFlightRow components for resetting
+  let swipeableRefs: Record<number, SwipeableFlightRow | undefined> = $state(
+    {},
+  );
+
+  // Expose a method to reset all swipeable rows
+  export const resetAllRows = () => {
+    Object.values(swipeableRefs).forEach((ref) => ref?.reset?.());
+  };
 
   const toggleSelection = (flightId: number) => {
     if (selectedFlights.includes(flightId)) {
@@ -62,32 +70,31 @@
           {@const isLastFlight = index === flights.length - 1}
           {@const isSelected = selecting && selectedFlights.includes(flight.id)}
           <div class="isolate">
-            {#key `${flight.id}-${resetToken}`}
-              <SwipeableFlightRow
-                disabled={selecting}
-                onEdit={() => onEdit?.(flight)}
-                onDelete={() => onDelete?.(flight)}
-              >
-                {#snippet children({ isInteracting })}
-                  <button
-                    type="button"
-                    class={cn(
-                      'w-full px-4 py-4 transition-colors',
-                      isSelected
-                        ? 'bg-destructive/10 hover:bg-destructive/15'
-                        : !isInteracting && 'hover:bg-hover active:bg-hover',
-                    )}
-                    onclick={() => {
-                      if (selecting) {
-                        toggleSelection(flight.id);
-                      }
-                    }}
-                  >
-                    <FlightCard {flight} />
-                  </button>
-                {/snippet}
-              </SwipeableFlightRow>
-            {/key}
+            <SwipeableFlightRow
+              bind:this={swipeableRefs[flight.id]}
+              disabled={selecting}
+              onEdit={() => onEdit?.(flight)}
+              onDelete={() => onDelete?.(flight)}
+            >
+              {#snippet children({ isInteracting })}
+                <button
+                  type="button"
+                  class={cn(
+                    'w-full px-4 py-4 transition-colors',
+                    isSelected
+                      ? 'bg-destructive/10 hover:bg-destructive/15'
+                      : !isInteracting && 'hover:bg-hover active:bg-hover',
+                  )}
+                  onclick={() => {
+                    if (selecting) {
+                      toggleSelection(flight.id);
+                    }
+                  }}
+                >
+                  <FlightCard {flight} />
+                </button>
+              {/snippet}
+            </SwipeableFlightRow>
             <!-- Separator outside swipeable content with its own stacking context -->
             {#if !(isLastFlight && isLastYear)}
               <div class="relative z-10 h-px bg-border"></div>


### PR DESCRIPTION
Fixes #436

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes corrupted swipe state in SwipeableFlightRow after closing edit/delete modals. Rows stay revealed while a modal is open and reset cleanly on modal close, preventing visual glitches and wrong edits.

- **Bug Fixes**
  - Keep row revealed during modal; reset all rows on modal close via MobileFlightList.resetAllRows().
  - Block interactions and outside listeners when an action is pending to avoid state corruption and GPU compositor artifacts.
  - Add {#key mobileEditFlight.id} to EditFlightModal to ensure the correct flight opens.

- **Refactors**
  - Replace resetToken and keyed rows with component refs and a resetAllRows() API.
  - Track previous modal open state in ListFlightsModal and call resetAllRows() when transitioning to closed.

<sup>Written for commit 46cde3dca7a4b6e3ed6005b8d74579efada2e83b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

