### PR TITLE
fix: allow flights with only scheduled departure time

### DIFF
--- a/src/lib/zod/flight.ts
+++ b/src/lib/zod/flight.ts
@@ -42,8 +42,7 @@ export const flightDateTimeSchema = z.object({
   departure: z
     .string()
     .datetime({ offset: true, message: 'Select a departure date' })
-    .nullable()
-    .refine((value) => value !== null, 'Select a departure date'),
+    .nullable(),
   departureTime: timePrimitive,
   departureScheduled: dateTimePrimitive.nullable(),
   departureScheduledTime: timePrimitive,


### PR DESCRIPTION
Fixes #449

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow flights to be saved with only a scheduled departure date/time. Either departure or departureScheduled is now accepted, fixing cases where future flights only have a schedule.

- **Bug Fixes**
  - Accept either departure or departureScheduled when saving.
  - Use departureScheduled for date validation and error messages when departure is missing.
  - Validate departureTime only if a departure date exists; relaxed zod schema to remove the hard requirement.

<sup>Written for commit 9916b1eaf147f1e0dece8b3eafe34635433a8dfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

