### PR TITLE
fix: normalize flight number format

### DIFF
--- a/src/lib/components/modals/flight-form/FlightNumber.svelte
+++ b/src/lib/components/modals/flight-form/FlightNumber.svelte
@@ -205,7 +205,7 @@
           bind:value={$formData.flightNumber}
           oninput={(e) => {
             lookupResults = null;
-            $formData.flightNumber = e.target.value
+            $formData.flightNumber = e.currentTarget.value
               .replace(/\s/g, '')
               .toUpperCase();
           }}


### PR DESCRIPTION
Flight numbers are normally written in uppercase and without spaces.
This change formats the input not only while searching for a flight but also for the normal flight number field that gets saved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize flight number input by stripping spaces and converting to uppercase as the user types. Also switched to currentTarget for type safety; ran lint/format, no functional changes.

<sup>Written for commit 1dcf8dfe54b2849e2310ee4ec388970a480fc956. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

