### PR TITLE
feat: add byAir data importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   integrate with your OAuth provider.
 - **Responsive Design**: Use the application on any device with a responsive design.
 - **Dark Mode**: Switch between light and dark mode.
-- **Import Flights**: Import flights from various sources including MyFlightRadar24, App in the Air and JetLog.
+- **Import Flights**: Import flights from various sources including MyFlightRadar24, App in the Air, JetLog, TripIt, Flighty and byAir.
 
 ## 🚀 Getting Started
 

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -176,7 +176,7 @@ function FeaturesSection() {
           <Users />
         </StaggerCard>
         <StaggerCard
-          description="Import flights from various sources including MyFlightRadar24, App in the Air and JetLog."
+          description="Import flights from various sources including MyFlightRadar24, App in the Air, JetLog, TripIt, Flighty and byAir."
           title="Import Flights"
         >
           <CloudDownload />

--- a/docs/content/docs/features/import.mdx
+++ b/docs/content/docs/features/import.mdx
@@ -5,7 +5,7 @@ title: Import
 The import feature allows you to import flight data from other sources into AirTrail.
 Currently, AirTrail supports importing flights from [MyFlightRadar24](https://my.flightradar24.com)
 , [App in the Air](https://appintheair.com), [JetLog](https://github.com/pbogre/jetlog), [TripIt (ICS)](https://www.tripit.com)
-, [Flighty](https://flightyapp.com) and [AirTrail JSON files](/docs/features/export).
+, [Flighty](https://flightyapp.com), [byAir](https://byair.app) and [AirTrail JSON files](/docs/features/export).
 
 ## Import flights from MyFlightradar24
 
@@ -114,6 +114,25 @@ Notes:
 
 - The importer will prioritize actual departure/arrival times over scheduled times when available.
 - Seat types, cabin classes, and flight reasons will be mapped to AirTrail's standardized values.
+
+## Import flights from byAir
+
+byAir is a flight tracking app that allows you to export your flight data as a CSV file.
+
+Export from byAir:
+
+1. Open the byAir app.
+2. Go to the "Profile" tab.
+3. Scroll down to the "Help" section and tap on "Export data".
+4. Enter your email address and click "Export".
+
+Import the CSV file into AirTrail:
+
+1. Open the AirTrail application.
+2. Go to the settings page and open the Import tab.
+3. Choose the source "byAir".
+4. Select your CSV file from byAir.
+5. Click Import.
 
 ## Import flights from AirTrail JSON files
 

--- a/src/lib/components/modals/settings/pages/import-page/index.ts
+++ b/src/lib/components/modals/settings/pages/import-page/index.ts
@@ -60,6 +60,16 @@ export const platforms = [
     },
   },
   {
+    name: 'byAir',
+    value: 'byair',
+    description: 'CSV export from byAir flight tracker.',
+    extensions: ['.csv'],
+    options: {
+      filterOwner: true,
+      airlineFromFlightNumber: true,
+    },
+  },
+  {
     name: 'AirTrail',
     value: 'airtrail',
     description: 'JSON export from AirTrail (re-import your data).',

--- a/src/lib/import/byair.ts
+++ b/src/lib/import/byair.ts
@@ -1,0 +1,260 @@
+import { tz, TZDate } from '@date-fns/tz';
+import { addDays, differenceInSeconds, isBefore } from 'date-fns';
+import { z } from 'zod';
+
+import { page } from '$app/state';
+import type { PlatformOptions } from '$lib/components/modals/settings/pages/import-page';
+import type { CreateFlight, Seat } from '$lib/db/types';
+import { api } from '$lib/trpc';
+import { parseCsv } from '$lib/utils';
+import { parseLocalISO, toUtc } from '$lib/utils/datetime';
+
+const nullTransformer = (v: string) => (v === '' ? null : v);
+
+const ByAirFlight = z.object({
+  flight_date: z.string(),
+  flight_code: z.string().transform(nullTransformer),
+  departure_airport_code: z.string(),
+  arrival_airport_code: z.string(),
+  departure_time: z.string().transform(nullTransformer),
+  arrival_time: z.string().transform(nullTransformer),
+  booking_code: z.string().transform(nullTransformer),
+  seat_number: z.string().transform(nullTransformer),
+  seat_type: z.string().transform(nullTransformer),
+  seat_class: z.string().transform(nullTransformer),
+  purpose: z.string().transform(nullTransformer),
+  notes: z.string().transform(nullTransformer),
+  ownership: z.string().transform(nullTransformer),
+  byair_flight_id: z.string().transform(nullTransformer),
+  byair_codeshare_id: z.string().transform(nullTransformer),
+});
+
+const parseByAirTime = (
+  date: string,
+  time: string | null,
+  airportTz: string,
+): TZDate | null => {
+  if (!time) return null;
+  const iso = `${date}T${time}:00`;
+  const parsed = parseLocalISO(iso, airportTz);
+  if (isNaN(parsed.getTime())) return null;
+  return toUtc(parsed);
+};
+
+const mapSeatType = (seatType: string | null): Seat['seat'] => {
+  if (!seatType) return null;
+  const normalized = seatType.toLowerCase().trim();
+  switch (normalized) {
+    case 'window':
+      return 'window';
+    case 'aisle':
+      return 'aisle';
+    case 'middle':
+      return 'middle';
+    default:
+      return 'other';
+  }
+};
+
+const mapSeatTypeFromClass = (seatClass: string | null): Seat['seat'] => {
+  if (!seatClass) return null;
+  const normalized = seatClass.toLowerCase().trim();
+  switch (normalized) {
+    case 'cockpit':
+      return 'pilot';
+    case 'jumpseat':
+      return 'jumpseat';
+    default:
+      return null;
+  }
+};
+
+const mapSeatClass = (seatClass: string | null): Seat['seatClass'] => {
+  if (!seatClass) return null;
+  const normalized = seatClass.toLowerCase().trim();
+  switch (normalized) {
+    case 'economy':
+      return 'economy';
+    case 'economy_plus':
+    case 'premium_economy':
+      return 'economy+';
+    case 'business':
+      return 'business';
+    case 'first_class':
+      return 'first';
+    case 'private':
+      return 'private';
+    case 'cockpit':
+    case 'jumpseat':
+      return null;
+    default:
+      return null;
+  }
+};
+
+const mapFlightReason = (
+  purpose: string | null,
+): CreateFlight['flightReason'] => {
+  if (!purpose) return null;
+  const normalized = purpose.toLowerCase().trim();
+  switch (normalized) {
+    case 'leisure':
+      return 'leisure';
+    case 'business':
+      return 'business';
+    default:
+      return null;
+  }
+};
+
+export const processByAirFile = async (
+  input: string,
+  options: PlatformOptions,
+) => {
+  const userId = page.data.user?.id;
+  if (!userId) {
+    throw new Error('User not found');
+  }
+
+  const [data, error] = parseCsv(input, ByAirFlight);
+  if (data.length === 0 || error) {
+    return {
+      flights: [],
+      unknownAirports: {},
+      unknownAirlines: {},
+    };
+  }
+
+  const flights: CreateFlight[] = [];
+  const unknownAirports: Record<string, number[]> = {};
+  const unknownAirlines: Record<string, number[]> = {};
+
+  for (const row of data) {
+    if (options.filterOwner && row.ownership !== 'mine') {
+      continue;
+    }
+
+    const fromCode = row.departure_airport_code.trim();
+    const toCode = row.arrival_airport_code.trim();
+
+    const mappedFrom = options.airportMapping?.[fromCode];
+    const mappedTo = options.airportMapping?.[toCode];
+    const from = mappedFrom ?? (await api.airport.getFromIata.query(fromCode));
+    const to = mappedTo ?? (await api.airport.getFromIata.query(toCode));
+
+    const departure = parseByAirTime(
+      row.flight_date,
+      row.departure_time,
+      from?.tz ?? 'UTC',
+    );
+    const arrival = parseByAirTime(
+      row.flight_date,
+      row.arrival_time,
+      to?.tz ?? 'UTC',
+    );
+
+    let adjustedArrival = arrival;
+    if (departure && adjustedArrival && isBefore(adjustedArrival, departure)) {
+      adjustedArrival = addDays(adjustedArrival, 1, { in: tz('UTC') });
+    }
+
+    const duration =
+      departure && adjustedArrival
+        ? differenceInSeconds(adjustedArrival, departure)
+        : null;
+
+    // Extract airline code from flight code (e.g., "SK501" -> "SK", "SL*1508" -> "SL")
+    let airline = null;
+    let airlineCode: string | undefined;
+    let flightNumber = row.flight_code;
+
+    if (options.airlineFromFlightNumber && row.flight_code) {
+      const match = row.flight_code.match(/^([A-Z]{2,3})\*?\d/);
+      if (match?.[1]) {
+        airlineCode = match[1];
+        const mappedAirline = options.airlineMapping?.[airlineCode];
+        airline = mappedAirline || null;
+        if (!airline) {
+          airline = (await api.airline.getByIata.query(airlineCode)) ?? null;
+        }
+        if (!airline) {
+          airline = (await api.airline.getByIcao.query(airlineCode)) ?? null;
+        }
+      }
+    }
+
+    // Clean up flight number: remove asterisk from codeshare notation (e.g., "SL*1508" -> "SL1508")
+    if (flightNumber) {
+      flightNumber = flightNumber.replace('*', '');
+    }
+
+    const date = row.flight_date;
+
+    const flightIndex = flights.length;
+
+    if (!from) {
+      if (!unknownAirports[fromCode]) unknownAirports[fromCode] = [];
+      unknownAirports[fromCode]!.push(flightIndex);
+    }
+    if (!to) {
+      if (!unknownAirports[toCode]) unknownAirports[toCode] = [];
+      unknownAirports[toCode]!.push(flightIndex);
+    }
+    if (!airline && airlineCode) {
+      if (!unknownAirlines[airlineCode]) unknownAirlines[airlineCode] = [];
+      unknownAirlines[airlineCode]!.push(flightIndex);
+    }
+
+    const buildNotes = (): string | null => {
+      const parts: string[] = [];
+      if (row.notes) {
+        parts.push(row.notes);
+      }
+      if (row.booking_code) {
+        parts.push(`Booking: ${row.booking_code}`);
+      }
+      return parts.length > 0 ? parts.join(' | ') : null;
+    };
+
+    flights.push({
+      date,
+      from: from || null,
+      to: to || null,
+      departure: departure ? departure.toISOString() : null,
+      arrival: adjustedArrival ? adjustedArrival.toISOString() : null,
+      departureScheduled: null,
+      arrivalScheduled: null,
+      takeoffScheduled: null,
+      takeoffActual: null,
+      landingScheduled: null,
+      landingActual: null,
+      departureTerminal: null,
+      departureGate: null,
+      arrivalTerminal: null,
+      arrivalGate: null,
+      duration,
+      flightNumber: flightNumber ? flightNumber.substring(0, 10) : null,
+      note: buildNotes(),
+      airline,
+      aircraft: null,
+      aircraftReg: null,
+      flightReason: mapFlightReason(row.purpose),
+      seats: [
+        {
+          userId,
+          seat:
+            mapSeatTypeFromClass(row.seat_class) ?? mapSeatType(row.seat_type),
+          seatClass: mapSeatClass(row.seat_class),
+          seatNumber: row.seat_number ? row.seat_number.substring(0, 5) : null,
+          guestName: null,
+        },
+      ],
+    });
+  }
+
+  return {
+    flights,
+    unknownAirports,
+    unknownAirlines,
+  };
+};

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -5,6 +5,7 @@ import {
 import type { CreateFlight } from '$lib/db/types';
 import { processAirTrailFile } from '$lib/import/airtrail';
 import { processAITAFile } from '$lib/import/aita';
+import { processByAirFile } from '$lib/import/byair';
 import { processFlightyFile } from '$lib/import/flighty';
 import { processFR24File } from '$lib/import/fr24';
 import { processJetLogFile } from '$lib/import/jetlog';
@@ -57,6 +58,8 @@ const processors: Record<PlatformValue, Processor> = {
     withDefaultUnknownUsers(() => processTripItFile(content, options)),
   flighty: async (content, options) =>
     withDefaultUnknownUsers(() => processFlightyFile(content, options)),
+  byair: async (content, options) =>
+    withDefaultUnknownUsers(() => processByAirFile(content, options)),
 };
 
 export const processFile = async (


### PR DESCRIPTION
Closes #456 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added support for importing flights from byAir CSV exports, with a new byAir option in the Import settings. Docs and README updated to list byAir as a supported source.

- **New Features**
  - Added byAir CSV importer and processor, available in the Import modal (.csv).
  - Parses local airport times, adjusts overnight arrivals, and computes duration.
  - Extracts airline from flight codes and maps seat class/type and flight reason.
  - Respects ownership filter (mine) and supports airport/airline mapping options.

<sup>Written for commit f9a84667df7e5c9e1bf69f181cfb83d62b57c7d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

