### PR TITLE
fix: resolve crash when setting validation length on custom fields

### DIFF
--- a/src/lib/components/modals/settings/pages/custom-fields-page/helpers.ts
+++ b/src/lib/components/modals/settings/pages/custom-fields-page/helpers.ts
@@ -133,8 +133,8 @@ export const getDefaultValue = (editing: EditingState): unknown => {
 };
 
 /** Parse a trimmed string into a finite number, or return undefined. */
-const parseFinite = (raw: string): number | undefined => {
-  const trimmed = raw.trim();
+const parseFinite = (raw: string | number): number | undefined => {
+  const trimmed = String(raw).trim();
   if (!trimmed) return undefined;
   const n = Number(trimmed);
   return Number.isFinite(n) ? n : undefined;


### PR DESCRIPTION
Fixes #481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when setting min/max length on custom fields by safely parsing numeric inputs during validation.

- **Bug Fixes**
  - Updated parseFinite to accept string | number and convert to string before trimming, preventing "trim is not a function" errors from number inputs.

<sup>Written for commit 51a0fcd1b3461eb343a1b94bb1fe0e766ede9a8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

