### PR TITLE
fix: validate flight date order across all time field pairs

### DIFF
--- a/src/lib/server/routes/flight.ts
+++ b/src/lib/server/routes/flight.ts
@@ -5,20 +5,12 @@ import { authedProcedure, router } from '../trpc';
 
 import { db } from '$lib/db';
 import type { CreateFlight } from '$lib/db/types';
-
-const validateFlightDateOrder = (flight: CreateFlight): string | null => {
-  if (flight.departure && flight.arrival) {
-    if (new Date(flight.arrival) < new Date(flight.departure)) {
-      return 'Arrival must be after departure';
-    }
-  }
-  return null;
-};
 import {
   createFlight,
   createManyFlights,
   deleteFlight,
   listFlights,
+  validateFlightDates,
 } from '$lib/server/utils/flight';
 import { getFlightRoute } from '$lib/server/utils/flight-lookup/flight-lookup';
 import { generateCsv } from '$lib/utils/csv';
@@ -185,7 +177,7 @@ export const flightRouter = router({
   create: authedProcedure
     .input(z.custom<CreateFlight>())
     .mutation(async ({ input }) => {
-      const dateError = validateFlightDateOrder(input);
+      const dateError = validateFlightDates(input);
       if (dateError) {
         throw new Error(dateError);
       }
@@ -200,7 +192,7 @@ export const flightRouter = router({
     )
     .mutation(async ({ ctx: { user }, input }) => {
       for (const flight of input.flights) {
-        const dateError = validateFlightDateOrder(flight);
+        const dateError = validateFlightDates(flight);
         if (dateError) {
           throw new Error(dateError);
         }

--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -31,6 +31,48 @@ import {
 import type { ErrorActionResult } from '$lib/utils/forms';
 import type { flightSchema } from '$lib/zod/flight';
 
+const assertDateOrder = (
+  start: Date | null | undefined,
+  end: Date | null | undefined,
+): boolean => {
+  if (!start || !end) return true;
+  return !isBefore(end, start);
+};
+
+export const validateFlightDates = (flight: CreateFlight): string | null => {
+  const pairs: [string | null, string | null, string][] = [
+    [flight.departure, flight.arrival, 'Arrival must be after departure'],
+    [
+      flight.departureScheduled,
+      flight.arrivalScheduled,
+      'Scheduled arrival must be after scheduled departure',
+    ],
+    [
+      flight.takeoffScheduled,
+      flight.landingScheduled,
+      'Scheduled landing must be after scheduled takeoff',
+    ],
+    [
+      flight.takeoffActual,
+      flight.landingActual,
+      'Actual landing must be after actual takeoff',
+    ],
+  ];
+
+  for (const [start, end, message] of pairs) {
+    if (
+      !assertDateOrder(
+        start ? parseISO(start) : null,
+        end ? parseISO(end) : null,
+      )
+    ) {
+      return message;
+    }
+  }
+
+  return null;
+};
+
 export const listFlightsQuery = (userId: string) => {
   return listFlightBaseQuery(db, userId);
 };
@@ -177,37 +219,25 @@ export const validateAndSaveFlight = async (
   if (landingActualResult.error) return landingActualResult.error;
   const landingActual = landingActualResult.value;
 
-  if (arrival && departure && isBefore(arrival, departure)) {
+  if (!assertDateOrder(departure, arrival)) {
     return pathError('arrival', 'Arrival must be after departure');
   }
 
-  if (
-    departureScheduled &&
-    arrivalScheduled &&
-    isBefore(arrivalScheduled, departureScheduled)
-  ) {
+  if (!assertDateOrder(departureScheduled, arrivalScheduled)) {
     return pathError(
       'arrivalScheduled',
       'Scheduled arrival must be after scheduled departure',
     );
   }
 
-  if (
-    takeoffScheduled &&
-    landingScheduled &&
-    isBefore(landingScheduled, takeoffScheduled)
-  ) {
+  if (!assertDateOrder(takeoffScheduled, landingScheduled)) {
     return pathError(
       'landingScheduled',
       'Scheduled landing must be after scheduled takeoff',
     );
   }
 
-  if (
-    takeoffActual &&
-    landingActual &&
-    isBefore(landingActual, takeoffActual)
-  ) {
+  if (!assertDateOrder(takeoffActual, landingActual)) {
     return pathError(
       'landingActual',
       'Actual landing must be after actual takeoff',


### PR DESCRIPTION
Prevent creation or editing of flights where arrival/landing occurs before departure/takeoff. Added validation checks for:

- Scheduled arrival vs scheduled departure
- Scheduled landing vs scheduled takeoff
- Actual landing vs actual takeoff
- Departure vs arrival in tRPC create/createMany endpoints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate flight date order across all time fields to prevent saving flights where arrival/landing occurs before departure/takeoff. Adds shared server-side checks and clear error messages.

- **Bug Fixes**
  - Scheduled arrival must be after scheduled departure.
  - Scheduled landing must be after scheduled takeoff.
  - Actual landing must be after actual takeoff.
  - tRPC create/createMany reject flights with any invalid date order across time pairs.

<sup>Written for commit 063086ac7f6b13cac6e3291f1832b564345e16ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

