### PR TITLE
fix: don't import flights with unknown airports before user maps them

### DIFF
--- a/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
@@ -104,18 +104,29 @@
       return;
     }
 
+    // Exclude flights with unknown airports/airlines so they aren't
+    // inserted with null references (which would cause duplicates when
+    // the user maps the unknowns and re-imports).
+    const unknownIndices = new Set([
+      ...Object.values(result.unknownAirports).flat(),
+      ...Object.values(result.unknownAirlines).flat(),
+    ]);
+    const flightsToImport = flights.filter((_, i) => !unknownIndices.has(i));
+
     // Send flights in batches to avoid exceeding the server body size limit
     const BATCH_SIZE = 50;
     let inserted = 0;
-    for (let i = 0; i < flights.length; i += BATCH_SIZE) {
-      const batch = flights.slice(i, i + BATCH_SIZE);
+    for (let i = 0; i < flightsToImport.length; i += BATCH_SIZE) {
+      const batch = flightsToImport.slice(i, i + BATCH_SIZE);
       const stats = await $createMany.mutateAsync({
         flights: batch,
         dedupe: dedupeImportedFlights,
       });
       inserted += stats?.insertedFlights ?? 0;
     }
-    trpc.flight.list.utils.invalidate();
+    if (flightsToImport.length > 0) {
+      trpc.flight.list.utils.invalidate();
+    }
 
     unknownAirports = result.unknownAirports;
     unknownAirlines = result.unknownAirlines;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip importing flights that reference unknown airports or airlines until the user maps them, preventing null references and duplicate rows on re-import. Flights with resolved references still import immediately.

- **Bug Fixes**
  - Build a set of unknown flight indices from `result.unknownAirports` and `result.unknownAirlines`, then import only the rest in batches.
  - Avoid dedupe mismatches (null vs real IDs) by holding back unknowns; they import correctly after mapping and re-import.
  - Only call `trpc.flight.list.utils.invalidate()` when at least one flight was inserted.

<sup>Written for commit 35ec9e88614bb9fa721d80fac821a08a212fc8c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

