### PR TITLE
fix: prevent deck.gl overlay from rendering above map controls

### DIFF
--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -252,6 +252,10 @@
         ],
       });
       map.addControl(layer);
+      // Prevent the deck.gl overlay from rendering above map controls
+      if (layer._container) {
+        layer._container.style.zIndex = '-1';
+      }
     }
   });
 


### PR DESCRIPTION
Fixes #508 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the deck.gl overlay container z-index to -1 so it renders beneath map controls. This prevents controls from being obscured and restores their clickability.

<sup>Written for commit 33fb71693815743d02ef31d72b2c50de2962ce75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

