### PR TITLE
feat: animate settings height changes

### DIFF
--- a/src/lib/components/modals/settings/SettingsModal.svelte
+++ b/src/lib/components/modals/settings/SettingsModal.svelte
@@ -89,10 +89,15 @@
 
 <Modal bind:open class="max-w-2xl" drawerNoPadding>
   <AnimatedSizeContainer
-    height
-    class="!overflow-y-clip !overflow-x-visible max-md:max-h-[calc(100dvh-200px)] max-md:px-6 max-md:py-3"
+    height={$isMediumScreen}
+    class={cn(
+      'max-md:px-6 max-md:py-3',
+      $isMediumScreen ? '!overflow-x-visible' : '!overflow-visible',
+    )}
   >
-    <div class="flex flex-col gap-6">
+    <div
+      class="flex flex-col gap-6 max-md:max-h-[calc(100dvh-200px)] max-md:overflow-y-auto"
+    >
       <div class="space-y-0.5">
         <h2 class="text-2xl font-bold tracking-tight">Settings</h2>
         <p class="text-muted-foreground">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Animate Settings modal height changes when switching tabs for smoother transitions and fewer layout jumps. Also fixes the active tab indicator clipping and enables scrolling in the mobile drawer.

- **New Features**
  - Wrapped modal body in `AnimatedSizeContainer` with height animation tied to `$isMediumScreen`.

- **Bug Fixes**
  - Moved layout classes into the animated container and adjusted overflow (clip vertically, keep horizontal visible) so the sidebar indicator renders correctly.
  - Enabled content scrolling in the mobile drawer with `max-md:overflow-y-auto` and kept height within the viewport.

<sup>Written for commit a9585e36e3297bfa168a405d189f6cc0b1b59265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

