### PR TITLE
fix: increase mobile flight list bottom spacer

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -354,7 +354,7 @@
         onDelete={readonly ? undefined : handleDelete}
         {readonly}
       />
-      <div class="h-[90px]"></div>
+      <div class="h-[130px] sm:h-[90px]"></div>
     {:else}
       <ScrollArea type="hover">
         <div class="hidden md:block">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the bottom spacer in the mobile flight list from 90px to 130px to prevent the last items from being hidden behind the bottom controls. On `sm` and larger screens, the spacer stays 90px.

<sup>Written for commit a2d3e30432a2266d1a3a4dd7249b7aa9e0843bf1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

