### PR TITLE
fix: remove 'Click to view all' message in non-clickable popups

### DIFF
--- a/src/lib/components/map/AirportPopup.svelte
+++ b/src/lib/components/map/AirportPopup.svelte
@@ -5,7 +5,7 @@
   import { formatAsDate } from '$lib/utils/datetime';
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let { data }: { data: any } = $props();
+  let { data, clickable }: { data: any; clickable: boolean } = $props();
 </script>
 
 <div class="min-w-[18rem]">
@@ -65,8 +65,10 @@
       </h4>
     {/if}
   </div>
-  <div class="h-px bg-muted my-2" />
-  <div class="px-3 pb-2">
-    <p class="text-xs text-muted-foreground text-center">Click to view all</p>
-  </div>
+  {#if clickable}
+    <div class="h-px bg-muted my-2" />
+    <div class="px-3 pb-2">
+      <p class="text-xs text-muted-foreground text-center">Click to view all</p>
+    </div>
+  {/if}
 </div>

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -57,6 +57,7 @@
   let id = getId('deckgl-layer');
   let hoveredAirport: VisitedAirport | undefined = $state.raw(undefined);
   let hoveredArc: FlightArc | undefined = $state.raw(undefined);
+  const clickable = $derived(tempFilters !== undefined);
 
   const context = getMapContext();
   const { map, loaded } = $derived(context);
@@ -274,9 +275,9 @@
   <Popup openOn="hover" anchor="top-left" offset={20}>
     {#snippet children({ data })}
       {#if data?.country}
-        <AirportPopup {data} />
+        <AirportPopup {data} {clickable} />
       {:else if data?.from}
-        <ArcPopup {data} />
+        <ArcPopup {data} {clickable} />
       {/if}
     {/snippet}
   </Popup>

--- a/src/lib/components/map/ArcPopup.svelte
+++ b/src/lib/components/map/ArcPopup.svelte
@@ -8,7 +8,7 @@
   const metric = $derived(page.data.user?.unit === 'metric');
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let { data }: { data: any } = $props();
+  let { data, clickable }: { data: any; clickable: boolean } = $props();
 </script>
 
 <div class="flex flex-col px-3 pt-3">
@@ -75,7 +75,9 @@
     </h4>
   {/if}
 </div>
-<div class="h-px bg-muted my-2" />
-<div class="px-3 pb-2">
-  <p class="text-xs text-muted-foreground text-center">Click to view all</p>
-</div>
+{#if clickable}
+  <div class="h-px bg-muted my-2" />
+  <div class="px-3 pb-2">
+    <p class="text-xs text-muted-foreground text-center">Click to view all</p>
+  </div>
+{/if}


### PR DESCRIPTION
Do not show "Click to view all" message on airport or arc popups when the popup is not clickable, like on a share map.

Fixes #533

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "Click to view all" message on airport and arc popups when they aren’t clickable, preventing misleading prompts (fixes #533). Adds a `clickable` prop and conditional rendering so the hint shows only when the popup is actionable.

<sup>Written for commit ad9761cc81fa65d6f732807cdab0b4e87913b227. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

