### PR TITLE
fix: improve rate limiting for aircraft search

### DIFF
--- a/src/lib/components/modals/flight-form/FlightNumber.svelte
+++ b/src/lib/components/modals/flight-form/FlightNumber.svelte
@@ -53,6 +53,7 @@
 
   let lookupResults: LookupResult[] | null = $state(null);
   let isSearching = $state(false);
+  let isApplying = $state(false);
 
   function clearResults() {
     lookupResults = null;
@@ -88,7 +89,7 @@
     return null;
   }
 
-  function applyLookupResult(result: LookupResult) {
+  async function applyLookupResult(result: LookupResult) {
     if (!result) return;
 
     if (
@@ -100,10 +101,23 @@
       return;
     }
 
+    let aircraft = result.aircraft ?? null;
+    if (!aircraft && result.aircraftReg) {
+      isApplying = true;
+      try {
+        aircraft = await api.flight.lookupAircraftByReg.query(
+          result.aircraftReg,
+        );
+      } catch {
+        // ignore, this field is not required
+      }
+      isApplying = false;
+    }
+
     $formData.from = result.from;
     $formData.to = result.to;
     $formData.airline = result.airline ?? null;
-    $formData.aircraft = result.aircraft ?? null;
+    $formData.aircraft = aircraft;
     $formData.aircraftReg = result.aircraftReg ?? null;
 
     if (result.arrival && result.departure && !isFutureFlight(result)) {
@@ -272,7 +286,7 @@
         />
         <Button
           onclick={lookupFlight}
-          disabled={!$formData.flightNumber || isSearching}
+          disabled={!$formData.flightNumber || isSearching || isApplying}
           variant="secondary"
           class="h-full"
           >{isSearching ? 'Searching...' : 'Search'}
@@ -289,7 +303,7 @@
       class="flex items-center justify-between text-sm text-muted-foreground"
     >
       <span>Select your flight</span>
-      <Button variant="ghost" size="sm" onclick={clearResults}>Clear</Button>
+      <Button variant="ghost" size="sm" onclick={clearResults} disabled={isApplying}>Clear</Button>
     </div>
 
     <div class="space-y-1.5">
@@ -298,6 +312,7 @@
         {@const isFlightToday = primaryDate && isToday(primaryDate)}
         <button
           onclick={() => applyLookupResult(r)}
+          disabled={isApplying}
           class="group w-full rounded-lg border bg-card p-3 text-left transition-all hover:border-primary hover:shadow-sm active:scale-[0.98] {isFlightToday
             ? 'border-primary/40 bg-primary/5'
             : ''}"

--- a/src/lib/components/modals/flight-form/FlightNumber.svelte
+++ b/src/lib/components/modals/flight-form/FlightNumber.svelte
@@ -303,7 +303,12 @@
       class="flex items-center justify-between text-sm text-muted-foreground"
     >
       <span>Select your flight</span>
-      <Button variant="ghost" size="sm" onclick={clearResults} disabled={isApplying}>Clear</Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={clearResults}
+        disabled={isApplying}>Clear</Button
+      >
     </div>
 
     <div class="space-y-1.5">

--- a/src/lib/server/routes/flight.ts
+++ b/src/lib/server/routes/flight.ts
@@ -14,6 +14,7 @@ import {
   listFlights,
   validateFlightDates,
 } from '$lib/server/utils/flight';
+import { getAircraftFromReg } from '$lib/server/utils/flight-lookup/aerodatabox';
 import { getFlightRoute } from '$lib/server/utils/flight-lookup/flight-lookup';
 import { generateCsv } from '$lib/utils/csv';
 import { omit } from '$lib/utils/other';
@@ -85,6 +86,11 @@ export const flightRouter = router({
         input.date ? { date: parseISO(input.date.split('T')[0]) } : undefined,
       );
 
+      const [onlyFlight] = results;
+      if (results.length === 1 && onlyFlight?.aircraftReg) {
+        onlyFlight.aircraft = await getAircraftFromReg(onlyFlight.aircraftReg);
+      }
+
       // The below mess is required to maintain timezone through serialization
       return results.map((r) => ({
         ...r,
@@ -99,6 +105,11 @@ export const flightRouter = router({
           ? r.arrivalScheduled.toISOString()
           : null,
       }));
+    }),
+  lookupAircraftByReg: authedProcedure
+    .input(z.string())
+    .query(async ({ input }) => {
+      return await getAircraftFromReg(input);
     }),
   list: authedProcedure
     .input(flightListInput)

--- a/src/lib/server/utils/flight-lookup/aerodatabox.ts
+++ b/src/lib/server/utils/flight-lookup/aerodatabox.ts
@@ -18,7 +18,7 @@ import { appConfig } from '$lib/server/utils/config';
 import { RequestRateLimiter } from '$lib/utils/ratelimiter';
 
 const BASE_URL = 'https://aerodatabox.p.rapidapi.com';
-const rateLimiter = new RequestRateLimiter();
+const rateLimiter = new RequestRateLimiter(1, 1, 2, 1, 1000);
 
 function sanitizeFlightNumber(fn: string): string {
   // Remove spaces and dashes, uppercase (e.g., "SK 728" -> "SK728")
@@ -183,6 +183,8 @@ export async function getFlightRoute(
 }
 
 async function getAircraftFromReg(reg: string): Promise<Aircraft | null> {
+  await rateLimiter.checkRequest();
+
   const config = await appConfig.get();
   const apiKey = config?.integrations?.aeroDataBoxKey ?? null;
   if (!apiKey) {

--- a/src/lib/server/utils/flight-lookup/aerodatabox.ts
+++ b/src/lib/server/utils/flight-lookup/aerodatabox.ts
@@ -166,9 +166,7 @@ export async function getFlightRoute(
       departureScheduled,
       arrivalScheduled,
       airline,
-      aircraft: item.aircraft?.reg
-        ? await getAircraftFromReg(item.aircraft.reg)
-        : null,
+      aircraft: null,
       aircraftReg: item.aircraft?.reg ?? null,
       departureTerminal: item.departure.terminal ?? null,
       departureGate: item.departure.gate ?? null,
@@ -182,7 +180,9 @@ export async function getFlightRoute(
   return result;
 }
 
-async function getAircraftFromReg(reg: string): Promise<Aircraft | null> {
+export async function getAircraftFromReg(
+  reg: string,
+): Promise<Aircraft | null> {
   await rateLimiter.checkRequest();
 
   const config = await appConfig.get();


### PR DESCRIPTION
This request improves the rate limiting for the aircraft API call. According to [AeroDataBox's documentation](https://aerodatabox.com/pricing/#:~:text=Rate%20Limiting,1%20request%20/%20second), the free tier of the API only allows 1 request per second. This means having to wait a second to fetch the aircraft type if the tail number is returned, but I personally think that is acceptable. However, when multiple flights are returned, this results in a much longer wait time (+1 second for each flight returned), so I changed when the aircraft search is performed so that it's only called after a flight is selected. This has a side benefit of reducing the total number of API calls being made when multiple flights are returned by the search, so a user can get more out of their monthly limit. I realize that this became a larger change than what was probably expected, so obviously I am open to discussing my implementation and how it can be done better.

Fixes #536

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve AeroDataBox rate limiting to 1 req/s and defer aircraft lookups until a flight is selected to cut wait times and reduce API usage. Fixes #536.

- **Bug Fixes**
  - Enforce 1 request/second in `aerodatabox` with a rate limiter.
  - Fetch aircraft only after a flight is chosen; prefetch when only one match; expose `lookupAircraftByReg` for on‑demand lookup.
  - Add applying state to disable actions and prevent duplicate calls; minor lint fixes.

<sup>Written for commit f247889c704cfb973741edc617777478b40be3d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

