### PR TITLE
feat: add history for back navigation to statistics modal

### DIFF
--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -163,12 +163,18 @@
 </script>
 
 <svelte:window
-  onkeydown={(e) => {
-    if (e.key !== 'Escape') return;
+  onpopstate={() => {
+    if (!open) return;
     if (activeContinent) {
       activeContinent = null;
     } else if (activeChart) {
       activeChart = null;
+    }
+  }}
+  onkeydown={(e) => {
+    if (e.key !== 'Escape') return;
+    if (activeContinent || activeChart) {
+      history.back();
     } else if (open) {
       open = false;
     }
@@ -188,14 +194,14 @@
     <BarChartDrillDown
       continent={activeContinent}
       countries={countriesByContinentDetailsData[activeContinent] || []}
-      onBack={() => (activeContinent = null)}
+      onBack={() => history.back()}
     />
   {:else if activeChart}
     <ChartDrillDown
       chartKey={activeChart}
       data={activeChartData}
       flights={completedFlights}
-      onBack={() => (activeChart = null)}
+      onBack={() => history.back()}
     />
   {:else}
     <div class="space-y-4">
@@ -280,7 +286,10 @@
       <h3 class="text-2xl font-bold tracking-tight pt-4">Flight Statistics</h3>
       <PieCharts
         flights={completedFlights}
-        onOpenChart={(key) => (activeChart = key)}
+        onOpenChart={(key) => {
+          activeChart = key;
+          history.pushState(null, '');
+        }}
         {seatUserId}
       />
       <div class="flex flex-col md:flex-row gap-4">
@@ -294,7 +303,10 @@
         <div class="grid gap-4 pb-2 md:grid-cols-2 xl:grid-cols-3">
           <div
             class="cursor-pointer"
-            onclick={() => (activeChart = 'visited-country-status')}
+            onclick={() => {
+              activeChart = 'visited-country-status';
+              history.pushState(null, '');
+            }}
           >
             <PieChart title="Visited Country Status" data={countryStatusData} />
           </div>
@@ -302,7 +314,10 @@
         <BarChart
           title="Countries by Continent"
           data={countriesByContinentData}
-          onBarClick={(continent) => (activeContinent = continent)}
+          onBarClick={(continent) => {
+            activeContinent = continent;
+            history.pushState(null, '');
+          }}
         />
       {/if}
     </div>

--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -100,6 +100,7 @@
   // Expanded chart state
   let activeChart: ChartKey | null = $state(null);
   let activeContinent: string | null = $state(null);
+  let wasOpen = $state(false);
   const ctx = $derived.by(() => ({ userId: seatUserId }));
 
   const activeChartData = $derived.by(() => {
@@ -128,6 +129,16 @@
   );
 
   $effect(() => {
+    const closedFromDrilldown =
+      wasOpen && !open && (activeChart || activeContinent);
+    wasOpen = open;
+
+    if (closedFromDrilldown) {
+      activeChart = null;
+      activeContinent = null;
+      history.back();
+    }
+
     if (open) {
       setTimeout(() => {
         flightCount = flights.length;


### PR DESCRIPTION
Implements #535

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds browser history to the statistics modal so users can use Back or Escape to step out of drilldowns without closing the modal. Also resets drilldown state and cleans up history when the modal closes from a drilldown.

- New Features
  - Push a history state when opening a chart or continent drilldown (`history.pushState`).
  - Handle `window.onpopstate` to step back inside the modal (drilldown → root) without closing it.
  - Replace drilldown back handlers with `history.back()`.
  - On `Escape`, call `history.back()` when in a drilldown; otherwise close the modal.

<sup>Written for commit dbafdb92dff90b7be132da284db54a0d806e0937. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

