### PR TITLE
fix: fall back to scheduled times in flight list

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -106,12 +106,16 @@
             ? Duration.fromSeconds(f.duration).toString()
             : '',
           month: f.date ? formatAsMonth(f.date) : null,
-          depTime: depDate
-            ? formatAsDateTime(depDate)
-            : f.date
-              ? formatAsDate(f.date)
+          depTime:
+            (depDate ?? depScheduled)
+              ? formatAsDateTime((depDate ?? depScheduled)!)
+              : f.date
+                ? formatAsDate(f.date)
+                : null,
+          arrTime:
+            (arrDate ?? arrScheduled)
+              ? formatAsDateTime((arrDate ?? arrScheduled)!)
               : null,
-          arrTime: arrDate ? formatAsDateTime(arrDate) : null,
           depStatus,
           arrStatus,
           seat: formatSeatForUser(f, seatUserId),


### PR DESCRIPTION
Fixes #544

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show scheduled departure and arrival times in the flight list when actual times are missing, so users see a time instead of blanks. If neither actual nor scheduled is available, we still fall back to the flight’s date.

<sup>Written for commit ad1fa0f421826a3daa4595c89f0ea1e476b327cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

