### PR TITLE
fix: show passengers instead of flight number in mobile flight list

### DIFF
--- a/src/lib/components/modals/list-flights/FlightCard.svelte
+++ b/src/lib/components/modals/list-flights/FlightCard.svelte
@@ -72,20 +72,15 @@
             {formatDate(flight)}
           </span>
         {/if}
-        {#if getFlightNumber(flight)}
-          <span class="text-[15px] text-muted-foreground">
-            {getFlightNumber(flight)}
-          </span>
-        {/if}
         {#if flight.passengers?.length}
           <Badge variant="outline" class="max-w-[120px] truncate self-end">
             {flight.passengers[0]}{flight.passengers.length > 1
               ? ` +${flight.passengers.length - 1}`
               : ''}
           </Badge>
-        {:else if flight.airline}
-          <span class="text-sm text-muted-foreground truncate max-w-[120px]">
-            {flight.airline.name}
+        {:else if getFlightNumber(flight)}
+          <span class="text-[15px] text-muted-foreground">
+            {getFlightNumber(flight)}
           </span>
         {/if}
       </div>


### PR DESCRIPTION
- Remove redundant airline name from FlightCard (logo already shown)
- Show passenger badge in place of flight number when passengers are present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a passenger badge instead of the flight number on mobile flight cards to improve readability. If no passengers are listed, show the flight number; remove the redundant airline name text since the logo is present.

<sup>Written for commit c9237cdd62fb9eb99cb8cdb1b291ef0c680a07ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

