### PR TITLE
fix: hide toolbar when nested modals are open

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -328,7 +328,10 @@
           {flightsPerPage}
           {hasTempFilters}
           numOfFlights={filteredFlights.length}
-          modalOpen={open}
+          modalOpen={open &&
+            !addFlightOpen &&
+            !mobileEditOpen &&
+            !deleteModalOpen}
           onAddFlight={readonly
             ? undefined
             : () => {


### PR DESCRIPTION
Fixes #531

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the toolbar in the List Flights modal when any nested modal (Add Flight, Mobile Edit, Delete) is open. Prevents overlap and accidental clicks.

- **Bug Fixes**
  - Set `modalOpen` to `open && !addFlightOpen && !mobileEditOpen && !deleteModalOpen` in `ListFlightsModal.svelte`.

<sup>Written for commit 765d00b5c2bfb45f7d9394398b79660845684366. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

