### PR TITLE
fix: hide tail numbers on shared links

### DIFF
--- a/src/lib/components/modals/settings/pages/ShareFormFields.svelte
+++ b/src/lib/components/modals/settings/pages/ShareFormFields.svelte
@@ -167,7 +167,7 @@
         {#snippet children({ props })}
           <Checkbox bind:checked={$formData.showAircraft} {...props} />
           <Form.Label class="text-sm font-normal"
-            >Show Aircraft Types</Form.Label
+            >Show Aircraft Types and Tail Numbers</Form.Label
           >
         {/snippet}
       </Form.Control>

--- a/src/lib/server/utils/share.ts
+++ b/src/lib/server/utils/share.ts
@@ -241,7 +241,7 @@ async function getFilteredFlightsForShare(share: PublicShare) {
  * Sanitize flight data based on privacy settings
  * Sends complete objects to frontend instead of individual field properties
  */
-function sanitizeFlightData(
+export function sanitizeFlightData(
   flights: Awaited<ReturnType<typeof getFilteredFlightsForShare>>,
   share: PublicShare,
 ): SanitizedFlight[] {
@@ -263,7 +263,7 @@ function sanitizeFlightData(
       to: flight.to!, // Always include complete to airport
       duration: flight.duration,
       flightReason: flight.flightReason,
-      aircraftReg: flight.aircraftReg,
+      aircraftReg: share.showAircraft ? flight.aircraftReg : null,
       seats: userSeats,
     };
 


### PR DESCRIPTION
Hide aircraft registrations on public shares unless aircraft visibility is enabled, and clarify the share setting label so tail numbers are covered.
Addresses #534

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide tail numbers on public share links unless aircraft visibility is enabled. Updated the share setting label to “Show Aircraft Types and Tail Numbers” for clarity.

- **Bug Fixes**
  - Redacts aircraftReg in sanitized flight data when `share.showAircraft` is false.

- **Refactors**
  - Exported `sanitizeFlightData` for reuse across server utilities.

<sup>Written for commit 663cf6b7044c1ecb92be111550fb5baa625e628c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

