### PR TITLE
fix: make usernames case-insensitive

### DIFF
--- a/src/lib/server/utils/auth.ts
+++ b/src/lib/server/utils/auth.ts
@@ -7,6 +7,9 @@ import type { User } from '$lib/db/types';
 import { hashSha256 } from '$lib/server/utils/hash';
 import { generateString } from '$lib/server/utils/random';
 
+const usernameEquals = (username: string) =>
+  sql<boolean>`lower("username") = lower(${username})` as any;
+
 export const createUser = async (
   id: string,
   username: string,
@@ -25,7 +28,7 @@ export const createUser = async (
 export const getUser = async (username: string) => {
   return db
     .selectFrom('user')
-    .where('username', '=', username)
+    .where(usernameEquals(username))
     .selectAll()
     .executeTakeFirst();
 };
@@ -57,12 +60,20 @@ export const deleteSession = async (lucia: Lucia, cookies: Cookies) => {
   });
 };
 
-export const usernameExists = async (username: string) => {
-  const users = await db
+export const usernameExists = async (
+  username: string,
+  excludeUserId?: string,
+) => {
+  let query = db
     .selectFrom('user')
-    .where('username', '=', username)
     .select(sql`1`.as('exists'))
-    .execute();
+    .where(usernameEquals(username));
+
+  if (excludeUserId) {
+    query = query.where('id', '!=', excludeUserId);
+  }
+
+  const users = await query.execute();
   return users.length > 0;
 };
 

--- a/src/routes/api/oauth/callback/+server.ts
+++ b/src/routes/api/oauth/callback/+server.ts
@@ -76,7 +76,14 @@ export const POST: RequestHandler = async ({ cookies, request, locals }) => {
   if (!user && profile.preferred_username) {
     const usernameUser = await getUser(profile.preferred_username);
     if (usernameUser) {
-      if (usernameUser.oauthId !== profile.sub) {
+      if (usernameUser.oauthId && usernameUser.oauthId !== profile.sub) {
+        return error(
+          500,
+          'Username already taken, and is linked to another account',
+        );
+      }
+
+      if (!usernameUser.oauthId) {
         user = await db
           .updateTable('user')
           .set('oauthId', profile.sub)

--- a/src/routes/api/oauth/callback/+server.ts
+++ b/src/routes/api/oauth/callback/+server.ts
@@ -7,7 +7,7 @@ import type { RequestHandler } from './$types';
 
 import { db, type User } from '$lib/db';
 import { lucia } from '$lib/server/auth';
-import { createSession } from '$lib/server/utils/auth';
+import { createSession, getUser } from '$lib/server/utils/auth';
 import { appConfig } from '$lib/server/utils/config';
 import { getOAuthProfile } from '$lib/server/utils/oauth';
 
@@ -74,23 +74,18 @@ export const POST: RequestHandler = async ({ cookies, request, locals }) => {
 
   // Case 3: User has not logged in via OAuth before, but has an account (we assume the username is owned by the user)
   if (!user && profile.preferred_username) {
-    const usernameUser = await db
-      .selectFrom('user')
-      .selectAll()
-      .where('username', '=', profile.preferred_username)
-      .executeTakeFirst();
+    const usernameUser = await getUser(profile.preferred_username);
     if (usernameUser) {
-      if (usernameUser.oauthId) {
-        throw new Error(
-          'Username already taken, and is linked to another account',
-        );
+      if (usernameUser.oauthId !== profile.sub) {
+        user = await db
+          .updateTable('user')
+          .set('oauthId', profile.sub)
+          .where('id', '=', usernameUser.id)
+          .returningAll()
+          .executeTakeFirst();
+      } else {
+        user = usernameUser;
       }
-      user = await db
-        .updateTable('user')
-        .set('oauthId', profile.sub)
-        .where('id', '=', usernameUser.id)
-        .returningAll()
-        .executeTakeFirst();
     }
   }
 

--- a/src/routes/api/users/admin-edit/+server.ts
+++ b/src/routes/api/users/admin-edit/+server.ts
@@ -77,7 +77,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   }
 
   if (updatedFields.username) {
-    const exists = await usernameExists(updatedFields.username);
+    const exists = await usernameExists(updatedFields.username, userId);
     if (exists) {
       setError(form, 'username', 'Username already exists');
       return actionResult('failure', { form });

--- a/src/routes/api/users/edit/+server.ts
+++ b/src/routes/api/users/edit/+server.ts
@@ -36,7 +36,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   }
 
   if (updatedFields.username) {
-    const exists = await usernameExists(updatedFields.username);
+    const exists = await usernameExists(updatedFields.username, user.id);
     if (exists) {
       setError(form, 'username', 'Username already exists');
       return actionResult('failure', { form });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make username checks case-insensitive and link OAuth logins to existing accounts when the provider username matches ignoring case. Prevents duplicate accounts and login errors.

- **Bug Fixes**
  - Added case-insensitive username matching via a shared helper; used in `getUser` and `usernameExists`.
  - `usernameExists` now supports `excludeUserId` to avoid false positives on profile edits; applied in admin and self-edit endpoints.
  - OAuth callback uses case-insensitive lookup; links or keeps `oauthId` for matching users, and returns a clear error if the username is linked to a different account.

<sup>Written for commit f5a00161596a6e6d2979a828a4dacb1b6b9a8ede. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



