### PR TITLE
feat: add API healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,12 +29,15 @@ COPY --from=build /app/prisma/migrations ./prisma/migrations
 
 COPY ./docker/migrate.js /app/docker/
 COPY ./docker/admin.js /app/docker/
+COPY ./docker/healthcheck.js /app/docker/
 COPY ./docker/entrypoint.sh /app/bin/
 COPY ./docker/airtrail-admin /app/bin/
-RUN chmod +x /app/bin/entrypoint.sh /app/bin/airtrail-admin
+COPY ./docker/airtrail-healthcheck /app/bin/
+RUN chmod +x /app/bin/entrypoint.sh /app/bin/airtrail-admin /app/bin/airtrail-healthcheck
 
 ENV PATH="${PATH}:/app/bin"
 
 USER node
 EXPOSE 3000/tcp
+HEALTHCHECK --interval=5m --start-period=30s --start-interval=10s --retries=3 CMD ["airtrail-healthcheck"]
 ENTRYPOINT [ "/app/bin/entrypoint.sh" ]

--- a/docker/airtrail-healthcheck
+++ b/docker/airtrail-healthcheck
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node /app/docker/healthcheck.js "$@"

--- a/docker/healthcheck.js
+++ b/docker/healthcheck.js
@@ -1,4 +1,5 @@
-const response = await fetch('http://127.0.0.1:3000/api/ping');
+const port = process.env.PORT ?? '3000';
+const response = await fetch(`http://127.0.0.1:${port}/api/ping`);
 
 if (!response.ok) {
   process.exit(1);

--- a/docker/healthcheck.js
+++ b/docker/healthcheck.js
@@ -1,0 +1,8 @@
+const response = await fetch('http://127.0.0.1:3000/api/ping');
+
+if (!response.ok) {
+  process.exit(1);
+}
+
+const body = await response.text();
+process.exit(body.trim() === 'pong' ? 0 : 1);

--- a/src/routes/api/ping/+server.ts
+++ b/src/routes/api/ping/+server.ts
@@ -1,0 +1,5 @@
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+  return new Response('pong');
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a lightweight API healthcheck and wire it into the container so Docker can detect unhealthy app instances. The app responds to GET /api/ping with "pong", and the Docker HEALTHCHECK runs it, honoring custom ports.

- **New Features**
  - Added GET /api/ping that returns "pong".
  - Added `airtrail-healthcheck` (Node) that pings localhost and respects `PORT` (defaults to 3000).
  - Configured Dockerfile HEALTHCHECK (interval 5m, start-period 30s, start-interval 10s, retries 3).

<sup>Written for commit 75a4d4d8971d7602d6673dc3db9ddace71be33da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

