### PR TITLE
feat: add frequency-based route color visualization

### DIFF
--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -330,10 +330,9 @@
   const getArcWidth = (d: FlightArc) => {
     if (mapPreferences.arcThickness === 'byFrequency') {
       const normalizedFreq = getArcFrequencyPercentile(d);
+      const scaledFreq = 1 + normalizedFreq * 2;
       return (
-        normalizedFreq *
-        3 *
-        FREQUENCY_ARC_MULTIPLIER[mapPreferences.arcThicknessScale]
+        scaledFreq * FREQUENCY_ARC_MULTIPLIER[mapPreferences.arcThicknessScale]
       );
     }
     return UNIFORM_ARC_WIDTH[mapPreferences.arcThicknessScale];

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -298,7 +298,11 @@
       } else if (mapPreferences.arcColor === 'byFrequency') {
         const normalizedFreq = getArcFrequencyPercentile(d);
         const baseColor = point === 'source' ? FROM_COLOR : TO_COLOR;
-        return interpolateColor(baseColor, HIGH_FREQUENCY_COLOR, normalizedFreq);
+        return interpolateColor(
+          baseColor,
+          HIGH_FREQUENCY_COLOR,
+          normalizedFreq,
+        );
       } else {
         return point === 'source' ? FROM_COLOR : TO_COLOR;
       }

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -2,6 +2,7 @@
   import type { Layer, PickingInfo, Color } from '@deck.gl/core';
   import { ArcLayer, ScatterplotLayer } from '@deck.gl/layers';
   import { MapboxOverlay } from '@deck.gl/mapbox';
+  import { isTouchDevice } from '@melt-ui/svelte/internal/helpers';
   import { onDestroy } from 'svelte';
   import {
     Box,
@@ -32,14 +33,27 @@
     prepareVisitedAirports,
   } from '$lib/utils';
   import { isMediumScreen } from '$lib/utils/size';
-  import { isTouchDevice } from '@melt-ui/svelte/internal/helpers';
 
   const AIRPORT_COLOR = (alpha: number): Color => [16, 185, 129, alpha]; // Tailwind emerald-500
   const INACTIVE_COLOR = (alpha: number): Color => [113, 113, 122, alpha];
   const FROM_COLOR = [59, 130, 246]; // Also the primary color
   const TO_COLOR = [139, 92, 246]; // TW violet-500
+  const HIGH_FREQUENCY_COLOR = [239, 68, 68]; // TW red-500
   const HOVER_COLOR = [16, 185, 129];
   const FUTURE_COLOR = [102, 217, 239, 100];
+
+  const interpolateColor = (
+    from: readonly [number, number, number],
+    to: readonly [number, number, number],
+    t: number,
+  ): Color => {
+    const clampedT = Math.max(0, Math.min(1, t));
+    return [
+      Math.round(from[0] + (to[0] - from[0]) * clampedT),
+      Math.round(from[1] + (to[1] - from[1]) * clampedT),
+      Math.round(from[2] + (to[2] - from[2]) * clampedT),
+    ];
+  };
 
   let {
     flights,
@@ -60,6 +74,48 @@
 
   type VisitedAirport = (typeof visitedAirports)[0];
   type FlightArc = (typeof flightArcs)[0];
+  const getRouteKey = (fromId: number, toId: number) =>
+    fromId <= toId ? `${fromId}:${toId}` : `${toId}:${fromId}`;
+
+  // Rank routes by frequency so the full 0..1 range is always used,
+  // even when one outlier route dominates absolute counts.
+  const arcFrequencyPercentileByRoute = $derived.by(() => {
+    const percentileByRoute: Record<string, number> = {};
+    if (!flightArcs || flightArcs.length === 0) return percentileByRoute;
+
+    if (flightArcs.length === 1) {
+      const onlyArc = flightArcs[0]!;
+      percentileByRoute[getRouteKey(onlyArc.from.id, onlyArc.to.id)] = 1;
+      return percentileByRoute;
+    }
+
+    const sorted = [...flightArcs].sort((a, b) => a.frequency - b.frequency);
+    const denominator = sorted.length - 1;
+
+    let i = 0;
+    while (i < sorted.length) {
+      const frequency = sorted[i]!.frequency;
+      let j = i + 1;
+      while (j < sorted.length && sorted[j]!.frequency === frequency) j += 1;
+
+      const averageRank = (i + (j - 1)) / 2;
+      const percentile = averageRank / denominator;
+
+      for (let k = i; k < j; k += 1) {
+        const arc = sorted[k]!;
+        percentileByRoute[getRouteKey(arc.from.id, arc.to.id)] = percentile;
+      }
+
+      i = j;
+    }
+
+    return percentileByRoute;
+  });
+
+  const getArcFrequencyPercentile = (d: FlightArc) => {
+    const routeKey = getRouteKey(d.from.id, d.to.id);
+    return arcFrequencyPercentileByRoute[routeKey] ?? 0;
+  };
 
   let id = getId('deckgl-layer');
   let hoveredAirport: VisitedAirport | undefined = $state.raw(undefined);
@@ -239,6 +295,10 @@
         return INACTIVE_COLOR(170);
       } else if (d.exclusivelyFuture) {
         return FUTURE_COLOR;
+      } else if (mapPreferences.arcColor === 'byFrequency') {
+        const normalizedFreq = getArcFrequencyPercentile(d);
+        const baseColor = point === 'source' ? FROM_COLOR : TO_COLOR;
+        return interpolateColor(baseColor, HIGH_FREQUENCY_COLOR, normalizedFreq);
       } else {
         return point === 'source' ? FROM_COLOR : TO_COLOR;
       }
@@ -265,8 +325,11 @@
 
   const getArcWidth = (d: FlightArc) => {
     if (mapPreferences.arcThickness === 'byFrequency') {
+      const normalizedFreq = getArcFrequencyPercentile(d);
       return (
-        d.frequency * FREQUENCY_ARC_MULTIPLIER[mapPreferences.arcThicknessScale]
+        normalizedFreq *
+        3 *
+        FREQUENCY_ARC_MULTIPLIER[mapPreferences.arcThicknessScale]
       );
     }
     return UNIFORM_ARC_WIDTH[mapPreferences.arcThicknessScale];
@@ -333,17 +396,22 @@
         hoveredAirport,
         selectedAirportId,
         selectedRoute,
+        mapPreferences.arcColor,
+        arcFrequencyPercentileByRoute,
       ],
       getTargetColor: [
         hoveredArc,
         hoveredAirport,
         selectedAirportId,
         selectedRoute,
+        mapPreferences.arcColor,
+        arcFrequencyPercentileByRoute,
       ],
       getWidth: [
         mapPreferences.arcThickness,
         mapPreferences.arcThicknessScale,
         selectedRoute,
+        arcFrequencyPercentileByRoute,
       ],
     },
     getWidth: getVisibleArcWidth,

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -145,176 +145,351 @@
     side="left"
     align="start"
     sideOffset={8}
-    class="w-[320px] p-0"
+    class="w-[min(calc(100vw-2rem),340px)] p-0"
   >
-    <div class="max-h-[calc(100vh-6rem)] overflow-y-auto p-4 space-y-5">
-      <section class="space-y-2">
-        <div class="flex items-baseline justify-between">
-          <h3 class="text-sm font-semibold">Basemap</h3>
-          <p class="text-muted-foreground text-[11px]">Style</p>
-        </div>
-        <div class="grid grid-cols-2 gap-2">
-          {#each BASEMAP_OPTIONS as option (option.value)}
-            <AppearanceTile
-              selected={mapPreferences.basemap === option.value}
-              onclick={() => (mapPreferences.basemap = option.value)}
-              label={option.label}
-              labelOutside
-            >
-              {#snippet illustration()}
-                <img
-                  src={option.value === 'satellite'
-                    ? `${base}/basemap-previews/satellite.jpg`
-                    : `${base}/basemap-previews/default-${basemapPreviewTheme}.png`}
-                  alt=""
-                  draggable="false"
-                  class="size-full object-cover"
-                />
-              {/snippet}
-            </AppearanceTile>
-          {/each}
-        </div>
-        {#if airportDetailSupported}
-          <div
-            class="space-y-2 border-t pt-3"
-            transition:fly={{ y: -8, duration: 160 }}
+    <div class="max-h-[calc(100vh-6rem)] overflow-y-auto">
+      <div class="flex items-center justify-between gap-3 border-b px-4 py-3">
+        <h2 class="text-sm font-semibold leading-none">Map appearance</h2>
+        <button
+          type="button"
+          class="text-muted-foreground hover:text-foreground rounded-sm px-1.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+          onclick={resetMapPreferences}
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="divide-y divide-border/60">
+        <section class="space-y-3 px-4 py-4">
+          <h3
+            class="text-muted-foreground text-[10px] font-medium uppercase tracking-wider"
           >
-            <div class="flex items-baseline justify-between">
-              <h4 class="text-xs font-semibold">Airport detail</h4>
-              <p class="text-muted-foreground text-[11px]">Overlay</p>
+            Basemap
+          </h3>
+          <div class="grid grid-cols-2 gap-2">
+            {#each BASEMAP_OPTIONS as option (option.value)}
+              <AppearanceTile
+                selected={mapPreferences.basemap === option.value}
+                onclick={() => (mapPreferences.basemap = option.value)}
+                label={option.label}
+                labelOutside
+              >
+                {#snippet illustration()}
+                  <img
+                    src={option.value === 'satellite'
+                      ? `${base}/basemap-previews/satellite.jpg`
+                      : `${base}/basemap-previews/default-${basemapPreviewTheme}.png`}
+                    alt=""
+                    draggable="false"
+                    class="size-full object-cover"
+                  />
+                {/snippet}
+              </AppearanceTile>
+            {/each}
+          </div>
+          {#if airportDetailSupported}
+            <div
+              class="space-y-2 border-t pt-3"
+              transition:fly={{ y: -8, duration: 160 }}
+            >
+              <h4
+                class="text-muted-foreground text-[10px] font-medium uppercase tracking-wider"
+              >
+                Airport detail
+              </h4>
+              <div class="grid grid-cols-2 gap-2">
+                {#each AIRPORT_DETAIL_OPTIONS as option (option.value)}
+                  <AppearanceTile
+                    selected={mapPreferences.airportOverlayDetail ===
+                      option.value}
+                    onclick={() =>
+                      (mapPreferences.airportOverlayDetail = option.value)}
+                    label={option.label}
+                  >
+                    {#snippet illustration()}
+                      <svg
+                        viewBox="0 0 72 32"
+                        class="airport-detail-tile h-full w-full"
+                        aria-hidden="true"
+                      >
+                        <rect
+                          width="72"
+                          height="32"
+                          fill="var(--airport-ground)"
+                        />
+                        <g transform="translate(36 16) rotate(-53)">
+                          <path
+                            d="M10 -20 V42"
+                            fill="none"
+                            stroke="var(--airport-taxiway-edge)"
+                            stroke-width="5"
+                            stroke-linecap="round"
+                          />
+                          <path
+                            d="M10 -20 V42"
+                            fill="none"
+                            stroke="var(--airport-taxiway)"
+                            stroke-width="3.5"
+                            stroke-linecap="round"
+                          />
+                          {#if option.value === 'detailed'}
+                            <path
+                              d="M10 -19 V41"
+                              fill="none"
+                              stroke="var(--airport-taxiway-centerline)"
+                              stroke-width="0.8"
+                              stroke-linecap="round"
+                            />
+                          {/if}
+                          <rect
+                            x="-36"
+                            y="-5"
+                            width="46"
+                            height="10"
+                            rx="1"
+                            fill="var(--airport-runway)"
+                            stroke="var(--airport-runway-edge)"
+                            stroke-width="0.5"
+                          />
+                          <path
+                            d="M-22 0 H2"
+                            fill="none"
+                            stroke="var(--airport-runway-marking)"
+                            stroke-width="1.25"
+                            stroke-dasharray="5 4"
+                            stroke-linecap="round"
+                            stroke-opacity="0.9"
+                          />
+                        </g>
+                        {#if option.value === 'detailed'}
+                          <g transform="translate(36 16) rotate(-53)">
+                            <path
+                              d="M8 -5 V5"
+                              fill="none"
+                              stroke="var(--airport-runway-marking)"
+                              stroke-width="1"
+                              stroke-linecap="round"
+                            />
+                            <path
+                              d="M-2 -4 V4 M0 -4 V4 M2 -4 V4 M4 -4 V4 M6 -4 V4"
+                              fill="none"
+                              stroke="var(--airport-runway-marking)"
+                              stroke-width="0.75"
+                            />
+                            <circle
+                              cx="-30"
+                              cy="-8"
+                              r="1"
+                              fill="var(--airport-edge-light)"
+                            />
+                            <circle
+                              cx="-20"
+                              cy="-8"
+                              r="1"
+                              fill="var(--airport-edge-light)"
+                            />
+                            <circle
+                              cx="-10"
+                              cy="-8"
+                              r="1"
+                              fill="var(--airport-edge-light)"
+                            />
+                            <circle
+                              cx="-30"
+                              cy="8"
+                              r="1"
+                              fill="var(--airport-edge-light)"
+                            />
+                            <circle
+                              cx="-20"
+                              cy="8"
+                              r="1"
+                              fill="var(--airport-edge-light)"
+                            />
+                            <circle
+                              cx="-10"
+                              cy="8"
+                              r="1"
+                              fill="var(--airport-edge-light)"
+                            />
+                            <path
+                              d="M10 -5 L13 -6.5 L13 -3.5 Z"
+                              fill="var(--airport-green-light)"
+                            />
+                            <path
+                              d="M10 -5 L7 -6.5 L7 -3.5 Z"
+                              fill="var(--airport-red-light)"
+                            />
+                            <path
+                              d="M10 5 L13 3.5 L13 6.5 Z"
+                              fill="var(--airport-green-light)"
+                            />
+                            <path
+                              d="M10 5 L7 3.5 L7 6.5 Z"
+                              fill="var(--airport-red-light)"
+                            />
+                          </g>
+                        {/if}
+                      </svg>
+                    {/snippet}
+                  </AppearanceTile>
+                {/each}
+              </div>
             </div>
+          {/if}
+        </section>
+
+        <section class="space-y-3 px-4 py-4">
+          <h3
+            class="text-muted-foreground text-[10px] font-medium uppercase tracking-wider"
+          >
+            Airports
+          </h3>
+          <div class="grid grid-cols-4 gap-2">
+            {#each AIRPORT_CIRCLE_OPTIONS as option (option.value)}
+              <AppearanceTile
+                selected={mapPreferences.airportCircles === option.value}
+                onclick={() => (mapPreferences.airportCircles = option.value)}
+                label={option.label}
+              >
+                {#snippet illustration()}
+                  {#if option.value === 'off'}
+                    <svg
+                      viewBox="0 0 48 32"
+                      class="h-full w-full text-muted-foreground"
+                      aria-hidden="true"
+                    >
+                      <circle
+                        cx="24"
+                        cy="16"
+                        r="6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-dasharray="2 2"
+                      />
+                      <line
+                        x1="14"
+                        y1="6"
+                        x2="34"
+                        y2="26"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  {:else}
+                    {@const radii =
+                      option.value === 'small'
+                        ? [2, 3, 2.5]
+                        : option.value === 'medium'
+                          ? [3.5, 5, 4]
+                          : [5, 7.5, 6]}
+                    <svg
+                      viewBox="0 0 48 32"
+                      class="h-full w-full text-primary"
+                      aria-hidden="true"
+                    >
+                      <circle
+                        cx="13"
+                        cy="20"
+                        r={radii[0]}
+                        fill="currentColor"
+                        fill-opacity="0.2"
+                        stroke="currentColor"
+                        stroke-width="1"
+                      />
+                      <circle
+                        cx="26"
+                        cy="13"
+                        r={radii[1]}
+                        fill="currentColor"
+                        fill-opacity="0.2"
+                        stroke="currentColor"
+                        stroke-width="1"
+                      />
+                      <circle
+                        cx="37"
+                        cy="22"
+                        r={radii[2]}
+                        fill="currentColor"
+                        fill-opacity="0.2"
+                        stroke="currentColor"
+                        stroke-width="1"
+                      />
+                    </svg>
+                  {/if}
+                {/snippet}
+              </AppearanceTile>
+            {/each}
+          </div>
+        </section>
+
+        <section class="space-y-3 px-4 py-4">
+          <h3
+            class="text-muted-foreground text-[10px] font-medium uppercase tracking-wider"
+          >
+            Routes
+          </h3>
+          <div class="space-y-2">
+            <p class="text-xs font-medium">Width</p>
             <div class="grid grid-cols-2 gap-2">
-              {#each AIRPORT_DETAIL_OPTIONS as option (option.value)}
+              {#each ARC_THICKNESS_OPTIONS as option (option.value)}
                 <AppearanceTile
-                  selected={mapPreferences.airportOverlayDetail ===
-                    option.value}
-                  onclick={() =>
-                    (mapPreferences.airportOverlayDetail = option.value)}
+                  selected={mapPreferences.arcThickness === option.value}
+                  onclick={() => (mapPreferences.arcThickness = option.value)}
                   label={option.label}
                 >
                   {#snippet illustration()}
                     <svg
                       viewBox="0 0 72 32"
-                      class="airport-detail-tile h-full w-full"
+                      class="h-full w-full text-primary"
                       aria-hidden="true"
                     >
-                      <rect
-                        width="72"
-                        height="32"
-                        fill="var(--airport-ground)"
-                      />
-                      <g transform="translate(36 16) rotate(-53)">
+                      {#if option.value === 'uniform'}
                         <path
-                          d="M10 -20 V42"
+                          d="M4 24 Q36 2 68 24"
                           fill="none"
-                          stroke="var(--airport-taxiway-edge)"
-                          stroke-width="5"
+                          stroke="currentColor"
+                          stroke-width="1.75"
                           stroke-linecap="round"
                         />
                         <path
-                          d="M10 -20 V42"
+                          d="M4 26 Q36 8 68 26"
                           fill="none"
-                          stroke="var(--airport-taxiway)"
+                          stroke="currentColor"
+                          stroke-width="1.75"
+                          stroke-linecap="round"
+                        />
+                        <path
+                          d="M4 28 Q36 14 68 28"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.75"
+                          stroke-linecap="round"
+                        />
+                      {:else}
+                        <path
+                          d="M4 24 Q36 2 68 24"
+                          fill="none"
+                          stroke="currentColor"
                           stroke-width="3.5"
                           stroke-linecap="round"
                         />
-                        {#if option.value === 'detailed'}
-                          <path
-                            d="M10 -19 V41"
-                            fill="none"
-                            stroke="var(--airport-taxiway-centerline)"
-                            stroke-width="0.8"
-                            stroke-linecap="round"
-                          />
-                        {/if}
-                        <rect
-                          x="-36"
-                          y="-5"
-                          width="46"
-                          height="10"
-                          rx="1"
-                          fill="var(--airport-runway)"
-                          stroke="var(--airport-runway-edge)"
-                          stroke-width="0.5"
+                        <path
+                          d="M4 26 Q36 8 68 26"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
                         />
                         <path
-                          d="M-22 0 H2"
+                          d="M4 28 Q36 14 68 28"
                           fill="none"
-                          stroke="var(--airport-runway-marking)"
-                          stroke-width="1.25"
-                          stroke-dasharray="5 4"
+                          stroke="currentColor"
+                          stroke-width="1"
                           stroke-linecap="round"
-                          stroke-opacity="0.9"
                         />
-                      </g>
-                      {#if option.value === 'detailed'}
-                        <g transform="translate(36 16) rotate(-53)">
-                          <path
-                            d="M8 -5 V5"
-                            fill="none"
-                            stroke="var(--airport-runway-marking)"
-                            stroke-width="1"
-                            stroke-linecap="round"
-                          />
-                          <path
-                            d="M-2 -4 V4 M0 -4 V4 M2 -4 V4 M4 -4 V4 M6 -4 V4"
-                            fill="none"
-                            stroke="var(--airport-runway-marking)"
-                            stroke-width="0.75"
-                          />
-                          <circle
-                            cx="-30"
-                            cy="-8"
-                            r="1"
-                            fill="var(--airport-edge-light)"
-                          />
-                          <circle
-                            cx="-20"
-                            cy="-8"
-                            r="1"
-                            fill="var(--airport-edge-light)"
-                          />
-                          <circle
-                            cx="-10"
-                            cy="-8"
-                            r="1"
-                            fill="var(--airport-edge-light)"
-                          />
-                          <circle
-                            cx="-30"
-                            cy="8"
-                            r="1"
-                            fill="var(--airport-edge-light)"
-                          />
-                          <circle
-                            cx="-20"
-                            cy="8"
-                            r="1"
-                            fill="var(--airport-edge-light)"
-                          />
-                          <circle
-                            cx="-10"
-                            cy="8"
-                            r="1"
-                            fill="var(--airport-edge-light)"
-                          />
-                          <path
-                            d="M10 -5 L13 -6.5 L13 -3.5 Z"
-                            fill="var(--airport-green-light)"
-                          />
-                          <path
-                            d="M10 -5 L7 -6.5 L7 -3.5 Z"
-                            fill="var(--airport-red-light)"
-                          />
-                          <path
-                            d="M10 5 L13 3.5 L13 6.5 Z"
-                            fill="var(--airport-green-light)"
-                          />
-                          <path
-                            d="M10 5 L7 3.5 L7 6.5 Z"
-                            fill="var(--airport-red-light)"
-                          />
-                        </g>
                       {/if}
                     </svg>
                   {/snippet}
@@ -322,413 +497,254 @@
               {/each}
             </div>
           </div>
-        {/if}
-      </section>
 
-      <section class="space-y-2">
-        <div class="flex items-baseline justify-between">
-          <h3 class="text-sm font-semibold">Airports</h3>
-          <p class="text-muted-foreground text-[11px]">Circle size</p>
-        </div>
-        <div class="grid grid-cols-4 gap-2">
-          {#each AIRPORT_CIRCLE_OPTIONS as option (option.value)}
-            <AppearanceTile
-              selected={mapPreferences.airportCircles === option.value}
-              onclick={() => (mapPreferences.airportCircles = option.value)}
-              label={option.label}
-            >
-              {#snippet illustration()}
-                {#if option.value === 'off'}
-                  <svg
-                    viewBox="0 0 48 32"
-                    class="h-full w-full text-muted-foreground"
-                    aria-hidden="true"
-                  >
-                    <circle
-                      cx="24"
-                      cy="16"
-                      r="6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-dasharray="2 2"
-                    />
-                    <line
-                      x1="14"
-                      y1="6"
-                      x2="34"
-                      y2="26"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                {:else}
-                  {@const radii =
-                    option.value === 'small'
-                      ? [2, 3, 2.5]
-                      : option.value === 'medium'
-                        ? [3.5, 5, 4]
-                        : [5, 7.5, 6]}
-                  <svg
-                    viewBox="0 0 48 32"
-                    class="h-full w-full text-primary"
-                    aria-hidden="true"
-                  >
-                    <circle
-                      cx="13"
-                      cy="20"
-                      r={radii[0]}
-                      fill="currentColor"
-                      fill-opacity="0.2"
-                      stroke="currentColor"
-                      stroke-width="1"
-                    />
-                    <circle
-                      cx="26"
-                      cy="13"
-                      r={radii[1]}
-                      fill="currentColor"
-                      fill-opacity="0.2"
-                      stroke="currentColor"
-                      stroke-width="1"
-                    />
-                    <circle
-                      cx="37"
-                      cy="22"
-                      r={radii[2]}
-                      fill="currentColor"
-                      fill-opacity="0.2"
-                      stroke="currentColor"
-                      stroke-width="1"
-                    />
-                  </svg>
-                {/if}
-              {/snippet}
-            </AppearanceTile>
-          {/each}
-        </div>
-      </section>
-
-      <section class="space-y-2">
-        <div class="flex items-baseline justify-between">
-          <h3 class="text-sm font-semibold">Arcs</h3>
-          <p class="text-muted-foreground text-[11px]">Thickness</p>
-        </div>
-        <div class="grid grid-cols-2 gap-2">
-          {#each ARC_THICKNESS_OPTIONS as option (option.value)}
-            <AppearanceTile
-              selected={mapPreferences.arcThickness === option.value}
-              onclick={() => (mapPreferences.arcThickness = option.value)}
-              label={option.label}
-            >
-              {#snippet illustration()}
-                <svg
-                  viewBox="0 0 72 32"
-                  class="h-full w-full text-primary"
-                  aria-hidden="true"
+          <div class="space-y-2">
+            <p class="text-xs font-medium">Scale</p>
+            <div class="grid grid-cols-3 gap-2">
+              {#each ARC_SCALE_OPTIONS as option (option.value)}
+                <AppearanceTile
+                  compact
+                  selected={mapPreferences.arcThicknessScale === option.value}
+                  onclick={() =>
+                    (mapPreferences.arcThicknessScale = option.value)}
+                  label={option.label}
                 >
-                  {#if option.value === 'uniform'}
-                    <path
-                      d="M4 24 Q36 2 68 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.75"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="M4 26 Q36 8 68 26"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.75"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="M4 28 Q36 14 68 28"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.75"
-                      stroke-linecap="round"
-                    />
-                  {:else}
-                    <path
-                      d="M4 24 Q36 2 68 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="3.5"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="M4 26 Q36 8 68 26"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="M4 28 Q36 14 68 28"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1"
-                      stroke-linecap="round"
-                    />
-                  {/if}
-                </svg>
-              {/snippet}
-            </AppearanceTile>
-          {/each}
-        </div>
-        <div class="grid grid-cols-3 gap-2">
-          {#each ARC_SCALE_OPTIONS as option (option.value)}
-            <AppearanceTile
-              compact
-              selected={mapPreferences.arcThicknessScale === option.value}
-              onclick={() => (mapPreferences.arcThicknessScale = option.value)}
-              label={option.label}
-            >
-              {#snippet illustration()}
-                {@const strokeWidth =
-                  option.value === 'thin'
-                    ? 1
-                    : option.value === 'normal'
-                      ? 2.25
-                      : 4}
-                <svg
-                  viewBox="0 0 72 24"
-                  class="h-full w-full text-primary"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M4 20 Q36 0 68 20"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width={strokeWidth}
-                    stroke-linecap="round"
-                  />
-                </svg>
-              {/snippet}
-            </AppearanceTile>
-          {/each}
-        </div>
-
-        <div class="space-y-2">
-          <div class="flex items-baseline justify-between">
-            <h3 class="text-sm font-semibold">Arcs</h3>
-            <p class="text-muted-foreground text-[11px]">Color</p>
+                  {#snippet illustration()}
+                    {@const strokeWidth =
+                      option.value === 'thin'
+                        ? 1
+                        : option.value === 'normal'
+                          ? 2.25
+                          : 4}
+                    <svg
+                      viewBox="0 0 72 24"
+                      class="h-full w-full text-primary"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M4 20 Q36 0 68 20"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width={strokeWidth}
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  {/snippet}
+                </AppearanceTile>
+              {/each}
+            </div>
           </div>
-          <div class="grid grid-cols-2 gap-2">
-            {#each ARC_COLOR_OPTIONS as option (option.value)}
-              <AppearanceTile
-                selected={mapPreferences.arcColor === option.value}
-                onclick={() => (mapPreferences.arcColor = option.value)}
-                label={option.label}
-              >
-                {#snippet illustration()}
-                  <svg
-                    viewBox="0 0 72 32"
-                    class="h-full w-full"
-                    aria-hidden="true"
-                  >
-                    {#if option.value === 'default'}
-                      <path
-                        d="M4 24 Q36 2 68 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        class="text-primary"
+
+          <div class="space-y-2">
+            <p class="text-xs font-medium">Color</p>
+            <div class="grid grid-cols-2 gap-2">
+              {#each ARC_COLOR_OPTIONS as option (option.value)}
+                <AppearanceTile
+                  selected={mapPreferences.arcColor === option.value}
+                  onclick={() => (mapPreferences.arcColor = option.value)}
+                  label={option.label}
+                >
+                  {#snippet illustration()}
+                    <svg
+                      viewBox="0 0 72 32"
+                      class="h-full w-full"
+                      aria-hidden="true"
+                    >
+                      {#if option.value === 'default'}
+                        <path
+                          d="M4 24 Q36 2 68 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          class="text-primary"
+                        />
+                        <path
+                          d="M4 26 Q36 8 68 26"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          class="text-primary"
+                        />
+                        <path
+                          d="M4 28 Q36 14 68 28"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          class="text-primary"
+                        />
+                      {:else}
+                        <path
+                          d="M4 24 Q36 2 68 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          class="text-blue-400"
+                        />
+                        <path
+                          d="M4 26 Q36 8 68 26"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          class="text-violet-400"
+                        />
+                        <path
+                          d="M4 28 Q36 14 68 28"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          class="text-red-500"
+                        />
+                      {/if}
+                    </svg>
+                  {/snippet}
+                </AppearanceTile>
+              {/each}
+            </div>
+          </div>
+        </section>
+
+        {#if openAipConfigured}
+          <section class="space-y-3 px-4 py-4">
+            <div class="flex items-center justify-between">
+              <div>
+                <h3
+                  class="text-muted-foreground text-[10px] font-medium uppercase tracking-wider"
+                >
+                  OpenAIP
+                </h3>
+                <p class="text-muted-foreground text-[11px]">
+                  Airspaces, airports, and navaids
+                </p>
+              </div>
+              <Switch
+                size="small"
+                checked={mapPreferences.openAipEnabled}
+                onCheckedChange={(v) => (mapPreferences.openAipEnabled = v)}
+              />
+            </div>
+            <div
+              class={cn(
+                'grid grid-cols-3 gap-2 transition-opacity',
+                !mapPreferences.openAipEnabled &&
+                  'pointer-events-none opacity-40',
+              )}
+              aria-hidden={!mapPreferences.openAipEnabled}
+            >
+              {#each OPENAIP_GROUP_OPTIONS as option (option.value)}
+                <AppearanceTile
+                  compact
+                  selected={mapPreferences.openAipGroups.includes(option.value)}
+                  onclick={() => toggleOpenAipGroup(option.value)}
+                  label={option.label}
+                >
+                  {#snippet illustration()}
+                    {#if option.value === 'airspaces'}
+                      <svg
+                        viewBox="0 0 48 24"
+                        class="h-full w-full"
+                        aria-hidden="true"
+                      >
+                        <path
+                          d="M6 18 L14 6 L30 6 L42 14 L36 20 L10 20 Z"
+                          fill="#8b5cf6"
+                          fill-opacity="0.25"
+                          stroke="#8b5cf6"
+                          stroke-width="1.25"
+                          stroke-linejoin="round"
+                        />
+                        <path
+                          d="M16 16 L22 10 L32 12 L30 18 Z"
+                          fill="#3b82f6"
+                          fill-opacity="0.3"
+                          stroke="#3b82f6"
+                          stroke-width="1"
+                          stroke-linejoin="round"
+                        />
+                      </svg>
+                    {:else if option.value === 'airspaceLabels'}
+                      <svg
+                        viewBox="0 0 48 24"
+                        class="h-full w-full"
+                        aria-hidden="true"
+                      >
+                        <path
+                          d="M5 18 L12 6 L32 6 L42 14 L36 20 L9 20 Z"
+                          fill="#8b5cf6"
+                          fill-opacity="0.18"
+                          stroke="#8b5cf6"
+                          stroke-width="1"
+                          stroke-linejoin="round"
+                          stroke-dasharray="2 2"
+                        />
+                        <text
+                          x="24"
+                          y="16"
+                          text-anchor="middle"
+                          font-size="9"
+                          font-weight="700"
+                          font-family="ui-sans-serif, system-ui, sans-serif"
+                          fill="#6d28d9"
+                        >
+                          CTR
+                        </text>
+                      </svg>
+                    {:else if option.value === 'airports'}
+                      <img
+                        src={aptSymbol}
+                        alt=""
+                        class="h-[88%] w-auto dark:invert"
                       />
-                      <path
-                        d="M4 26 Q36 8 68 26"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        class="text-primary"
-                      />
-                      <path
-                        d="M4 28 Q36 14 68 28"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        class="text-primary"
+                    {:else if option.value === 'navaids'}
+                      <img
+                        src={navaidRoseSymbol}
+                        alt=""
+                        class="h-[92%] w-auto dark:invert"
                       />
                     {:else}
-                      <path
-                        d="M4 24 Q36 2 68 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        class="text-blue-400"
-                      />
-                      <path
-                        d="M4 26 Q36 8 68 26"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        class="text-violet-400"
-                      />
-                      <path
-                        d="M4 28 Q36 14 68 28"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        class="text-red-500"
+                      <img
+                        src={reportingPointSymbol}
+                        alt=""
+                        class="h-[82%] w-auto dark:invert"
                       />
                     {/if}
-                  </svg>
-                {/snippet}
-              </AppearanceTile>
-            {/each}
-          </div>
-        </div>
-      </section>
-
-      {#if openAipConfigured}
-        <section class="space-y-3">
-          <div class="flex items-center justify-between">
-            <div>
-              <h3 class="text-sm font-semibold">OpenAIP overlay</h3>
-              <p class="text-muted-foreground text-[11px]">
-                Airspaces, airports, and navaids
-              </p>
+                  {/snippet}
+                </AppearanceTile>
+              {/each}
             </div>
-            <Switch
-              size="small"
-              checked={mapPreferences.openAipEnabled}
-              onCheckedChange={(v) => (mapPreferences.openAipEnabled = v)}
-            />
-          </div>
-          <div
-            class={cn(
-              'grid grid-cols-3 gap-2 transition-opacity',
-              !mapPreferences.openAipEnabled &&
-                'pointer-events-none opacity-40',
-            )}
-            aria-hidden={!mapPreferences.openAipEnabled}
+          </section>
+        {:else if isAdmin}
+          <section
+            class="m-4 space-y-2 rounded-md border border-dashed bg-muted/40 p-3"
           >
-            {#each OPENAIP_GROUP_OPTIONS as option (option.value)}
-              <AppearanceTile
-                compact
-                selected={mapPreferences.openAipGroups.includes(option.value)}
-                onclick={() => toggleOpenAipGroup(option.value)}
-                label={option.label}
-              >
-                {#snippet illustration()}
-                  {#if option.value === 'airspaces'}
-                    <svg
-                      viewBox="0 0 48 24"
-                      class="h-full w-full"
-                      aria-hidden="true"
-                    >
-                      <path
-                        d="M6 18 L14 6 L30 6 L42 14 L36 20 L10 20 Z"
-                        fill="#8b5cf6"
-                        fill-opacity="0.25"
-                        stroke="#8b5cf6"
-                        stroke-width="1.25"
-                        stroke-linejoin="round"
-                      />
-                      <path
-                        d="M16 16 L22 10 L32 12 L30 18 Z"
-                        fill="#3b82f6"
-                        fill-opacity="0.3"
-                        stroke="#3b82f6"
-                        stroke-width="1"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
-                  {:else if option.value === 'airspaceLabels'}
-                    <svg
-                      viewBox="0 0 48 24"
-                      class="h-full w-full"
-                      aria-hidden="true"
-                    >
-                      <path
-                        d="M5 18 L12 6 L32 6 L42 14 L36 20 L9 20 Z"
-                        fill="#8b5cf6"
-                        fill-opacity="0.18"
-                        stroke="#8b5cf6"
-                        stroke-width="1"
-                        stroke-linejoin="round"
-                        stroke-dasharray="2 2"
-                      />
-                      <text
-                        x="24"
-                        y="16"
-                        text-anchor="middle"
-                        font-size="9"
-                        font-weight="700"
-                        font-family="ui-sans-serif, system-ui, sans-serif"
-                        fill="#6d28d9"
-                      >
-                        CTR
-                      </text>
-                    </svg>
-                  {:else if option.value === 'airports'}
-                    <img
-                      src={aptSymbol}
-                      alt=""
-                      class="h-[88%] w-auto dark:invert"
-                    />
-                  {:else if option.value === 'navaids'}
-                    <img
-                      src={navaidRoseSymbol}
-                      alt=""
-                      class="h-[92%] w-auto dark:invert"
-                    />
-                  {:else}
-                    <img
-                      src={reportingPointSymbol}
-                      alt=""
-                      class="h-[82%] w-auto dark:invert"
-                    />
-                  {/if}
-                {/snippet}
-              </AppearanceTile>
-            {/each}
-          </div>
-        </section>
-      {:else if isAdmin}
-        <section
-          class="rounded-md border border-dashed bg-muted/40 p-3 space-y-2"
-        >
-          <div class="flex items-start gap-2">
-            <Settings2
-              class="mt-0.5 size-4 shrink-0 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <div class="space-y-0.5">
-              <h3 class="text-sm font-semibold">OpenAIP overlay</h3>
-              <p class="text-muted-foreground text-[11px] leading-snug">
-                Add an OpenAIP API key in integration settings to enable
-                airspaces, navaids, and reporting points.
-              </p>
+            <div class="flex items-start gap-2">
+              <Settings2
+                class="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <div class="space-y-0.5">
+                <h3 class="text-sm font-semibold">OpenAIP overlay</h3>
+                <p class="text-muted-foreground text-[11px] leading-snug">
+                  Add an OpenAIP API key in integration settings to enable
+                  airspaces, navaids, and reporting points.
+                </p>
+              </div>
             </div>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            class="w-full"
-            onclick={openIntegrationSettings}
-          >
-            Open integration settings
-          </Button>
-        </section>
-      {/if}
-
-      <div class="flex justify-end border-t pt-3 -mx-4 px-4">
-        <button
-          type="button"
-          class="text-muted-foreground hover:text-foreground text-xs font-medium"
-          onclick={resetMapPreferences}
-        >
-          Reset to defaults
-        </button>
+            <Button
+              variant="outline"
+              size="sm"
+              class="w-full"
+              onclick={openIntegrationSettings}
+            >
+              Open integration settings
+            </Button>
+          </section>
+        {/if}
       </div>
     </div>
   </Popover.Content>

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -21,6 +21,7 @@
     toggleOpenAipGroup,
     type AirportOverlayDetail,
     type AirportCirclesMode,
+    type ArcColorMode,
     type ArcThicknessMode,
     type ArcThicknessScale,
   } from '$lib/map/map-preferences.svelte';
@@ -50,6 +51,14 @@
     { value: 'small', label: 'Small' },
     { value: 'medium', label: 'Medium' },
     { value: 'large', label: 'Large' },
+  ];
+
+  const ARC_COLOR_OPTIONS: Array<{
+    value: ArcColorMode;
+    label: string;
+  }> = [
+    { value: 'default', label: 'Default' },
+    { value: 'byFrequency', label: 'By frequency' },
   ];
 
   const ARC_THICKNESS_OPTIONS: Array<{
@@ -500,6 +509,82 @@
               {/snippet}
             </AppearanceTile>
           {/each}
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-baseline justify-between">
+            <h3 class="text-sm font-semibold">Arcs</h3>
+            <p class="text-muted-foreground text-[11px]">Color</p>
+          </div>
+          <div class="grid grid-cols-2 gap-2">
+            {#each ARC_COLOR_OPTIONS as option (option.value)}
+              <AppearanceTile
+                selected={mapPreferences.arcColor === option.value}
+                onclick={() => (mapPreferences.arcColor = option.value)}
+                label={option.label}
+              >
+                {#snippet illustration()}
+                  <svg
+                    viewBox="0 0 72 32"
+                    class="h-full w-full"
+                    aria-hidden="true"
+                  >
+                    {#if option.value === 'default'}
+                      <path
+                        d="M4 24 Q36 2 68 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        class="text-primary"
+                      />
+                      <path
+                        d="M4 26 Q36 8 68 26"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        class="text-primary"
+                      />
+                      <path
+                        d="M4 28 Q36 14 68 28"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        class="text-primary"
+                      />
+                    {:else}
+                      <path
+                        d="M4 24 Q36 2 68 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        class="text-blue-400"
+                      />
+                      <path
+                        d="M4 26 Q36 8 68 26"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        class="text-violet-400"
+                      />
+                      <path
+                        d="M4 28 Q36 14 68 28"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        class="text-red-500"
+                      />
+                    {/if}
+                  </svg>
+                {/snippet}
+              </AppearanceTile>
+            {/each}
+          </div>
         </div>
       </section>
 

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -8,6 +8,7 @@ import {
 import { MAP_BASEMAPS, type MapBasemap } from './basemap';
 
 export type AirportCirclesMode = 'off' | 'small' | 'medium' | 'large';
+export type ArcColorMode = 'default' | 'byFrequency';
 export type ArcThicknessMode = 'uniform' | 'byFrequency';
 export type ArcThicknessScale = 'thin' | 'normal' | 'thick';
 export type AirportOverlayDetail = 'standard' | 'detailed';
@@ -15,6 +16,7 @@ export type AirportOverlayDetail = 'standard' | 'detailed';
 export type MapPreferences = {
   basemap: MapBasemap;
   airportCircles: AirportCirclesMode;
+  arcColor: ArcColorMode;
   arcThickness: ArcThicknessMode;
   arcThicknessScale: ArcThicknessScale;
   airportOverlayDetail: AirportOverlayDetail;
@@ -30,6 +32,10 @@ const AIRPORT_CIRCLES_MODES: readonly AirportCirclesMode[] = [
   'small',
   'medium',
   'large',
+];
+const ARC_COLOR_MODES: readonly ArcColorMode[] = [
+  'default',
+  'byFrequency',
 ];
 const ARC_THICKNESS_MODES: readonly ArcThicknessMode[] = [
   'uniform',
@@ -48,6 +54,7 @@ const AIRPORT_OVERLAY_DETAIL_MODES: readonly AirportOverlayDetail[] = [
 export const MAP_PREFERENCE_DEFAULTS: MapPreferences = {
   basemap: 'default',
   airportCircles: 'large',
+  arcColor: 'default',
   arcThickness: 'uniform',
   arcThicknessScale: 'normal',
   airportOverlayDetail: 'detailed',
@@ -80,6 +87,12 @@ const sanitize = (raw: unknown): MapPreferences => {
     AIRPORT_CIRCLES_MODES.includes(input.airportCircles as AirportCirclesMode)
   ) {
     result.airportCircles = input.airportCircles as AirportCirclesMode;
+  }
+  if (
+    typeof input.arcColor === 'string' &&
+    ARC_COLOR_MODES.includes(input.arcColor as ArcColorMode)
+  ) {
+    result.arcColor = input.arcColor as ArcColorMode;
   }
   if (
     typeof input.arcThickness === 'string' &&
@@ -146,6 +159,7 @@ export const initMapPreferences = () => {
   const hydrated = sanitize(parsed);
   mapPreferences.basemap = hydrated.basemap;
   mapPreferences.airportCircles = hydrated.airportCircles;
+  mapPreferences.arcColor = hydrated.arcColor;
   mapPreferences.arcThickness = hydrated.arcThickness;
   mapPreferences.arcThicknessScale = hydrated.arcThicknessScale;
   mapPreferences.airportOverlayDetail = hydrated.airportOverlayDetail;
@@ -157,6 +171,7 @@ export const initMapPreferences = () => {
       const snapshot: MapPreferences = {
         basemap: mapPreferences.basemap,
         airportCircles: mapPreferences.airportCircles,
+        arcColor: mapPreferences.arcColor,
         arcThickness: mapPreferences.arcThickness,
         arcThicknessScale: mapPreferences.arcThicknessScale,
         airportOverlayDetail: mapPreferences.airportOverlayDetail,
@@ -175,6 +190,7 @@ export const initMapPreferences = () => {
 export const resetMapPreferences = () => {
   mapPreferences.basemap = MAP_PREFERENCE_DEFAULTS.basemap;
   mapPreferences.airportCircles = MAP_PREFERENCE_DEFAULTS.airportCircles;
+  mapPreferences.arcColor = MAP_PREFERENCE_DEFAULTS.arcColor;
   mapPreferences.arcThickness = MAP_PREFERENCE_DEFAULTS.arcThickness;
   mapPreferences.arcThicknessScale = MAP_PREFERENCE_DEFAULTS.arcThicknessScale;
   mapPreferences.airportOverlayDetail =

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -33,10 +33,7 @@ const AIRPORT_CIRCLES_MODES: readonly AirportCirclesMode[] = [
   'medium',
   'large',
 ];
-const ARC_COLOR_MODES: readonly ArcColorMode[] = [
-  'default',
-  'byFrequency',
-];
+const ARC_COLOR_MODES: readonly ArcColorMode[] = ['default', 'byFrequency'];
 const ARC_THICKNESS_MODES: readonly ArcThicknessMode[] = [
   'uniform',
   'byFrequency',


### PR DESCRIPTION
**Description**
Map appearance: improve frequency-based arc styling (color + thickness) with percentile scaling.

**Issues**
Raw frequency values were dominated by extreme routes, collapsing many routes into near-identical visuals.
(ex, if one route is flown 100 times, a route flown 20 times will have no visual difference with a route flown 1 time)

**Changes**
- patch: arc thickness by frequency uses percentile-based scaling instead of absolute value.
- add: arc color by frequency.


<img width="1587" height="852" alt="image" src="https://github.com/user-attachments/assets/37c546a6-6b7a-4470-a23e-e60e3c61e5a1" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved route frequency visualization: arc thickness now uses percentile scaling and arcs can color by frequency, making busy routes stand out without flattening others. Adds a simple control in Map Appearance and persists the choice.

- **New Features**
  - Arc thickness uses percentile ranks (per-route, undirected keys) instead of raw counts.
  - New arc color mode: "By frequency" blends base colors toward red as frequency increases; default remains unchanged.
  - Map Appearance → Arcs → Color with "Default" and "By frequency".
  - Preferences: added `arcColor` to `MapPreferences`; sanitized, persisted, and resettable.
  - Internals: deck.gl update triggers now include `arcColor` and per-route percentiles for color and width recalculation.

<sup>Written for commit ba1aa6c017e45b90e7adb07ae2d659a2298f8e26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add frequency-based route color visualization to the flights map
> - Adds a new `byFrequency` arc color mode that blends each route's source/target color toward a high-frequency red based on its percentile rank across all routes.
> - Adds `ArcColorMode` type, `arcColor` preference (defaulting to `'default'`), and wires it through localStorage persistence, sanitization, and reset in [map-preferences.svelte.ts](https://github.com/johanohly/AirTrail/pull/571/files#diff-7de144adf31aa0d20aa84c1d37751538ab95b6bc801ab2ac31af5ef9fc72770f).
> - Exposes a 'Routes → Color' selector in [MapAppearanceControl.svelte](https://github.com/johanohly/AirTrail/pull/571/files#diff-cc78f2f9305525c510df3c0b9e1c77aa12b84e70843390543e84b495d0e2290b) with 'Default' and 'By frequency' options; also moves the reset action to the panel header.
> - Behavioral Change: when arc width is set to `byFrequency`, widths are now driven by a normalized 0–1 percentile scale instead of absolute frequency counts, so visual thickness is relative rather than absolute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 920799d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->