### PR TITLE
fix: constrain deduplicate table height to viewport

### DIFF
--- a/src/routes/tools/deduplicate/+page.svelte
+++ b/src/routes/tools/deduplicate/+page.svelte
@@ -125,7 +125,7 @@
     All of these already exist in the database, with the same origin,
     destination, and date.
   </p>
-  <div class="rounded-md border">
+  <div class="rounded-md border [&>div]:max-h-[calc(100vh-350px)]">
     <Table.Root>
       <Table.Header>
         {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}


### PR DESCRIPTION
### Description

**What changed?**
This PR fixes a layout issue on the `tools/deduplicate` page. Previously, when a large number of duplicate flights were loaded, the `Table` component grew unrestricted, causing the entire page to overflow the `100vh` limit and pushing the "Delete Flights" button off-screen.

I've constrained the height of the table's inner wrapper by applying `[&>div]:max-h-[calc(100vh-350px)]` to the outer parent container. 

**Why was this change made?**
To improve the user experience. By constraining the height, the table now handles its own vertical scrolling. This keeps the page layout static and ensures the page header and the "Delete Flights" action button remain firmly anchored within the user's viewport at all times.

### How to test
1. Navigate to `/tools/deduplicate`.
2. Ensure you have enough duplicate flights in your database to cause an overflow (e.g., 30+ flights).
3. Observe that the main browser window no longer scrolls.
4. Verify that the table itself is scrollable and the "Delete Flights" button is permanently visible at the bottom of the screen.

***

*(Note: Since `CONTRIBUTING.md` mentions that opening an issue beforehand isn't required for obvious errors, this layout fix qualifies as an obvious UI correction and you should be good to submit it directly!)*

|Before:|After:|
|--|--|
|<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/4ac01db8-6256-4a33-8349-2506d5247f40" />|<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/7dfe059a-361f-4368-a7b6-195b19da3192" />|
