### PR TITLE
feat: add proxy support for integration API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,10 @@ DB_USERNAME=airtrail
 # For Docker: Use a path inside the container that's mounted to a volume (e.g., /app/uploads)
 # For local development: Use an absolute path on your system
 UPLOAD_LOCATION=/app/uploads
+
+# Integration outbound proxy (optional)
+###################################################################################
+# Route server-side calls to AeroDataBox/RapidAPI and OpenAIP through an HTTP(S) or SOCKS5 proxy
+# Leave empty to connect directly.
+# INTEGRATIONS_PROXY_URL=http://proxyhost.com:8888
+# INTEGRATIONS_PROXY_URL=socks5://proxyuser:proxypassword@proxyhost.com:1080

--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,10 @@
       "dependencies": {
         "@node-rs/argon2": "^2.0.2",
         "geo-tz": "^8.1.6",
+        "https-proxy-agent": "^7.0.2",
         "memoize": "^10.2.0",
         "pg": "^8.20.0",
+        "socks-proxy-agent": "^8.0.5",
       },
       "devDependencies": {
         "@date-fns/tz": "^1.4.1",
@@ -1659,6 +1661,8 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
@@ -2235,7 +2239,13 @@
 
     "slice-source": ["slice-source@0.4.1", "", {}, "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
     "smob": ["smob@1.5.0", "", {}, "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig=="],
+
+    "socks": ["socks@2.8.8", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
     "geo-tz": "^8.1.6",
+    "https-proxy-agent": "^7.0.2",
     "memoize": "^10.2.0",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "socks-proxy-agent": "^8.0.5"
   },
   "devDependencies": {
     "@date-fns/tz": "^1.4.1",

--- a/src/lib/server/utils/flight-lookup/aerodatabox.ts
+++ b/src/lib/server/utils/flight-lookup/aerodatabox.ts
@@ -15,6 +15,7 @@ import { getAircraftByIcao } from '$lib/server/utils/aircraft';
 import { getAirlineByIcao, getAirlineByIata } from '$lib/server/utils/airline';
 import { getAirportByIcao } from '$lib/server/utils/airport';
 import { appConfig } from '$lib/server/utils/config';
+import { fetchIntegration } from '$lib/server/utils/integration-fetch';
 import { RequestRateLimiter } from '$lib/utils/ratelimiter';
 
 const BASE_URL = 'https://aerodatabox.p.rapidapi.com';
@@ -64,7 +65,7 @@ export async function getFlightRoute(
     )}/${fromDate}/${toDate}?dateLocalRole=Both&withAircraftImage=false&withLocation=false`;
   }
 
-  const resp = await fetch(url, {
+  const resp = await fetchIntegration(url, {
     headers: {
       'x-rapidapi-key': apiKey,
     },
@@ -192,7 +193,7 @@ export async function getAircraftFromReg(
   }
 
   const url = `${BASE_URL}/aircrafts/reg/${encodeURIComponent(reg)}`;
-  const resp = await fetch(url, {
+  const resp = await fetchIntegration(url, {
     headers: {
       'x-rapidapi-key': apiKey,
     },

--- a/src/lib/server/utils/integration-fetch.ts
+++ b/src/lib/server/utils/integration-fetch.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/private';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import type { OutgoingHttpHeaders } from 'node:http';
+import type { IncomingMessage, OutgoingHttpHeaders } from 'node:http';
 import https from 'node:https';
 import { Readable } from 'node:stream';
 import { SocksProxyAgent } from 'socks-proxy-agent';
@@ -29,10 +29,7 @@ const createAbortError = () =>
 const hasHeader = (headers: OutgoingHttpHeaders, name: string) =>
   Object.keys(headers).some((key) => key.toLowerCase() === name);
 
-const prepareBody = async (
-  init: RequestInit,
-  headers: OutgoingHttpHeaders,
-) => {
+const prepareBody = async (init: RequestInit, headers: OutgoingHttpHeaders) => {
   if (init.body == null) {
     return null;
   }
@@ -86,15 +83,26 @@ const fetchThroughProxy = async (
   }
 
   return new Promise((resolve, reject) => {
-    let settled = false;
+    let promiseSettled = false;
     let req: ReturnType<typeof https.request> | null = null;
+    let res: IncomingMessage | null = null;
     let abortHandler: (() => void) | null = null;
 
-    const settle = <T>(callback: (value: T) => void, value: T) => {
-      if (settled) return;
-      settled = true;
+    const cleanupAbortHandler = () => {
       if (init.signal && abortHandler) {
         init.signal.removeEventListener('abort', abortHandler);
+      }
+    };
+
+    const settle = <T>(
+      callback: (value: T) => void,
+      value: T,
+      { cleanupAbort = true } = {},
+    ) => {
+      if (promiseSettled) return;
+      promiseSettled = true;
+      if (cleanupAbort) {
+        cleanupAbortHandler();
       }
       callback(value);
     };
@@ -103,16 +111,20 @@ const fetchThroughProxy = async (
       ? () => {
           const err = createAbortError();
           req?.destroy(err);
-          settle(reject, err);
+          res?.destroy(err);
+          if (!promiseSettled) {
+            settle(reject, err);
+          }
         }
       : null;
 
     req = https.request(
       url,
       createRequestOptions(init, proxyUrl, headers),
-      (res) => {
+      (upstreamResponse) => {
+        res = upstreamResponse;
         const headers = new Headers();
-        for (const [key, value] of Object.entries(res.headers)) {
+        for (const [key, value] of Object.entries(upstreamResponse.headers)) {
           if (Array.isArray(value)) {
             for (const item of value) headers.append(key, item);
           } else if (value !== undefined) {
@@ -120,19 +132,28 @@ const fetchThroughProxy = async (
           }
         }
 
-        const status = res.statusCode ?? 500;
+        const status = upstreamResponse.statusCode ?? 500;
+        if (responseCannotHaveBody(status)) {
+          cleanupAbortHandler();
+        } else {
+          upstreamResponse.once('close', cleanupAbortHandler);
+          upstreamResponse.once('end', cleanupAbortHandler);
+          upstreamResponse.once('error', cleanupAbortHandler);
+        }
+
         settle(
           resolve,
           new Response(
             responseCannotHaveBody(status)
               ? null
-              : (Readable.toWeb(res) as ReadableStream),
+              : (Readable.toWeb(upstreamResponse) as ReadableStream),
             {
               status,
-              statusText: res.statusMessage ?? '',
+              statusText: upstreamResponse.statusMessage ?? '',
               headers,
             },
           ),
+          { cleanupAbort: responseCannotHaveBody(status) },
         );
       },
     );

--- a/src/lib/server/utils/integration-fetch.ts
+++ b/src/lib/server/utils/integration-fetch.ts
@@ -23,42 +23,51 @@ const isSocksProxy = (proxyUrl: string) => {
 const responseCannotHaveBody = (status: number) =>
   status === 204 || status === 205 || status === 304;
 
-const writeBody = (req: ReturnType<typeof https.request>, body: BodyInit) => {
-  if (
-    typeof body === 'string' ||
-    body instanceof Uint8Array ||
-    Buffer.isBuffer(body)
-  ) {
-    req.write(body);
-    return;
+const createAbortError = () =>
+  new DOMException('This operation was aborted', 'AbortError');
+
+const hasHeader = (headers: OutgoingHttpHeaders, name: string) =>
+  Object.keys(headers).some((key) => key.toLowerCase() === name);
+
+const prepareBody = async (
+  init: RequestInit,
+  headers: OutgoingHttpHeaders,
+) => {
+  if (init.body == null) {
+    return null;
   }
 
-  if (body instanceof ArrayBuffer) {
-    req.write(Buffer.from(body));
-    return;
+  const bodyResponse = new Response(init.body);
+  const contentType = bodyResponse.headers.get('content-type');
+  const body = Buffer.from(await bodyResponse.arrayBuffer());
+
+  if (contentType && !hasHeader(headers, 'content-type')) {
+    headers['content-type'] = contentType;
+  }
+  if (!hasHeader(headers, 'content-length')) {
+    headers['content-length'] = body.byteLength;
   }
 
-  if (body instanceof URLSearchParams) {
-    req.write(body.toString());
-    return;
-  }
-
-  throw new Error('Unsupported integration proxy request body type');
+  return body;
 };
 
-const createRequestOptions = (init: RequestInit, proxyUrl: string) => {
+const createRequestOptions = (
+  init: RequestInit,
+  proxyUrl: string,
+  headers: OutgoingHttpHeaders,
+) => {
   const agent = isSocksProxy(proxyUrl)
     ? new SocksProxyAgent(proxyUrl)
     : new HttpsProxyAgent(proxyUrl);
 
   return {
     method: init.method ?? 'GET',
-    headers: normalizeHeaders(init.headers),
+    headers,
     agent,
   };
 };
 
-const fetchThroughProxy = (
+const fetchThroughProxy = async (
   url: URL,
   init: RequestInit,
   proxyUrl: string,
@@ -66,11 +75,41 @@ const fetchThroughProxy = (
   if (url.protocol !== 'https:') {
     throw new Error('Integration proxy only supports HTTPS upstream URLs');
   }
+  if (init.signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const headers = normalizeHeaders(init.headers);
+  const body = await prepareBody(init, headers);
+  if (init.signal?.aborted) {
+    throw createAbortError();
+  }
 
   return new Promise((resolve, reject) => {
-    const req = https.request(
+    let settled = false;
+    let req: ReturnType<typeof https.request> | null = null;
+    let abortHandler: (() => void) | null = null;
+
+    const settle = <T>(callback: (value: T) => void, value: T) => {
+      if (settled) return;
+      settled = true;
+      if (init.signal && abortHandler) {
+        init.signal.removeEventListener('abort', abortHandler);
+      }
+      callback(value);
+    };
+
+    abortHandler = init.signal
+      ? () => {
+          const err = createAbortError();
+          req?.destroy(err);
+          settle(reject, err);
+        }
+      : null;
+
+    req = https.request(
       url,
-      createRequestOptions(init, proxyUrl),
+      createRequestOptions(init, proxyUrl, headers),
       (res) => {
         const headers = new Headers();
         for (const [key, value] of Object.entries(res.headers)) {
@@ -82,7 +121,8 @@ const fetchThroughProxy = (
         }
 
         const status = res.statusCode ?? 500;
-        resolve(
+        settle(
+          resolve,
           new Response(
             responseCannotHaveBody(status)
               ? null
@@ -97,18 +137,14 @@ const fetchThroughProxy = (
       },
     );
 
-    req.on('error', reject);
+    req.on('error', (err) => settle(reject, err));
 
-    if (init.signal) {
-      init.signal.addEventListener(
-        'abort',
-        () => req.destroy(new Error('Request aborted')),
-        { once: true },
-      );
+    if (init.signal && abortHandler) {
+      init.signal.addEventListener('abort', abortHandler, { once: true });
     }
 
-    if (init.body) {
-      writeBody(req, init.body);
+    if (body) {
+      req.write(body);
     }
 
     req.end();

--- a/src/lib/server/utils/integration-fetch.ts
+++ b/src/lib/server/utils/integration-fetch.ts
@@ -1,0 +1,129 @@
+import { env } from '$env/dynamic/private';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import type { OutgoingHttpHeaders } from 'node:http';
+import https from 'node:https';
+import { Readable } from 'node:stream';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+
+const getProxyUrl = () => env.INTEGRATIONS_PROXY_URL?.trim() || null;
+
+const normalizeHeaders = (headersInit: RequestInit['headers']) => {
+  const headers: OutgoingHttpHeaders = {};
+  new Headers(headersInit).forEach((value, key) => {
+    headers[key] = value;
+  });
+  return headers;
+};
+
+const isSocksProxy = (proxyUrl: string) => {
+  const protocol = new URL(proxyUrl).protocol;
+  return protocol === 'socks5:' || protocol === 'socks5h:';
+};
+
+const responseCannotHaveBody = (status: number) =>
+  status === 204 || status === 205 || status === 304;
+
+const writeBody = (req: ReturnType<typeof https.request>, body: BodyInit) => {
+  if (
+    typeof body === 'string' ||
+    body instanceof Uint8Array ||
+    Buffer.isBuffer(body)
+  ) {
+    req.write(body);
+    return;
+  }
+
+  if (body instanceof ArrayBuffer) {
+    req.write(Buffer.from(body));
+    return;
+  }
+
+  if (body instanceof URLSearchParams) {
+    req.write(body.toString());
+    return;
+  }
+
+  throw new Error('Unsupported integration proxy request body type');
+};
+
+const createRequestOptions = (init: RequestInit, proxyUrl: string) => {
+  const agent = isSocksProxy(proxyUrl)
+    ? new SocksProxyAgent(proxyUrl)
+    : new HttpsProxyAgent(proxyUrl);
+
+  return {
+    method: init.method ?? 'GET',
+    headers: normalizeHeaders(init.headers),
+    agent,
+  };
+};
+
+const fetchThroughProxy = (
+  url: URL,
+  init: RequestInit,
+  proxyUrl: string,
+): Promise<Response> => {
+  if (url.protocol !== 'https:') {
+    throw new Error('Integration proxy only supports HTTPS upstream URLs');
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      createRequestOptions(init, proxyUrl),
+      (res) => {
+        const headers = new Headers();
+        for (const [key, value] of Object.entries(res.headers)) {
+          if (Array.isArray(value)) {
+            for (const item of value) headers.append(key, item);
+          } else if (value !== undefined) {
+            headers.set(key, String(value));
+          }
+        }
+
+        const status = res.statusCode ?? 500;
+        resolve(
+          new Response(
+            responseCannotHaveBody(status)
+              ? null
+              : (Readable.toWeb(res) as ReadableStream),
+            {
+              status,
+              statusText: res.statusMessage ?? '',
+              headers,
+            },
+          ),
+        );
+      },
+    );
+
+    req.on('error', reject);
+
+    if (init.signal) {
+      init.signal.addEventListener(
+        'abort',
+        () => req.destroy(new Error('Request aborted')),
+        { once: true },
+      );
+    }
+
+    if (init.body) {
+      writeBody(req, init.body);
+    }
+
+    req.end();
+  });
+};
+
+export const fetchIntegration = async (
+  input: string | URL,
+  init: RequestInit = {},
+  fetchImpl: typeof fetch = fetch,
+) => {
+  const proxyUrl = getProxyUrl();
+  if (!proxyUrl) {
+    return fetchImpl(input, init);
+  }
+
+  return fetchThroughProxy(new URL(input), init, proxyUrl);
+};

--- a/src/routes/api/map-styles/openaip/tiles/[z]/[x]/[y]/+server.ts
+++ b/src/routes/api/map-styles/openaip/tiles/[z]/[x]/[y]/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from './$types';
 
 import { appConfig } from '$lib/server/utils/config';
+import { fetchIntegration } from '$lib/server/utils/integration-fetch';
 
 const OPENAIP_TILE_BASE_URL = 'https://api.tiles.openaip.net/api/data/openaip';
 const PRIVATE_CACHE_CONTROL =
@@ -30,7 +31,7 @@ export const GET: RequestHandler = async ({ locals, params, fetch }) => {
     });
   }
 
-  const upstream = await fetch(
+  const upstream = await fetchIntegration(
     `${OPENAIP_TILE_BASE_URL}/${params.z}/${params.x}/${params.y}.pbf`,
     {
       headers: {
@@ -38,6 +39,7 @@ export const GET: RequestHandler = async ({ locals, params, fetch }) => {
         accept: 'application/vnd.mapbox-vector-tile,application/x-protobuf',
       },
     },
+    fetch,
   );
 
   if (upstream.status === 204) {


### PR DESCRIPTION
Support HTTP and SOCKS proxy for AeroDataBox and OpenAIP API requests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional HTTP(S)/SOCKS5 proxy support for AeroDataBox (RapidAPI) and OpenAIP server requests via `INTEGRATIONS_PROXY_URL`. Integration traffic uses the proxy when set; behavior is unchanged when unset.

- **New Features**
  - Implemented `fetchIntegration` to route HTTPS requests through per-request proxy agents (`https-proxy-agent` or `socks-proxy-agent`), stream responses, and honor abort signals; falls back to native `fetch` when no proxy is set.
  - Switched AeroDataBox flight lookup and OpenAIP tile endpoints to use `fetchIntegration` (upstream must be HTTPS). OpenAIP handler passes `fetch` for correct fallback behavior.
  - Documented `INTEGRATIONS_PROXY_URL` in `.env.example` with HTTP(S) and SOCKS5 usage examples.

- **Migration**
  - Optional: set `INTEGRATIONS_PROXY_URL` (e.g., `http://host:8888` or `socks5://user:pass@host:1080`) to enable proxying.

<sup>Written for commit 185e9487b7cb5e23b67897f2aa3202b2ea01202f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

