### PR TITLE
docs: document outbound proxy configuration

### DIFF
--- a/docs/content/docs/administration/meta.json
+++ b/docs/content/docs/administration/meta.json
@@ -1,3 +1,3 @@
 {
-  "items": ["admin-cli"]
+  "items": ["admin-cli", "outbound-proxy"]
 }

--- a/docs/content/docs/administration/outbound-proxy.mdx
+++ b/docs/content/docs/administration/outbound-proxy.mdx
@@ -1,0 +1,53 @@
+---
+title: Outbound Proxy
+---
+
+AirTrail normally connects directly to third-party APIs from the server. If your deployment environment requires outbound HTTP(S) traffic to go through a proxy, configure Node.js standard proxy environment variables for the AirTrail process.
+
+## Requirements
+
+Node.js 22.21.0 or newer is required for `NODE_USE_ENV_PROXY`.
+
+AirTrail Docker images use a compatible Node.js 22 runtime. If you build the image yourself, rebuild with a current `node:22-slim` base image.
+
+<Callout>
+  Node.js currently labels this proxy support as active development and may log
+  an `UNDICI-EHPA` experimental warning when it is enabled.
+</Callout>
+
+## Docker Compose
+
+Add the proxy variables to the `airtrail` service environment or to the `.env` file used by Docker Compose:
+
+```bash
+NODE_USE_ENV_PROXY=1
+HTTPS_PROXY=http://proxy.example.com:8080
+HTTP_PROXY=http://proxy.example.com:8080
+NO_PROXY=localhost,127.0.0.1,db,airtrail_db
+```
+
+## Manual Installation
+
+Set the variables before starting AirTrail:
+
+```bash
+NODE_USE_ENV_PROXY=1 \
+HTTPS_PROXY=http://proxy.example.com:8080 \
+HTTP_PROXY=http://proxy.example.com:8080 \
+NO_PROXY=localhost,127.0.0.1 \
+bun ./build
+```
+
+## TLS Inspection
+
+If your proxy intercepts TLS traffic, Node.js may also need to trust your organization's certificate authority:
+
+```bash
+NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
+```
+
+## Notes
+
+- This uses Node.js built-in proxy support.
+- SOCKS proxies are not supported by this setup.
+- These variables affect outbound server-side HTTP(S) requests made by the AirTrail process.

--- a/docs/content/docs/administration/outbound-proxy.mdx
+++ b/docs/content/docs/administration/outbound-proxy.mdx
@@ -35,7 +35,7 @@ NODE_USE_ENV_PROXY=1 \
 HTTPS_PROXY=http://proxy.example.com:8080 \
 HTTP_PROXY=http://proxy.example.com:8080 \
 NO_PROXY=localhost,127.0.0.1 \
-bun ./build
+node ./build
 ```
 
 ## TLS Inspection

--- a/docs/content/docs/install/manual.mdx
+++ b/docs/content/docs/install/manual.mdx
@@ -48,7 +48,7 @@ bun run db:migrate-deploy
 5. Start the server:
 
 ```bash
-bun ./build
+node ./build
 ```
 
 The app should now be running on [localhost:3000](http://localhost:3000).


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Document outbound proxy configuration for AirTrail
- Adds a new [outbound-proxy.mdx](https://github.com/johanohly/AirTrail/pull/579/files#diff-9219f3e5579cc4d26848d3aa03578c669133843596437f38c9a50c16dd9225c8) page covering how to configure outbound HTTP(S) proxy support using Node.js environment variables, with examples for Docker Compose and manual installs.
- Covers TLS inspection CA configuration and notes on scope and limitations.
- Registers the new page in [meta.json](https://github.com/johanohly/AirTrail/pull/579/files#diff-ef3f4e98838e9282878079e34e8c42ba60c045c4e3b2c5ea2e793de4839f285f) so it appears in the administration nav.
- Fixes the server start command in [manual.mdx](https://github.com/johanohly/AirTrail/pull/579/files#diff-6eb461803a0b59887e7d1f7e089de7e33271365b3e48df57129ebc8f7671bf68) from `bun ./build` to `node ./build`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb889ba.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->