### PR TITLE
fix: add fallback for Carto map style fetch failures

### DIFF
--- a/src/lib/map/carto.ts
+++ b/src/lib/map/carto.ts
@@ -4,6 +4,12 @@ export const CARTO_POSITRON_STYLE_URL =
   'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
 export const CARTO_DARK_MATTER_STYLE_URL =
   'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+const CARTO_LIGHT_RASTER_TILE_URL =
+  'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+const CARTO_DARK_RASTER_TILE_URL =
+  'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png';
+const CARTO_GLYPHS_URL =
+  'https://tiles.basemaps.cartocdn.com/fonts/{fontstack}/{range}.pbf';
 
 export const normalizeCartoTheme = (theme: string): CartoTheme =>
   theme === 'dark' ? 'dark' : 'light';
@@ -12,3 +18,34 @@ export const getCartoBasemapStyleUrl = (theme: string) =>
   normalizeCartoTheme(theme) === 'dark'
     ? CARTO_DARK_MATTER_STYLE_URL
     : CARTO_POSITRON_STYLE_URL;
+
+export const getCartoFallbackBasemapStyle = (theme: string) => {
+  const normalizedTheme = normalizeCartoTheme(theme);
+  const isDark = normalizedTheme === 'dark';
+
+  return {
+    version: 8,
+    name: isDark ? 'Carto Dark Matter Fallback' : 'Carto Positron Fallback',
+    glyphs: CARTO_GLYPHS_URL,
+    sources: {
+      'carto-raster': {
+        type: 'raster',
+        tiles: [
+          isDark ? CARTO_DARK_RASTER_TILE_URL : CARTO_LIGHT_RASTER_TILE_URL,
+        ],
+        tileSize: 256,
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      },
+    },
+    layers: [
+      {
+        id: 'carto-raster',
+        type: 'raster',
+        source: 'carto-raster',
+        minzoom: 0,
+        maxzoom: 22,
+      },
+    ],
+  };
+};

--- a/src/routes/api/map-styles/airport/style.json/+server.ts
+++ b/src/routes/api/map-styles/airport/style.json/+server.ts
@@ -4,7 +4,11 @@ import {
   getArcgisWorldImageryStyle,
   normalizeMapBasemap,
 } from '$lib/map/basemap';
-import { getCartoBasemapStyleUrl, normalizeCartoTheme } from '$lib/map/carto';
+import {
+  getCartoBasemapStyleUrl,
+  getCartoFallbackBasemapStyle,
+  normalizeCartoTheme,
+} from '$lib/map/carto';
 import { buildPmtilesAirportStyle } from '$lib/map/airport-style';
 
 const BASE_STYLE_TTL_MS = 60 * 60 * 1000;
@@ -70,7 +74,14 @@ export const GET: RequestHandler = async ({ fetch, url }) => {
     }
 
     const baseStyleUrl = getCartoBasemapStyleUrl(theme);
-    const baseStyle = await fetchBaseStyle(fetch, baseStyleUrl);
+    let baseStyle: Record<string, unknown>;
+
+    try {
+      baseStyle = await fetchBaseStyle(fetch, baseStyleUrl);
+    } catch {
+      baseStyle = getCartoFallbackBasemapStyle(theme);
+    }
+
     const style = buildPmtilesAirportStyle(baseStyle, theme);
 
     return Response.json(style, {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add raster basemap fallback for Carto map style fetch failures
- Adds `getCartoFallbackBasemapStyle(theme)` in [carto.ts](https://github.com/johanohly/AirTrail/pull/587/files#diff-2dde2a2360602eaffaad9769662cb45272235ea4c36e7b561bbc77076ade4bef) that returns a Mapbox GL v8 style using CARTO raster tile endpoints for light/dark themes, without requiring a remote fetch.
- Updates the airport map style handler in [+server.ts](https://github.com/johanohly/AirTrail/pull/587/files#diff-cddeb71a161edb170986fea4d0f7c997e6ab0af11ef5c336a4cef52929c7c0f9) to catch fetch errors and call `getCartoFallbackBasemapStyle` instead of propagating the failure.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cb5ba2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->