### PR TITLE
feat: time of day layer

### DIFF
--- a/scripts/data/generate-airport-overlay.js
+++ b/scripts/data/generate-airport-overlay.js
@@ -231,7 +231,7 @@ const bufferLineString = (coordinates, halfWidthM) => {
     const right = coordinates.map((_, i) =>
       offsetVertex(coordinates, i, 1, halfWidthM),
     );
-    return [...left, ...right.slice().reverse(), left[0]];
+    return [...left, ...right.toReversed(), left[0]];
   } catch {
     return null;
   }

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -17,6 +17,7 @@
   import MapFallback from './MapFallback.svelte';
   import MapStatusShelf from './MapStatusShelf.svelte';
   import OpenAipOverlay from './OpenAipOverlay.svelte';
+  import TimeOfDayLayer from './TimeOfDayLayer.svelte';
 
   import { AirportsArcsLayer } from '.';
 
@@ -646,6 +647,10 @@
         if (filters) filters.routes = [];
       }}
     />
+
+    {#if mapPreferences.timeOfDayEnabled}
+      <TimeOfDayLayer />
+    {/if}
 
     {#if openAipActive}
       <OpenAipOverlay

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -753,6 +753,27 @@
           </div>
         </section>
 
+        <section class="space-y-3 px-4 py-4">
+          <h3
+            class="text-muted-foreground text-[10px] font-medium uppercase tracking-wider"
+          >
+            Layers
+          </h3>
+          <div class="flex items-center justify-between gap-3">
+            <div class="min-w-0">
+              <p class="text-sm font-medium leading-none">Time of day</p>
+              <p class="text-muted-foreground mt-1 text-[11px]">
+                Live day/night shading
+              </p>
+            </div>
+            <Switch
+              size="small"
+              checked={mapPreferences.timeOfDayEnabled}
+              onCheckedChange={(v) => (mapPreferences.timeOfDayEnabled = v)}
+            />
+          </div>
+        </section>
+
         {#if openAipConfigured}
           <section class="space-y-3 px-4 py-4">
             <div class="flex items-center justify-between">

--- a/src/lib/components/map/TimeOfDayLayer.svelte
+++ b/src/lib/components/map/TimeOfDayLayer.svelte
@@ -23,6 +23,18 @@
   );
   const data = $derived(createTimeOfDayGeoJson(currentTime, projection));
   const isDarkMode = $derived(mode.current === 'dark');
+  const isSatellite = $derived(mapPreferences.basemap === 'satellite');
+  const fillOpacityScale = $derived.by(() => {
+    if (isSatellite) return 4.35;
+    if (isDarkMode) return 12;
+    return 1;
+  });
+  const getSeverityScale = (item: (typeof TIME_OF_DAY_SEVERITIES)[number]) =>
+    !isSatellite && isDarkMode && item.severity === 'civil' ? 0.86 : 1;
+  const getBaseOpacity = (item: (typeof TIME_OF_DAY_SEVERITIES)[number]) =>
+    isSatellite || !isDarkMode ? item.lightOpacity : item.darkOpacity;
+  const getFillOpacity = (item: (typeof TIME_OF_DAY_SEVERITIES)[number]) =>
+    getBaseOpacity(item) * fillOpacityScale * getSeverityScale(item);
 
   onMount(() => {
     const interval = window.setInterval(() => {
@@ -44,7 +56,7 @@
       filter={['==', ['get', 'severity'], item.severity]}
       paint={{
         'fill-color': NIGHT_FILL,
-        'fill-opacity': isDarkMode ? item.darkOpacity : item.lightOpacity,
+        'fill-opacity': getFillOpacity(item),
         'fill-antialias': true,
       }}
     />

--- a/src/lib/components/map/TimeOfDayLayer.svelte
+++ b/src/lib/components/map/TimeOfDayLayer.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { mode } from 'mode-watcher';
+  import { onMount } from 'svelte';
+  import { FillLayer, GeoJSON } from 'svelte-maplibre';
+
+  import { mapPreferences } from '$lib/map/map-preferences.svelte';
+  import {
+    createTimeOfDayGeoJson,
+    TIME_OF_DAY_LAYER_ID_PREFIX,
+    TIME_OF_DAY_SEVERITIES,
+    TIME_OF_DAY_SOURCE_ID,
+    type TimeOfDayProjection,
+  } from '$lib/map/time-of-day';
+
+  const REFRESH_INTERVAL_MS = 60_000;
+  const NIGHT_FILL = 'rgb(5, 8, 18)';
+
+  let currentTime = $state(new Date());
+  const projection = $derived(
+    mapPreferences.projection === 'globe'
+      ? ('globe' satisfies TimeOfDayProjection)
+      : ('mercator' satisfies TimeOfDayProjection),
+  );
+  const data = $derived(createTimeOfDayGeoJson(currentTime, projection));
+  const isDarkMode = $derived(mode.current === 'dark');
+
+  onMount(() => {
+    const interval = window.setInterval(() => {
+      currentTime = new Date();
+    }, REFRESH_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  });
+</script>
+
+<GeoJSON id={TIME_OF_DAY_SOURCE_ID} {data} tolerance={0}>
+  {#each TIME_OF_DAY_SEVERITIES as item (item.severity)}
+    <FillLayer
+      id={`${TIME_OF_DAY_LAYER_ID_PREFIX}-${item.severity}`}
+      beforeLayerType="symbol"
+      interactive={false}
+      filter={['==', ['get', 'severity'], item.severity]}
+      paint={{
+        'fill-color': NIGHT_FILL,
+        'fill-opacity': isDarkMode ? item.darkOpacity : item.lightOpacity,
+        'fill-antialias': true,
+      }}
+    />
+  {/each}
+</GeoJSON>

--- a/src/lib/components/modals/settings/SettingsModal.svelte
+++ b/src/lib/components/modals/settings/SettingsModal.svelte
@@ -87,11 +87,6 @@
       checkForNewVersions();
     }
   });
-  //
-  // Switching between airport local time and e.g. UTC display/input causes some weirdness until refresh
-  // Close date picker after picking https://github.com/johanohly/AirTrail/discussions/255
-  // https://www.rainviewer.com/api.html
-  //
 </script>
 
 <Modal bind:open class="max-w-2xl" drawerNoPadding>

--- a/src/lib/components/modals/settings/SettingsModal.svelte
+++ b/src/lib/components/modals/settings/SettingsModal.svelte
@@ -87,6 +87,11 @@
       checkForNewVersions();
     }
   });
+  //
+  // Switching between airport local time and e.g. UTC display/input causes some weirdness until refresh
+  // Close date picker after picking https://github.com/johanohly/AirTrail/discussions/255
+  // https://www.rainviewer.com/api.html
+  //
 </script>
 
 <Modal bind:open class="max-w-2xl" drawerNoPadding>

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -17,6 +17,7 @@ export type MapProjection = 'mercator' | 'globe';
 export type MapPreferences = {
   basemap: MapBasemap;
   projection: MapProjection;
+  timeOfDayEnabled: boolean;
   airportCircles: AirportCirclesMode;
   arcColor: ArcColorMode;
   arcThickness: ArcThicknessMode;
@@ -54,6 +55,7 @@ const MAP_PROJECTIONS: readonly MapProjection[] = ['mercator', 'globe'];
 export const MAP_PREFERENCE_DEFAULTS: MapPreferences = {
   basemap: 'default',
   projection: 'mercator',
+  timeOfDayEnabled: false,
   airportCircles: 'large',
   arcColor: 'default',
   arcThickness: 'uniform',
@@ -88,6 +90,9 @@ const sanitize = (raw: unknown): MapPreferences => {
     MAP_PROJECTIONS.includes(input.projection as MapProjection)
   ) {
     result.projection = input.projection as MapProjection;
+  }
+  if (typeof input.timeOfDayEnabled === 'boolean') {
+    result.timeOfDayEnabled = input.timeOfDayEnabled;
   }
   if (
     typeof input.airportCircles === 'string' &&
@@ -166,6 +171,7 @@ export const initMapPreferences = () => {
   const hydrated = sanitize(parsed);
   mapPreferences.basemap = hydrated.basemap;
   mapPreferences.projection = hydrated.projection;
+  mapPreferences.timeOfDayEnabled = hydrated.timeOfDayEnabled;
   mapPreferences.airportCircles = hydrated.airportCircles;
   mapPreferences.arcColor = hydrated.arcColor;
   mapPreferences.arcThickness = hydrated.arcThickness;
@@ -179,6 +185,7 @@ export const initMapPreferences = () => {
       const snapshot: MapPreferences = {
         basemap: mapPreferences.basemap,
         projection: mapPreferences.projection,
+        timeOfDayEnabled: mapPreferences.timeOfDayEnabled,
         airportCircles: mapPreferences.airportCircles,
         arcColor: mapPreferences.arcColor,
         arcThickness: mapPreferences.arcThickness,
@@ -199,6 +206,7 @@ export const initMapPreferences = () => {
 export const resetMapPreferences = () => {
   mapPreferences.basemap = MAP_PREFERENCE_DEFAULTS.basemap;
   mapPreferences.projection = MAP_PREFERENCE_DEFAULTS.projection;
+  mapPreferences.timeOfDayEnabled = MAP_PREFERENCE_DEFAULTS.timeOfDayEnabled;
   mapPreferences.airportCircles = MAP_PREFERENCE_DEFAULTS.airportCircles;
   mapPreferences.arcColor = MAP_PREFERENCE_DEFAULTS.arcColor;
   mapPreferences.arcThickness = MAP_PREFERENCE_DEFAULTS.arcThickness;

--- a/src/lib/map/time-of-day.ts
+++ b/src/lib/map/time-of-day.ts
@@ -1,0 +1,324 @@
+import { geoCircle } from 'd3-geo';
+import type {
+  Feature,
+  FeatureCollection,
+  MultiPolygon,
+  Polygon,
+} from 'geojson';
+
+export const TIME_OF_DAY_SOURCE_ID = 'airtrail-time-of-day-source';
+export const TIME_OF_DAY_LAYER_ID_PREFIX = 'airtrail-time-of-day';
+export const TIME_OF_DAY_LAYER_ID = `${TIME_OF_DAY_LAYER_ID_PREFIX}-night`;
+
+export type TimeOfDayProjection = 'mercator' | 'globe';
+export type TimeOfDaySeverity = 'civil' | 'nautical' | 'astronomical' | 'night';
+
+export type TimeOfDayFeature = Feature<
+  Polygon | MultiPolygon,
+  {
+    severity: TimeOfDaySeverity;
+  }
+>;
+
+export type TimeOfDayFeatureCollection = FeatureCollection<
+  Polygon | MultiPolygon,
+  TimeOfDayFeature['properties']
+>;
+
+export const TIME_OF_DAY_SEVERITIES: Array<{
+  severity: TimeOfDaySeverity;
+  altitudeMax: number;
+  lightOpacity: number;
+  darkOpacity: number;
+}> = [
+  { severity: 'civil', altitudeMax: 0, lightOpacity: 0.1, darkOpacity: 0.035 },
+  {
+    severity: 'nautical',
+    altitudeMax: -6,
+    lightOpacity: 0.085,
+    darkOpacity: 0.025,
+  },
+  {
+    severity: 'astronomical',
+    altitudeMax: -12,
+    lightOpacity: 0.075,
+    darkOpacity: 0.02,
+  },
+  {
+    severity: 'night',
+    altitudeMax: -18,
+    lightOpacity: 0.07,
+    darkOpacity: 0.02,
+  },
+];
+
+const DAY_IN_MS = 86_400_000;
+const J2000 = 2_451_545;
+const JD1970 = 2_440_588;
+const CIRCLE_PRECISION_DEGREES = 0.5;
+const POLE_EDGE_LATITUDE = 89.999;
+
+const degreesToRadians = (degrees: number) => (degrees * Math.PI) / 180;
+const radiansToDegrees = (radians: number) => (radians * 180) / Math.PI;
+
+const normalizeDegrees = (degrees: number) => {
+  const normalized = ((degrees + 180) % 360) - 180;
+  return normalized < -180 ? normalized + 360 : normalized;
+};
+
+const getSolarPosition = (date: Date) => {
+  const julianDay = date.getTime() / DAY_IN_MS - 0.5 + JD1970;
+  const days = julianDay - J2000;
+  const meanLongitude = normalizeDegrees(280.459 + 0.98564736 * days);
+  const meanAnomaly = degreesToRadians(
+    normalizeDegrees(357.529 + 0.98560028 * days),
+  );
+  const eclipticLongitude = degreesToRadians(
+    normalizeDegrees(
+      meanLongitude +
+        1.915 * Math.sin(meanAnomaly) +
+        0.02 * Math.sin(2 * meanAnomaly),
+    ),
+  );
+  const obliquity = degreesToRadians(23.439 - 0.00000036 * days);
+  const rightAscension = Math.atan2(
+    Math.cos(obliquity) * Math.sin(eclipticLongitude),
+    Math.cos(eclipticLongitude),
+  );
+  const declination = Math.asin(
+    Math.sin(obliquity) * Math.sin(eclipticLongitude),
+  );
+  const greenwichSiderealTime =
+    ((18.697374558 + 24.06570982441908 * days) % 24) * 15;
+  const subsolarLongitude = normalizeDegrees(
+    radiansToDegrees(rightAscension) - greenwichSiderealTime,
+  );
+
+  return {
+    subsolarLatitude: radiansToDegrees(declination),
+    subsolarLongitude,
+  };
+};
+
+const createFeature = (
+  severity: TimeOfDaySeverity,
+  geometry: Polygon | MultiPolygon,
+): TimeOfDayFeature => ({
+  type: 'Feature',
+  properties: { severity },
+  geometry,
+});
+
+const closeRing = (
+  ring: Polygon['coordinates'][number],
+): Polygon['coordinates'][number] => {
+  const first = ring[0];
+
+  if (!first) {
+    return ring;
+  }
+
+  const last = ring.at(-1);
+
+  if (last?.[0] === first[0] && last[1] === first[1]) {
+    return ring;
+  }
+
+  return [...ring, first];
+};
+
+const findDatelineJumpIndex = (ring: Polygon['coordinates'][number]) =>
+  ring.findIndex((coordinate, index) => {
+    const next = ring[(index + 1) % ring.length];
+
+    if (!next) {
+      return false;
+    }
+
+    return Math.abs(next[0] - coordinate[0]) > 180;
+  });
+
+const findDatelineJumpIndexes = (ring: Polygon['coordinates'][number]) => {
+  const jumpIndexes: number[] = [];
+
+  ring.forEach((coordinate, index) => {
+    const next = ring[index + 1];
+
+    if (!next) {
+      return;
+    }
+
+    if (Math.abs(next[0] - coordinate[0]) > 180) {
+      jumpIndexes.push(index);
+    }
+  });
+
+  return jumpIndexes;
+};
+
+const interpolateDatelineCrossing = (
+  start: [number, number],
+  end: [number, number],
+) => {
+  const endLongitude = start[0] > 0 && end[0] < 0 ? end[0] + 360 : end[0] - 360;
+  const crossingLongitude = start[0] > 0 ? 180 : -180;
+  const progress = (crossingLongitude - start[0]) / (endLongitude - start[0]);
+  const latitude = start[1] + (end[1] - start[1]) * progress;
+
+  return {
+    east: [180, latitude] satisfies [number, number],
+    west: [-180, latitude] satisfies [number, number],
+  };
+};
+
+const createPolarCapPolygon = (
+  ring: Polygon['coordinates'][number],
+  pole: 'north' | 'south',
+): Polygon => {
+  const jumpIndex = findDatelineJumpIndex(ring);
+
+  if (jumpIndex === -1) {
+    return { type: 'Polygon', coordinates: [ring] };
+  }
+
+  const start = ring[jumpIndex] as [number, number];
+  const end = ring[(jumpIndex + 1) % ring.length] as [number, number];
+  const crossing = interpolateDatelineCrossing(start, end);
+  const ringWithoutClosingPoint = ring.slice(0, -1) as Array<[number, number]>;
+  const boundary = [
+    ...ringWithoutClosingPoint.slice(jumpIndex + 1),
+    ...ringWithoutClosingPoint.slice(0, jumpIndex + 1),
+  ];
+  const boundaryWestToEast =
+    start[0] > 0
+      ? [crossing.west, ...boundary, crossing.east]
+      : [crossing.west, ...boundary.reverse(), crossing.east];
+  const poleLatitude =
+    pole === 'north' ? POLE_EDGE_LATITUDE : -POLE_EDGE_LATITUDE;
+  const poleEdge = [180, 120, 60, 0, -60, -120, -180].map(
+    (longitude) => [longitude, poleLatitude] satisfies [number, number],
+  );
+  const closedRing = [
+    ...boundaryWestToEast,
+    ...poleEdge,
+    boundaryWestToEast[0],
+  ];
+
+  return {
+    type: 'Polygon',
+    coordinates: [closeRing(closedRing)],
+  };
+};
+
+const createAntimeridianSplitPolygon = (
+  ring: Polygon['coordinates'][number],
+): MultiPolygon | null => {
+  const jumpIndexes = findDatelineJumpIndexes(ring);
+
+  if (jumpIndexes.length !== 2) {
+    return null;
+  }
+
+  const ringWithoutClosingPoint = ring.slice(0, -1) as Array<[number, number]>;
+  const [firstJumpIndex, secondJumpIndex] = jumpIndexes;
+  const firstCrossing = interpolateDatelineCrossing(
+    ringWithoutClosingPoint[firstJumpIndex],
+    ringWithoutClosingPoint[firstJumpIndex + 1],
+  );
+  const secondCrossing = interpolateDatelineCrossing(
+    ringWithoutClosingPoint[secondJumpIndex],
+    ringWithoutClosingPoint[
+      (secondJumpIndex + 1) % ringWithoutClosingPoint.length
+    ],
+  );
+  const firstJumpIsEastToWest =
+    ringWithoutClosingPoint[firstJumpIndex][0] > 0 &&
+    ringWithoutClosingPoint[firstJumpIndex + 1][0] < 0;
+  const eastRing = firstJumpIsEastToWest
+    ? closeRing([
+        secondCrossing.east,
+        ...ringWithoutClosingPoint.slice(secondJumpIndex + 1),
+        ...ringWithoutClosingPoint.slice(0, firstJumpIndex + 1),
+        firstCrossing.east,
+      ])
+    : closeRing([
+        firstCrossing.east,
+        ...ringWithoutClosingPoint.slice(
+          firstJumpIndex + 1,
+          secondJumpIndex + 1,
+        ),
+        secondCrossing.east,
+      ]);
+  const westRing = firstJumpIsEastToWest
+    ? closeRing([
+        firstCrossing.west,
+        ...ringWithoutClosingPoint.slice(
+          firstJumpIndex + 1,
+          secondJumpIndex + 1,
+        ),
+        secondCrossing.west,
+      ])
+    : closeRing([
+        secondCrossing.west,
+        ...ringWithoutClosingPoint.slice(secondJumpIndex + 1),
+        ...ringWithoutClosingPoint.slice(0, firstJumpIndex + 1),
+        firstCrossing.west,
+      ]);
+
+  return {
+    type: 'MultiPolygon',
+    coordinates: [[eastRing], [westRing]],
+  };
+};
+
+const createCirclePolygon = (
+  center: [number, number],
+  radius: number,
+): Polygon | MultiPolygon => {
+  const geometry = geoCircle()
+    .center(center)
+    .radius(radius)
+    .precision(CIRCLE_PRECISION_DEGREES)() as Polygon;
+  const distanceToNorthPole = 90 - center[1];
+  const distanceToSouthPole = 90 + center[1];
+
+  if (distanceToNorthPole <= radius) {
+    return createPolarCapPolygon(geometry.coordinates[0], 'north');
+  }
+
+  if (distanceToSouthPole <= radius) {
+    return createPolarCapPolygon(geometry.coordinates[0], 'south');
+  }
+
+  const splitGeometry = createAntimeridianSplitPolygon(geometry.coordinates[0]);
+
+  if (splitGeometry) {
+    return splitGeometry;
+  }
+
+  return {
+    ...geometry,
+    coordinates: geometry.coordinates.map(closeRing),
+  };
+};
+
+export const createTimeOfDayGeoJson = (
+  date = new Date(),
+  _projection: TimeOfDayProjection = 'mercator',
+): TimeOfDayFeatureCollection => {
+  const { subsolarLatitude, subsolarLongitude } = getSolarPosition(date);
+  const antiSolarCenter: [number, number] = [
+    normalizeDegrees(subsolarLongitude + 180),
+    -subsolarLatitude,
+  ];
+
+  return {
+    type: 'FeatureCollection',
+    features: TIME_OF_DAY_SEVERITIES.map((item) =>
+      createFeature(
+        item.severity,
+        createCirclePolygon(antiSolarCenter, 90 + item.altitudeMax),
+      ),
+    ),
+  };
+};

--- a/src/lib/map/time-of-day.ts
+++ b/src/lib/map/time-of-day.ts
@@ -171,6 +171,15 @@ const interpolateDatelineCrossing = (
   };
 };
 
+const createCircleGeometry = (
+  center: [number, number],
+  radius: number,
+): Polygon =>
+  geoCircle()
+    .center(center)
+    .radius(radius)
+    .precision(CIRCLE_PRECISION_DEGREES)() as Polygon;
+
 const createPolarCapPolygon = (
   ring: Polygon['coordinates'][number],
   pole: 'north' | 'south',
@@ -192,7 +201,7 @@ const createPolarCapPolygon = (
   const boundaryWestToEast =
     start[0] > 0
       ? [crossing.west, ...boundary, crossing.east]
-      : [crossing.west, ...boundary.reverse(), crossing.east];
+      : [crossing.west, ...boundary.toReversed(), crossing.east];
   const poleLatitude =
     pole === 'north' ? POLE_EDGE_LATITUDE : -POLE_EDGE_LATITUDE;
   const poleEdge = [180, 120, 60, 0, -60, -120, -180].map(
@@ -275,10 +284,7 @@ const createCirclePolygon = (
   center: [number, number],
   radius: number,
 ): Polygon | MultiPolygon => {
-  const geometry = geoCircle()
-    .center(center)
-    .radius(radius)
-    .precision(CIRCLE_PRECISION_DEGREES)() as Polygon;
+  const geometry = createCircleGeometry(center, radius);
   const distanceToNorthPole = 90 - center[1];
   const distanceToSouthPole = 90 + center[1];
 

--- a/src/lib/map/time-of-day.ts
+++ b/src/lib/map/time-of-day.ts
@@ -230,19 +230,21 @@ const createAntimeridianSplitPolygon = (
 
   const ringWithoutClosingPoint = ring.slice(0, -1) as Array<[number, number]>;
   const [firstJumpIndex, secondJumpIndex] = jumpIndexes;
+  const firstJumpNextIndex =
+    (firstJumpIndex + 1) % ringWithoutClosingPoint.length;
+  const secondJumpNextIndex =
+    (secondJumpIndex + 1) % ringWithoutClosingPoint.length;
   const firstCrossing = interpolateDatelineCrossing(
     ringWithoutClosingPoint[firstJumpIndex],
-    ringWithoutClosingPoint[firstJumpIndex + 1],
+    ringWithoutClosingPoint[firstJumpNextIndex],
   );
   const secondCrossing = interpolateDatelineCrossing(
     ringWithoutClosingPoint[secondJumpIndex],
-    ringWithoutClosingPoint[
-      (secondJumpIndex + 1) % ringWithoutClosingPoint.length
-    ],
+    ringWithoutClosingPoint[secondJumpNextIndex],
   );
   const firstJumpIsEastToWest =
     ringWithoutClosingPoint[firstJumpIndex][0] > 0 &&
-    ringWithoutClosingPoint[firstJumpIndex + 1][0] < 0;
+    ringWithoutClosingPoint[firstJumpNextIndex][0] < 0;
   const eastRing = firstJumpIsEastToWest
     ? closeRing([
         secondCrossing.east,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add time-of-day shading overlay to the map
- Adds a new [`TimeOfDayLayer`](https://github.com/johanohly/AirTrail/pull/595/files#diff-40b3ca0df0ee186be731ebdc823c658aacc2b53d9b85725c0b9ffae10838b954) component that renders GeoJSON polygons for night and twilight zones, computed from the antisolar point for the current time and refreshed every 60 seconds.
- Adds a [`time-of-day`](https://github.com/johanohly/AirTrail/pull/595/files#diff-5d295bf2429411e36400ba20b57636f375beffd95bcde3346edb9310a684d80f) module with solar position math, circle/polygon generation, and antimeridian/polar handling to produce the GeoJSON feature collection.
- Exposes a toggle in [`MapAppearanceControl`](https://github.com/johanohly/AirTrail/pull/595/files#diff-cc78f2f9305525c510df3c0b9e1c77aa12b84e70843390543e84b495d0e2290b) under a new "Layers" section, bound to a `timeOfDayEnabled` preference that persists to localStorage and defaults to `false`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c04f85.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->