### PR TITLE
feat: rain layer

### DIFF
--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -17,6 +17,7 @@
   import MapFallback from './MapFallback.svelte';
   import MapStatusShelf from './MapStatusShelf.svelte';
   import OpenAipOverlay from './OpenAipOverlay.svelte';
+  import RainViewerLayer from './RainViewerLayer.svelte';
   import TimeOfDayLayer from './TimeOfDayLayer.svelte';
 
   import { AirportsArcsLayer } from '.';
@@ -650,6 +651,10 @@
 
     {#if mapPreferences.timeOfDayEnabled}
       <TimeOfDayLayer />
+    {/if}
+
+    {#if mapPreferences.rainViewerEnabled}
+      <RainViewerLayer />
     {/if}
 
     {#if openAipActive}

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -772,6 +772,19 @@
               onCheckedChange={(v) => (mapPreferences.timeOfDayEnabled = v)}
             />
           </div>
+          <div class="flex items-center justify-between gap-3">
+            <div class="min-w-0">
+              <p class="text-sm font-medium leading-none">Rain radar</p>
+              <p class="text-muted-foreground mt-1 text-[11px]">
+                Latest RainViewer precipitation
+              </p>
+            </div>
+            <Switch
+              size="small"
+              checked={mapPreferences.rainViewerEnabled}
+              onCheckedChange={(v) => (mapPreferences.rainViewerEnabled = v)}
+            />
+          </div>
         </section>
 
         {#if openAipConfigured}

--- a/src/lib/components/map/RainViewerLayer.svelte
+++ b/src/lib/components/map/RainViewerLayer.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { mode } from 'mode-watcher';
+  import { onMount } from 'svelte';
+  import { RasterLayer, RasterTileSource } from 'svelte-maplibre';
+
+  import {
+    getLatestRainViewerTileTemplate,
+    RAINVIEWER_LAYER_ID,
+    RAINVIEWER_MAX_NATIVE_ZOOM,
+    RAINVIEWER_METADATA_URL,
+    RAINVIEWER_SOURCE_ID,
+  } from '$lib/map/rainviewer';
+
+  const REFRESH_INTERVAL_MS = 5 * 60_000;
+
+  let tileTemplate = $state<string | null>(null);
+  const opacity = $derived(mode.current === 'dark' ? 0.42 : 0.58);
+
+  const refreshTileTemplate = async (signal?: AbortSignal) => {
+    const response = await fetch(RAINVIEWER_METADATA_URL, {
+      signal,
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      return;
+    }
+
+    tileTemplate = getLatestRainViewerTileTemplate(await response.json());
+  };
+
+  onMount(() => {
+    const controller = new AbortController();
+
+    refreshTileTemplate(controller.signal).catch(() => {
+      tileTemplate = null;
+    });
+
+    const interval = window.setInterval(() => {
+      refreshTileTemplate().catch(() => {
+        tileTemplate = null;
+      });
+    }, REFRESH_INTERVAL_MS);
+
+    return () => {
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  });
+</script>
+
+{#if tileTemplate}
+  <RasterTileSource
+    id={RAINVIEWER_SOURCE_ID}
+    tiles={[tileTemplate]}
+    tileSize={512}
+    minzoom={0}
+    maxzoom={RAINVIEWER_MAX_NATIVE_ZOOM}
+    attribution={'<a href="https://www.rainviewer.com" target="_blank" rel="noreferrer">RainViewer</a>'}
+  >
+    <RasterLayer
+      id={RAINVIEWER_LAYER_ID}
+      beforeLayerType="symbol"
+      paint={{
+        'raster-opacity': opacity,
+        'raster-fade-duration': 250,
+        'raster-resampling': 'linear',
+      }}
+    />
+  </RasterTileSource>
+{/if}

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -18,6 +18,7 @@ export type MapPreferences = {
   basemap: MapBasemap;
   projection: MapProjection;
   timeOfDayEnabled: boolean;
+  rainViewerEnabled: boolean;
   airportCircles: AirportCirclesMode;
   arcColor: ArcColorMode;
   arcThickness: ArcThicknessMode;
@@ -56,6 +57,7 @@ export const MAP_PREFERENCE_DEFAULTS: MapPreferences = {
   basemap: 'default',
   projection: 'mercator',
   timeOfDayEnabled: false,
+  rainViewerEnabled: false,
   airportCircles: 'large',
   arcColor: 'default',
   arcThickness: 'uniform',
@@ -93,6 +95,9 @@ const sanitize = (raw: unknown): MapPreferences => {
   }
   if (typeof input.timeOfDayEnabled === 'boolean') {
     result.timeOfDayEnabled = input.timeOfDayEnabled;
+  }
+  if (typeof input.rainViewerEnabled === 'boolean') {
+    result.rainViewerEnabled = input.rainViewerEnabled;
   }
   if (
     typeof input.airportCircles === 'string' &&
@@ -172,6 +177,7 @@ export const initMapPreferences = () => {
   mapPreferences.basemap = hydrated.basemap;
   mapPreferences.projection = hydrated.projection;
   mapPreferences.timeOfDayEnabled = hydrated.timeOfDayEnabled;
+  mapPreferences.rainViewerEnabled = hydrated.rainViewerEnabled;
   mapPreferences.airportCircles = hydrated.airportCircles;
   mapPreferences.arcColor = hydrated.arcColor;
   mapPreferences.arcThickness = hydrated.arcThickness;
@@ -186,6 +192,7 @@ export const initMapPreferences = () => {
         basemap: mapPreferences.basemap,
         projection: mapPreferences.projection,
         timeOfDayEnabled: mapPreferences.timeOfDayEnabled,
+        rainViewerEnabled: mapPreferences.rainViewerEnabled,
         airportCircles: mapPreferences.airportCircles,
         arcColor: mapPreferences.arcColor,
         arcThickness: mapPreferences.arcThickness,
@@ -207,6 +214,7 @@ export const resetMapPreferences = () => {
   mapPreferences.basemap = MAP_PREFERENCE_DEFAULTS.basemap;
   mapPreferences.projection = MAP_PREFERENCE_DEFAULTS.projection;
   mapPreferences.timeOfDayEnabled = MAP_PREFERENCE_DEFAULTS.timeOfDayEnabled;
+  mapPreferences.rainViewerEnabled = MAP_PREFERENCE_DEFAULTS.rainViewerEnabled;
   mapPreferences.airportCircles = MAP_PREFERENCE_DEFAULTS.airportCircles;
   mapPreferences.arcColor = MAP_PREFERENCE_DEFAULTS.arcColor;
   mapPreferences.arcThickness = MAP_PREFERENCE_DEFAULTS.arcThickness;

--- a/src/lib/map/rainviewer.ts
+++ b/src/lib/map/rainviewer.ts
@@ -1,0 +1,53 @@
+export const RAINVIEWER_METADATA_URL =
+  'https://api.rainviewer.com/public/weather-maps.json';
+export const RAINVIEWER_SOURCE_ID = 'airtrail-rainviewer-source';
+export const RAINVIEWER_LAYER_ID = 'airtrail-rainviewer-radar';
+export const RAINVIEWER_MAX_NATIVE_ZOOM = 7;
+
+type RainViewerFrame = {
+  time: number;
+  path: string;
+};
+
+type RainViewerMetadata = {
+  host: string;
+  radar?: {
+    past?: RainViewerFrame[];
+    nowcast?: RainViewerFrame[];
+  };
+};
+
+const isFrame = (value: unknown): value is RainViewerFrame => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const frame = value as Partial<RainViewerFrame>;
+
+  return typeof frame.time === 'number' && typeof frame.path === 'string';
+};
+
+export const getLatestRainViewerTileTemplate = (
+  metadata: unknown,
+): string | null => {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const input = metadata as Partial<RainViewerMetadata>;
+
+  if (typeof input.host !== 'string') {
+    return null;
+  }
+
+  const observedFrames = (input.radar?.past ?? []).filter(isFrame);
+  const forecastFrames = (input.radar?.nowcast ?? []).filter(isFrame);
+  const frames = observedFrames.length > 0 ? observedFrames : forecastFrames;
+  const latestFrame = frames.at(-1);
+
+  if (!latestFrame) {
+    return null;
+  }
+
+  return `${input.host}${latestFrame.path}/512/{z}/{x}/{y}/2/1_1.png`;
+};


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add RainViewer precipitation radar layer to the map
- Adds a new `RainViewerLayer` component ([RainViewerLayer.svelte](https://github.com/johanohly/AirTrail/pull/596/files#diff-89c7ae9b4d44e2657de623c2d175aef7e9d97d601f090723a92ed38aeda62f1c)) that fetches RainViewer metadata and renders a raster tile overlay using the latest available radar frame, refreshing every 5 minutes.
- Adds a `rainViewerEnabled` preference (default `false`) to `MapPreferences`, persisted in localStorage and exposed as a toggle in the map Appearance controls.
- On fetch failure or missing metadata, the layer hides itself by clearing the tile template. Opacity adapts to dark/light mode.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71f0e61.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->