### PR TITLE
feat: add uniform airport circle size

### DIFF
--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -557,6 +557,7 @@
     normal: 1.5,
     thick: 2.5,
   } as const;
+  const UNIFORM_AIRPORT_FREQUENCY = 2;
 
   const getArcWidth = (d: FlightArc) => {
     if (mapPreferences.arcThickness === 'byFrequency') {
@@ -579,6 +580,10 @@
     const preset =
       mode === 'off' ? AIRPORT_CIRCLE_SIZE.large : AIRPORT_CIRCLE_SIZE[mode];
     const baseUnits = $isMediumScreen ? 50_000 : 100_000;
+    const getFrequencyScale = (airport: VisitedAirport) =>
+      mapPreferences.airportCircleRadius === 'uniform'
+        ? UNIFORM_AIRPORT_FREQUENCY
+        : airport.frequency;
     return {
       id: 'scatterplot-layer',
       parameters: isGlobe
@@ -588,7 +593,7 @@
       data: visitedAirports,
       getPosition: (airport: VisitedAirport) => [airport.lon, airport.lat],
       getRadius: (airport: VisitedAirport) =>
-        airport.frequency * baseUnits * preset.scale,
+        getFrequencyScale(airport) * baseUnits * preset.scale,
       radiusMaxPixels: preset.maxPixels,
       lineWidthUnits: 'pixels',
       getLineWidth: (airport: VisitedAirport) =>
@@ -615,7 +620,7 @@
           selectedRoute,
         ],
         getLineWidth: [selectedAirportId, selectedRoute],
-        getRadius: [mode, $isMediumScreen],
+        getRadius: [mode, mapPreferences.airportCircleRadius, $isMediumScreen],
       },
       stroked: true,
     };

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -19,6 +19,7 @@
     mapPreferences,
     resetMapPreferences,
     toggleOpenAipGroup,
+    type AirportCircleRadiusMode,
     type AirportOverlayDetail,
     type AirportCirclesMode,
     type ArcColorMode,
@@ -52,6 +53,14 @@
     { value: 'small', label: 'Small' },
     { value: 'medium', label: 'Medium' },
     { value: 'large', label: 'Large' },
+  ];
+
+  const AIRPORT_CIRCLE_RADIUS_OPTIONS: Array<{
+    value: AirportCircleRadiusMode;
+    label: string;
+  }> = [
+    { value: 'byFrequency', label: 'By frequency' },
+    { value: 'uniform', label: 'Uniform' },
   ];
 
   const ARC_COLOR_OPTIONS: Array<{
@@ -489,83 +498,166 @@
           >
             Airports
           </h3>
-          <div class="grid grid-cols-4 gap-2">
-            {#each AIRPORT_CIRCLE_OPTIONS as option (option.value)}
-              <AppearanceTile
-                selected={mapPreferences.airportCircles === option.value}
-                onclick={() => (mapPreferences.airportCircles = option.value)}
-                label={option.label}
-              >
-                {#snippet illustration()}
-                  {#if option.value === 'off'}
+          <div class="space-y-2">
+            <p class="text-xs font-medium">Size</p>
+            <div class="grid grid-cols-4 gap-2">
+              {#each AIRPORT_CIRCLE_OPTIONS as option (option.value)}
+                <AppearanceTile
+                  selected={mapPreferences.airportCircles === option.value}
+                  onclick={() => (mapPreferences.airportCircles = option.value)}
+                  label={option.label}
+                >
+                  {#snippet illustration()}
+                    {#if option.value === 'off'}
+                      <svg
+                        viewBox="0 0 48 32"
+                        class="h-full w-full text-muted-foreground"
+                        aria-hidden="true"
+                      >
+                        <circle
+                          cx="24"
+                          cy="16"
+                          r="6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          stroke-dasharray="2 2"
+                        />
+                        <line
+                          x1="14"
+                          y1="6"
+                          x2="34"
+                          y2="26"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          stroke-linecap="round"
+                        />
+                      </svg>
+                    {:else}
+                      {@const radii =
+                        option.value === 'small'
+                          ? [2, 3, 2.5]
+                          : option.value === 'medium'
+                            ? [3.5, 5, 4]
+                            : [5, 7.5, 6]}
+                      <svg
+                        viewBox="0 0 48 32"
+                        class="h-full w-full text-primary"
+                        aria-hidden="true"
+                      >
+                        <circle
+                          cx="13"
+                          cy="20"
+                          r={radii[0]}
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                        <circle
+                          cx="26"
+                          cy="13"
+                          r={radii[1]}
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                        <circle
+                          cx="37"
+                          cy="22"
+                          r={radii[2]}
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                      </svg>
+                    {/if}
+                  {/snippet}
+                </AppearanceTile>
+              {/each}
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <p class="text-xs font-medium">Mode</p>
+            <div class="grid grid-cols-2 gap-2">
+              {#each AIRPORT_CIRCLE_RADIUS_OPTIONS as option (option.value)}
+                <AppearanceTile
+                  selected={mapPreferences.airportCircleRadius === option.value}
+                  onclick={() =>
+                    (mapPreferences.airportCircleRadius = option.value)}
+                  label={option.label}
+                >
+                  {#snippet illustration()}
                     <svg
-                      viewBox="0 0 48 32"
-                      class="h-full w-full text-muted-foreground"
-                      aria-hidden="true"
-                    >
-                      <circle
-                        cx="24"
-                        cy="16"
-                        r="6"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-dasharray="2 2"
-                      />
-                      <line
-                        x1="14"
-                        y1="6"
-                        x2="34"
-                        y2="26"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                      />
-                    </svg>
-                  {:else}
-                    {@const radii =
-                      option.value === 'small'
-                        ? [2, 3, 2.5]
-                        : option.value === 'medium'
-                          ? [3.5, 5, 4]
-                          : [5, 7.5, 6]}
-                    <svg
-                      viewBox="0 0 48 32"
+                      viewBox="0 0 72 32"
                       class="h-full w-full text-primary"
                       aria-hidden="true"
                     >
-                      <circle
-                        cx="13"
-                        cy="20"
-                        r={radii[0]}
-                        fill="currentColor"
-                        fill-opacity="0.2"
-                        stroke="currentColor"
-                        stroke-width="1"
-                      />
-                      <circle
-                        cx="26"
-                        cy="13"
-                        r={radii[1]}
-                        fill="currentColor"
-                        fill-opacity="0.2"
-                        stroke="currentColor"
-                        stroke-width="1"
-                      />
-                      <circle
-                        cx="37"
-                        cy="22"
-                        r={radii[2]}
-                        fill="currentColor"
-                        fill-opacity="0.2"
-                        stroke="currentColor"
-                        stroke-width="1"
-                      />
+                      {#if option.value === 'uniform'}
+                        <circle
+                          cx="18"
+                          cy="19"
+                          r="4.75"
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                        <circle
+                          cx="36"
+                          cy="12"
+                          r="4.75"
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                        <circle
+                          cx="54"
+                          cy="21"
+                          r="4.75"
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                      {:else}
+                        <circle
+                          cx="18"
+                          cy="19"
+                          r="2.75"
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                        <circle
+                          cx="36"
+                          cy="12"
+                          r="6.5"
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                        <circle
+                          cx="54"
+                          cy="21"
+                          r="4.25"
+                          fill="currentColor"
+                          fill-opacity="0.2"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        />
+                      {/if}
                     </svg>
-                  {/if}
-                {/snippet}
-              </AppearanceTile>
-            {/each}
+                  {/snippet}
+                </AppearanceTile>
+              {/each}
+            </div>
           </div>
         </section>
 

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -8,6 +8,7 @@ import {
 import { MAP_BASEMAPS, type MapBasemap } from './basemap';
 
 export type AirportCirclesMode = 'off' | 'small' | 'medium' | 'large';
+export type AirportCircleRadiusMode = 'byFrequency' | 'uniform';
 export type ArcColorMode = 'default' | 'byFrequency';
 export type ArcThicknessMode = 'uniform' | 'byFrequency';
 export type ArcThicknessScale = 'thin' | 'normal' | 'thick';
@@ -20,6 +21,7 @@ export type MapPreferences = {
   timeOfDayEnabled: boolean;
   rainViewerEnabled: boolean;
   airportCircles: AirportCirclesMode;
+  airportCircleRadius: AirportCircleRadiusMode;
   arcColor: ArcColorMode;
   arcThickness: ArcThicknessMode;
   arcThicknessScale: ArcThicknessScale;
@@ -36,6 +38,10 @@ const AIRPORT_CIRCLES_MODES: readonly AirportCirclesMode[] = [
   'small',
   'medium',
   'large',
+];
+const AIRPORT_CIRCLE_RADIUS_MODES: readonly AirportCircleRadiusMode[] = [
+  'byFrequency',
+  'uniform',
 ];
 const ARC_COLOR_MODES: readonly ArcColorMode[] = ['default', 'byFrequency'];
 const ARC_THICKNESS_MODES: readonly ArcThicknessMode[] = [
@@ -59,6 +65,7 @@ export const MAP_PREFERENCE_DEFAULTS: MapPreferences = {
   timeOfDayEnabled: false,
   rainViewerEnabled: false,
   airportCircles: 'large',
+  airportCircleRadius: 'byFrequency',
   arcColor: 'default',
   arcThickness: 'uniform',
   arcThicknessScale: 'normal',
@@ -104,6 +111,15 @@ const sanitize = (raw: unknown): MapPreferences => {
     AIRPORT_CIRCLES_MODES.includes(input.airportCircles as AirportCirclesMode)
   ) {
     result.airportCircles = input.airportCircles as AirportCirclesMode;
+  }
+  if (
+    typeof input.airportCircleRadius === 'string' &&
+    AIRPORT_CIRCLE_RADIUS_MODES.includes(
+      input.airportCircleRadius as AirportCircleRadiusMode,
+    )
+  ) {
+    result.airportCircleRadius =
+      input.airportCircleRadius as AirportCircleRadiusMode;
   }
   if (
     typeof input.arcColor === 'string' &&
@@ -179,6 +195,7 @@ export const initMapPreferences = () => {
   mapPreferences.timeOfDayEnabled = hydrated.timeOfDayEnabled;
   mapPreferences.rainViewerEnabled = hydrated.rainViewerEnabled;
   mapPreferences.airportCircles = hydrated.airportCircles;
+  mapPreferences.airportCircleRadius = hydrated.airportCircleRadius;
   mapPreferences.arcColor = hydrated.arcColor;
   mapPreferences.arcThickness = hydrated.arcThickness;
   mapPreferences.arcThicknessScale = hydrated.arcThicknessScale;
@@ -194,6 +211,7 @@ export const initMapPreferences = () => {
         timeOfDayEnabled: mapPreferences.timeOfDayEnabled,
         rainViewerEnabled: mapPreferences.rainViewerEnabled,
         airportCircles: mapPreferences.airportCircles,
+        airportCircleRadius: mapPreferences.airportCircleRadius,
         arcColor: mapPreferences.arcColor,
         arcThickness: mapPreferences.arcThickness,
         arcThicknessScale: mapPreferences.arcThicknessScale,
@@ -216,6 +234,8 @@ export const resetMapPreferences = () => {
   mapPreferences.timeOfDayEnabled = MAP_PREFERENCE_DEFAULTS.timeOfDayEnabled;
   mapPreferences.rainViewerEnabled = MAP_PREFERENCE_DEFAULTS.rainViewerEnabled;
   mapPreferences.airportCircles = MAP_PREFERENCE_DEFAULTS.airportCircles;
+  mapPreferences.airportCircleRadius =
+    MAP_PREFERENCE_DEFAULTS.airportCircleRadius;
   mapPreferences.arcColor = MAP_PREFERENCE_DEFAULTS.arcColor;
   mapPreferences.arcThickness = MAP_PREFERENCE_DEFAULTS.arcThickness;
   mapPreferences.arcThicknessScale = MAP_PREFERENCE_DEFAULTS.arcThicknessScale;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add uniform airport circle size mode to map preferences
- Adds a new `AirportCircleRadiusMode` type (`'byFrequency' | 'uniform'`) to [map-preferences.svelte.ts](https://github.com/johanohly/AirTrail/pull/598/files#diff-7de144adf31aa0d20aa84c1d37751538ab95b6bc801ab2ac31af5ef9fc72770f), persisted in and restored from localStorage.
- In [AirportsArcsLayer.svelte](https://github.com/johanohly/AirTrail/pull/598/files#diff-4afe79e0339cf3be73d747515004ab3b4e390bdf9b120d52b3d59249167946b4), a `getFrequencyScale` helper returns a fixed constant when mode is `'uniform'`, otherwise scales by airport frequency.
- Adds a 'Mode' control in [MapAppearanceControl.svelte](https://github.com/johanohly/AirTrail/pull/598/files#diff-cc78f2f9305525c510df3c0b9e1c77aa12b84e70843390543e84b495d0e2290b) with SVG illustrations for each option, bound to `mapPreferences.airportCircleRadius`.
- Behavioral Change: default mode is `'byFrequency'`; resetting map preferences also resets this value.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce04ca9.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->