### PR TITLE
feat: add JetLovers importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   integrate with your OAuth provider.
 - **Responsive Design**: Use the application on any device with a responsive design.
 - **Dark Mode**: Switch between light and dark mode.
-- **Import Flights**: Import flights from various sources including MyFlightRadar24, App in the Air, JetLog, TripIt, Flighty and byAir.
+- **Import Flights**: Import flights from various sources including MyFlightRadar24, App in the Air, JetLog, TripIt, Flighty, byAir, JetLovers and OpenFlights.
 
 ## 🚀 Getting Started
 

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -131,7 +131,7 @@ export default function HomePage() {
               <FeatureCard
                 icon={<CloudDownload className="size-5" />}
                 title="Import From Anywhere"
-                description="Bring in flights from MyFlightRadar24, App in the Air, JetLog, TripIt, Flighty, byAir, and more."
+                description="Bring in flights from MyFlightRadar24, App in the Air, JetLog, TripIt, Flighty, byAir, JetLovers, OpenFlights, and more."
               />
             </FadeInOnScroll>
 

--- a/docs/content/docs/features/import.mdx
+++ b/docs/content/docs/features/import.mdx
@@ -5,7 +5,7 @@ title: Import
 The import feature allows you to import flight data from other sources into AirTrail.
 Currently, AirTrail supports importing flights from [MyFlightRadar24](https://my.flightradar24.com)
 , [App in the Air](https://appintheair.com), [JetLog](https://github.com/pbogre/jetlog), [TripIt (ICS)](https://www.tripit.com)
-, [Flighty](https://flightyapp.com), [byAir](https://byair.app), [OpenFlights](https://openflights.org) and [AirTrail JSON files](/docs/features/export).
+, [Flighty](https://flightyapp.com), [byAir](https://byair.app), [JetLovers](https://www.jetlovers.com), [OpenFlights](https://openflights.org) and [AirTrail JSON files](/docs/features/export).
 
 ## Import flights from MyFlightradar24
 
@@ -127,6 +127,24 @@ Import the CSV file into AirTrail:
 2. Go to the settings page and open the Import tab.
 3. Choose the source "byAir".
 4. Select your CSV file from byAir.
+5. Click Import.
+
+## Import flights from JetLovers
+
+JetLovers allows you to export your flight data as a CSV file.
+
+Export from JetLovers:
+
+1. Open [JetLovers](https://www.jetlovers.com).
+2. Go to "My flights".
+3. Click "CSV Export".
+
+Import the CSV file into AirTrail:
+
+1. Open the AirTrail application.
+2. Go to the settings page and open the Import tab.
+3. Choose the source "JetLovers".
+4. Select your CSV file from JetLovers.
 5. Click Import.
 
 ## Import flights from OpenFlights

--- a/src/lib/components/modals/settings/pages/import-page/index.ts
+++ b/src/lib/components/modals/settings/pages/import-page/index.ts
@@ -75,6 +75,16 @@ export const platforms = [
     },
   },
   {
+    name: 'JetLovers',
+    value: 'jetlovers',
+    description: 'CSV export from JetLovers flight tracker.',
+    extensions: ['.csv'],
+    options: {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+    },
+  },
+  {
     name: 'OpenFlights',
     value: 'openflights',
     description: 'CSV backup from OpenFlights.',

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -8,6 +8,7 @@ import { processAITAFile } from '$lib/import/aita';
 import { processByAirFile } from '$lib/import/byair';
 import { processFlightyFile } from '$lib/import/flighty';
 import { processFR24File } from '$lib/import/fr24';
+import { processJetLoversFile } from '$lib/import/jetlovers';
 import { processJetLogFile } from '$lib/import/jetlog';
 import { processLegacyAirTrailFile } from '$lib/import/legacy-airtrail';
 import { processOpenFlightsFile } from '$lib/import/openflights';
@@ -62,6 +63,8 @@ const processors: Record<PlatformValue, Processor> = {
     withDefaultUnknownUsers(() => processFlightyFile(content, options)),
   byair: async (content, options) =>
     withDefaultUnknownUsers(() => processByAirFile(content, options)),
+  jetlovers: async (content, options) =>
+    withDefaultUnknownUsers(() => processJetLoversFile(content, options)),
   openflights: async (content, options) =>
     withDefaultUnknownUsers(() => processOpenFlightsFile(content, options)),
 };

--- a/src/lib/import/jetlovers.test.ts
+++ b/src/lib/import/jetlovers.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { processJetLoversFile } from './jetlovers';
+
+const { getAirportByIata, getAirlineByName, getAircraftByName } = vi.hoisted(
+  () => ({
+    getAirportByIata: vi.fn(async (iata: string) => ({
+      id: iata,
+      iata,
+      tz: 'UTC',
+    })),
+    getAirlineByName: vi.fn(async (name: string) => ({ id: name, name })),
+    getAircraftByName: vi.fn(async (name: string) => ({ id: name, name })),
+  }),
+);
+
+vi.mock('$app/state', () => ({
+  page: {
+    data: {
+      user: {
+        id: 'user-1',
+      },
+    },
+  },
+}));
+
+vi.mock('$lib/utils/data/airports/cache', () => ({
+  getAirportByIata,
+}));
+
+vi.mock('$lib/utils/data/airlines', () => ({
+  getAirlineByIata: vi.fn(),
+  getAirlineByIcao: vi.fn(),
+  getAirlineByName,
+}));
+
+vi.mock('$lib/utils/data/aircraft', () => ({
+  getAircraftByName,
+}));
+
+describe('processJetLoversFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('imports the JetLovers CSV export shape', async () => {
+    const content =
+      'id,date,from,to,miles,airline,flightnum,aircraft,aircraft_reg,class,reason,seat_type,seat\n' +
+      '3918815,2024-06-14,CDG,SNN,561,Aer Lingus,EI909,Airbus A321neo,EI-LRA,B,L,W,3K';
+
+    const result = await processJetLoversFile(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+    });
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.skippedRows).toBe(0);
+    expect(getAirportByIata).toHaveBeenCalledWith('CDG');
+    expect(getAirportByIata).toHaveBeenCalledWith('SNN');
+    expect(getAirlineByName).toHaveBeenCalledWith('Aer Lingus');
+    expect(getAircraftByName).toHaveBeenCalledWith('Airbus A321neo');
+
+    const flight = result.flights[0]!;
+    expect(flight.date).toBe('2024-06-14');
+    expect(flight.flightNumber).toBe('EI909');
+    expect(flight.aircraftReg).toBe('EI-LRA');
+    expect(flight.flightReason).toBe('leisure');
+    expect(flight.seats[0]).toMatchObject({
+      userId: 'user-1',
+      seat: 'window',
+      seatClass: 'business',
+      seatNumber: '3K',
+    });
+  });
+});

--- a/src/lib/import/jetlovers.ts
+++ b/src/lib/import/jetlovers.ts
@@ -1,0 +1,206 @@
+import { z } from 'zod';
+
+import { page } from '$app/state';
+import type { PlatformOptions } from '$lib/components/modals/settings/pages/import-page';
+import type { CreateFlight, Seat } from '$lib/db/types';
+import { parseCsv } from '$lib/utils';
+import { getAircraftByName } from '$lib/utils/data/aircraft';
+import {
+  getAirlineByIata,
+  getAirlineByIcao,
+  getAirlineByName,
+} from '$lib/utils/data/airlines';
+import { getAirportByIata } from '$lib/utils/data/airports/cache';
+
+const nullTransformer = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+};
+
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+const JetLoversFlight = z.object({
+  id: z.string().transform(nullTransformer),
+  date: z.string().regex(dateRegex),
+  from: z.string(),
+  to: z.string(),
+  miles: z.string().transform(nullTransformer),
+  airline: z.string().transform(nullTransformer),
+  flightnum: z.string().transform(nullTransformer),
+  aircraft: z.string().transform(nullTransformer),
+  aircraft_reg: z.string().transform(nullTransformer),
+  class: z.string().transform(nullTransformer),
+  reason: z.string().transform(nullTransformer),
+  seat_type: z.string().transform(nullTransformer),
+  seat: z.string().transform(nullTransformer),
+});
+
+const JETLOVERS_SEAT_TYPE_MAP: Record<string, Seat['seat']> = {
+  W: 'window',
+  A: 'aisle',
+  M: 'middle',
+};
+const JETLOVERS_SEAT_CLASS_MAP: Record<string, Seat['seatClass']> = {
+  F: 'first',
+  C: 'business',
+  B: 'business',
+  P: 'economy+',
+  Y: 'economy',
+};
+const JETLOVERS_FLIGHT_REASON_MAP: Record<
+  string,
+  NonNullable<CreateFlight['flightReason']>
+> = {
+  B: 'business',
+  L: 'leisure',
+  C: 'crew',
+  O: 'other',
+};
+
+const mapNullableCode = <T>(map: Record<string, T>, value: string | null) => {
+  if (!value) return null;
+  return map[value.trim().toUpperCase()] ?? null;
+};
+
+const mapSeatType = (seatType: string | null): Seat['seat'] => {
+  return mapNullableCode(JETLOVERS_SEAT_TYPE_MAP, seatType);
+};
+
+const mapSeatClass = (seatClass: string | null): Seat['seatClass'] => {
+  return mapNullableCode(JETLOVERS_SEAT_CLASS_MAP, seatClass);
+};
+
+const mapFlightReason = (
+  reason: string | null,
+): CreateFlight['flightReason'] => {
+  return mapNullableCode(JETLOVERS_FLIGHT_REASON_MAP, reason);
+};
+
+const extractAirlineCodeFromFlightNumber = (flightNumber: string | null) => {
+  if (!flightNumber) return null;
+  return (
+    flightNumber.match(/^([A-Za-z]{2,3})\*?\d/)?.[1]?.toUpperCase() ?? null
+  );
+};
+
+const lookupAirline = async (
+  row: z.infer<typeof JetLoversFlight>,
+  options: PlatformOptions,
+) => {
+  const name = row.airline?.trim() || null;
+  const flightNumberCode = options.airlineFromFlightNumber
+    ? extractAirlineCodeFromFlightNumber(row.flightnum)
+    : null;
+  const mappingKey = name ?? flightNumberCode;
+
+  if (mappingKey && options.airlineMapping?.[mappingKey]) {
+    return {
+      airline: options.airlineMapping[mappingKey],
+      airlineKey: mappingKey,
+    };
+  }
+
+  let airline = name ? await getAirlineByName(name) : null;
+  airline ??= flightNumberCode
+    ? ((await getAirlineByIata(flightNumberCode)) ??
+      (await getAirlineByIcao(flightNumberCode)))
+    : null;
+
+  return { airline, airlineKey: mappingKey };
+};
+
+export const processJetLoversFile = async (
+  input: string,
+  options: PlatformOptions,
+) => {
+  const userId = page.data.user?.id;
+  if (!userId) {
+    throw new Error('User not found');
+  }
+
+  const { rows: data, skipped } = parseCsv(input, JetLoversFlight);
+  if (data.length === 0) {
+    return {
+      flights: [],
+      unknownAirports: {},
+      unknownAirlines: {},
+      skippedRows: skipped.length,
+    };
+  }
+
+  const flights: CreateFlight[] = [];
+  const unknownAirports: Record<string, number[]> = {};
+  const unknownAirlines: Record<string, number[]> = {};
+
+  for (const row of data) {
+    const fromCode = row.from.trim().toUpperCase();
+    const toCode = row.to.trim().toUpperCase();
+
+    const mappedFrom = options.airportMapping?.[fromCode];
+    const mappedTo = options.airportMapping?.[toCode];
+    const from = mappedFrom ?? (await getAirportByIata(fromCode));
+    const to = mappedTo ?? (await getAirportByIata(toCode));
+
+    const { airline, airlineKey } = await lookupAirline(row, options);
+    const aircraft = row.aircraft
+      ? await getAircraftByName(row.aircraft)
+      : null;
+    const flightNumber = row.flightnum?.replace('*', '') ?? null;
+    const flightIndex = flights.length;
+
+    if (!from) {
+      unknownAirports[fromCode] ??= [];
+      unknownAirports[fromCode].push(flightIndex);
+    }
+    if (!to) {
+      unknownAirports[toCode] ??= [];
+      unknownAirports[toCode].push(flightIndex);
+    }
+    if (!airline && airlineKey) {
+      unknownAirlines[airlineKey] ??= [];
+      unknownAirlines[airlineKey].push(flightIndex);
+    }
+
+    flights.push({
+      date: row.date,
+      from: from || null,
+      to: to || null,
+      departure: null,
+      arrival: null,
+      departureScheduled: null,
+      arrivalScheduled: null,
+      takeoffScheduled: null,
+      takeoffActual: null,
+      landingScheduled: null,
+      landingActual: null,
+      datePrecision: 'day',
+      departureTerminal: null,
+      departureGate: null,
+      arrivalTerminal: null,
+      arrivalGate: null,
+      duration: null,
+      flightNumber: flightNumber ? flightNumber.substring(0, 10) : null,
+      note: null,
+      airline,
+      aircraft,
+      aircraftReg: row.aircraft_reg ? row.aircraft_reg.substring(0, 10) : null,
+      flightReason: mapFlightReason(row.reason),
+      seats: [
+        {
+          userId,
+          seat: mapSeatType(row.seat_type),
+          seatClass: mapSeatClass(row.class),
+          seatNumber: row.seat ? row.seat.substring(0, 5) : null,
+          guestName: null,
+        },
+      ],
+    });
+  }
+
+  return {
+    flights,
+    unknownAirports,
+    unknownAirlines,
+    skippedRows: skipped.length,
+  };
+};


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add JetLovers CSV flight importer
- Adds a new [`processJetLoversFile`](https://github.com/johanohly/AirTrail/pull/612/files#diff-27c2c317c79d7766b49122761d0bec6a8f4be144d207765cab577428a733096c) processor that parses JetLovers CSV exports into `CreateFlight` objects, resolving airports, airlines, and aircraft with fallback lookups.
- Maps JetLovers-specific fields to internal enums: seat type (W/A/M), seat class (F/C/B/P/Y), and flight reason (B/L/C/O); normalizes flight numbers and truncates field lengths.
- Registers `jetlovers` as a selectable platform in the import modal with `.csv` support and `airlineFromFlightNumber=true` as default.
- Updates landing page copy and import documentation to list JetLovers as a supported source.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized db77317. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->