### PR TITLE
fix: stop exposing user password hashes

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,7 +6,7 @@ declare global {
     }
 
     interface PageData {
-      user: import('$lib/db/types').PublicUser | null;
+      user: import('$lib/db/types').PageUser | null;
       users: import('$lib/db/types').PublicUser[];
     }
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,8 +6,8 @@ declare global {
     }
 
     interface PageData {
-      user: import('lucia').User | null;
-      users: Omit<import('lucia').User, 'password'>[];
+      user: import('$lib/db/types').PublicUser | null;
+      users: import('$lib/db/types').PublicUser[];
     }
 
     namespace Superforms {

--- a/src/lib/components/modals/flight-form/PassengerPicker.svelte
+++ b/src/lib/components/modals/flight-form/PassengerPicker.svelte
@@ -7,7 +7,7 @@
 
   import { page } from '$app/state';
   import UserModal from '$lib/components/modals/settings/pages/users-page/UserModal.svelte';
-  import type { User as UserType } from '$lib/db/types';
+  import type { PublicUser } from '$lib/db/types';
   import { cn } from '$lib/utils';
 
   let {
@@ -29,7 +29,7 @@
     page.data.user?.role === 'admin' || page.data.user?.role === 'owner',
   );
 
-  const getUsers = () => (page.data.users as UserType[]) ?? [];
+  const getUsers = () => page.data.users ?? [];
 
   const availableUsers = $derived.by(() => {
     const users = getUsers();
@@ -48,7 +48,7 @@
   };
 
   type SelectionValue =
-    | { type: 'user'; user: UserType }
+    | { type: 'user'; user: PublicUser }
     | { type: 'guest'; name: string }
     | { type: 'create'; name: string };
 

--- a/src/lib/components/modals/settings/pages/security-page/OAuth.svelte
+++ b/src/lib/components/modals/settings/pages/security-page/OAuth.svelte
@@ -5,11 +5,11 @@
   import { invalidateAll } from '$app/navigation';
   import { Confirm } from '$lib/components/helpers';
   import { Button } from '$lib/components/ui/button';
-  import type { User } from '$lib/db/types';
+  import type { PageUser } from '$lib/db/types';
   import { appConfig } from '$lib/state.svelte';
   import { api } from '$lib/trpc';
 
-  let { user }: { user: User | null } = $props();
+  let { user }: { user: PageUser | null } = $props();
 
   let loading = $state(false);
   const link = async () => {
@@ -46,7 +46,7 @@
     <div class="space-y-0.5">
       <h4 class="font-medium leading-4">OAuth</h4>
       <p class="text-sm text-muted-foreground">
-        {#if user.oauthId}
+        {#if user.hasOAuthLinked}
           You can currently sign in via OAuth.
         {:else}
           Link your account to an OAuth provider.
@@ -54,7 +54,7 @@
       </p>
     </div>
     <div>
-      {#if user.oauthId}
+      {#if user.hasOAuthLinked}
         <Confirm
           onConfirm={unlink}
           title="Unlink OAuth"

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -15,6 +15,22 @@ import type { Insertable, Selectable } from 'kysely';
 
 export type FullUser = Selectable<user>;
 export type User = Omit<FullUser, 'password'>;
+export const publicUserFields = [
+  'id',
+  'username',
+  'displayName',
+  'role',
+  'oauthId',
+  'distanceUnit',
+  'windSpeedUnit',
+  'temperatureUnit',
+  'pressureUnit',
+  'timeFormat',
+  'dateFormat',
+  'weekStartsOn',
+  'flightTimeDisplay',
+] as const satisfies readonly (keyof User)[];
+export type PublicUser = Pick<User, (typeof publicUserFields)[number]>;
 export type ApiKey = Omit<Selectable<api_key>, 'key' | 'userId'>;
 export type Aircraft = Selectable<aircraft>;
 export type Airline = Selectable<airline>;

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -20,7 +20,6 @@ export const publicUserFields = [
   'username',
   'displayName',
   'role',
-  'oauthId',
   'distanceUnit',
   'windSpeedUnit',
   'temperatureUnit',
@@ -31,6 +30,7 @@ export const publicUserFields = [
   'flightTimeDisplay',
 ] as const satisfies readonly (keyof User)[];
 export type PublicUser = Pick<User, (typeof publicUserFields)[number]>;
+export type PageUser = PublicUser & { hasOAuthLinked: boolean };
 export type ApiKey = Omit<Selectable<api_key>, 'key' | 'userId'>;
 export type Aircraft = Selectable<aircraft>;
 export type Airline = Selectable<airline>;

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -20,7 +20,6 @@ export const lucia = new Lucia(adapter, {
   getUserAttributes(db) {
     return {
       username: db.username,
-      password: db.password,
       // @ts-expect-error - Lucia establishes its own connection so the camel case translation layer does not get applied here
       displayName: db.display_name,
       role: db.role,

--- a/src/lib/server/routes/user.ts
+++ b/src/lib/server/routes/user.ts
@@ -6,6 +6,7 @@ import { authedProcedure, publicProcedure, router } from '../trpc';
 
 import { db } from '$lib/db';
 import { createApiKey } from '$lib/server/utils/auth';
+import { publicUserSelect } from '$lib/server/utils/user';
 import { updatePreferencesSchema } from '$lib/zod/user';
 
 export const userRouter = router({
@@ -51,7 +52,7 @@ export const userRouter = router({
     return result.numDeletedRows > 0;
   }),
   list: authedProcedure.query(async () => {
-    return db.selectFrom('user').selectAll().execute();
+    return db.selectFrom('user').select(publicUserSelect).execute();
   }),
   listApiKeys: authedProcedure.query(async ({ ctx }) => {
     return db

--- a/src/lib/server/utils/auth.ts
+++ b/src/lib/server/utils/auth.ts
@@ -49,6 +49,14 @@ export const getUserWithPassword = async (username: string) => {
     .executeTakeFirst();
 };
 
+export const getUserWithOAuthId = async (username: string) => {
+  return db
+    .selectFrom('user')
+    .where(usernameEquals(username))
+    .select([...publicUserFields, 'oauthId'])
+    .executeTakeFirst();
+};
+
 export const getUserPasswordHash = async (userId: string) => {
   const user = await db
     .selectFrom('user')

--- a/src/lib/server/utils/auth.ts
+++ b/src/lib/server/utils/auth.ts
@@ -3,7 +3,7 @@ import { sql } from 'kysely';
 import type { Lucia } from 'lucia';
 
 import { db } from '$lib/db';
-import type { User } from '$lib/db/types';
+import { publicUserFields, type User } from '$lib/db/types';
 import { hashSha256 } from '$lib/server/utils/hash';
 import { generateString } from '$lib/server/utils/random';
 import type { Preferences } from '$lib/zod/user';
@@ -37,8 +37,25 @@ export const getUser = async (username: string) => {
   return db
     .selectFrom('user')
     .where(usernameEquals(username))
+    .select(publicUserFields)
+    .executeTakeFirst();
+};
+
+export const getUserWithPassword = async (username: string) => {
+  return db
+    .selectFrom('user')
+    .where(usernameEquals(username))
     .selectAll()
     .executeTakeFirst();
+};
+
+export const getUserPasswordHash = async (userId: string) => {
+  const user = await db
+    .selectFrom('user')
+    .select('password')
+    .where('id', '=', userId)
+    .executeTakeFirst();
+  return user?.password ?? null;
 };
 
 export const createSessionCookie = async (lucia: Lucia, userId: string) => {

--- a/src/lib/server/utils/user.ts
+++ b/src/lib/server/utils/user.ts
@@ -1,6 +1,6 @@
-import { publicUserFields, type PublicUser } from '$lib/db/types';
+import type { PageUser, PublicUser, User } from '$lib/db/types';
 
-export const publicUserSelect = publicUserFields;
+export { publicUserFields as publicUserSelect } from '$lib/db/types';
 
 export const toPublicUser = (user: PublicUser): PublicUser => {
   const {
@@ -8,7 +8,6 @@ export const toPublicUser = (user: PublicUser): PublicUser => {
     username,
     displayName,
     role,
-    oauthId,
     distanceUnit,
     windSpeedUnit,
     temperatureUnit,
@@ -24,7 +23,6 @@ export const toPublicUser = (user: PublicUser): PublicUser => {
     username,
     displayName,
     role,
-    oauthId,
     distanceUnit,
     windSpeedUnit,
     temperatureUnit,
@@ -35,3 +33,8 @@ export const toPublicUser = (user: PublicUser): PublicUser => {
     flightTimeDisplay,
   };
 };
+
+export const toPageUser = (user: User): PageUser => ({
+  ...toPublicUser(user),
+  hasOAuthLinked: Boolean(user.oauthId),
+});

--- a/src/lib/server/utils/user.ts
+++ b/src/lib/server/utils/user.ts
@@ -1,0 +1,37 @@
+import { publicUserFields, type PublicUser } from '$lib/db/types';
+
+export const publicUserSelect = publicUserFields;
+
+export const toPublicUser = (user: PublicUser): PublicUser => {
+  const {
+    id,
+    username,
+    displayName,
+    role,
+    oauthId,
+    distanceUnit,
+    windSpeedUnit,
+    temperatureUnit,
+    pressureUnit,
+    timeFormat,
+    dateFormat,
+    weekStartsOn,
+    flightTimeDisplay,
+  } = user;
+
+  return {
+    id,
+    username,
+    displayName,
+    role,
+    oauthId,
+    distanceUnit,
+    windSpeedUnit,
+    temperatureUnit,
+    pressureUnit,
+    timeFormat,
+    dateFormat,
+    weekStartsOn,
+    flightTimeDisplay,
+  };
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -6,7 +6,7 @@ import { resolve } from '$app/paths';
 import { db } from '$lib/db';
 import { trpcServer } from '$lib/server/server';
 import { appConfig } from '$lib/server/utils/config';
-import { publicUserSelect, toPublicUser } from '$lib/server/utils/user';
+import { publicUserSelect, toPageUser } from '$lib/server/utils/user';
 
 export const load = async (event: Parameters<LayoutServerLoad>[0]) => {
   if (
@@ -22,7 +22,7 @@ export const load = async (event: Parameters<LayoutServerLoad>[0]) => {
 
   return {
     trpc: await trpcServer.hydrateToClient(event),
-    user: event.locals.user ? toPublicUser(event.locals.user) : null,
+    user: event.locals.user ? toPageUser(event.locals.user) : null,
     users: await db.selectFrom('user').select(publicUserSelect).execute(),
     appConfig: {
       config,

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -6,6 +6,7 @@ import { resolve } from '$app/paths';
 import { db } from '$lib/db';
 import { trpcServer } from '$lib/server/server';
 import { appConfig } from '$lib/server/utils/config';
+import { publicUserSelect, toPublicUser } from '$lib/server/utils/user';
 
 export const load = async (event: Parameters<LayoutServerLoad>[0]) => {
   if (
@@ -17,20 +18,12 @@ export const load = async (event: Parameters<LayoutServerLoad>[0]) => {
     return redirect(302, resolve('/login'));
   }
 
-  let user = null;
-  if (event.locals.user) {
-    const { password: _, ...rest } = event.locals.user;
-    user = rest;
-  }
-
   const config = await appConfig.getClientConfig();
 
   return {
     trpc: await trpcServer.hydrateToClient(event),
-    user,
-    users: (await db.selectFrom('user').selectAll().execute()).map(
-      ({ password: _, ...rest }) => rest,
-    ),
+    user: event.locals.user ? toPublicUser(event.locals.user) : null,
+    users: await db.selectFrom('user').select(publicUserSelect).execute(),
     appConfig: {
       config,
       configured: appConfig.configured,

--- a/src/routes/api/oauth/callback/+server.ts
+++ b/src/routes/api/oauth/callback/+server.ts
@@ -5,9 +5,10 @@ import { z } from 'zod';
 
 import type { RequestHandler } from './$types';
 
-import { db, type User } from '$lib/db';
+import { db } from '$lib/db';
+import type { User } from '$lib/db/types';
 import { lucia } from '$lib/server/auth';
-import { createSession, getUser } from '$lib/server/utils/auth';
+import { createSession, getUserWithOAuthId } from '$lib/server/utils/auth';
 import { appConfig } from '$lib/server/utils/config';
 import {
   getOAuthProfile,
@@ -90,7 +91,7 @@ export const POST: RequestHandler = async ({ cookies, request, locals }) => {
   // Case 3: User has not logged in via OAuth before, but has an account.
   // preferred_username is only a hint; local password auth is required before linking.
   if (!user && profile.preferred_username) {
-    const usernameUser = await getUser(profile.preferred_username);
+    const usernameUser = await getUserWithOAuthId(profile.preferred_username);
     if (usernameUser) {
       if (usernameUser.oauthId && usernameUser.oauthId !== profile.sub) {
         return error(

--- a/src/routes/api/users/edit-password/+server.ts
+++ b/src/routes/api/users/edit-password/+server.ts
@@ -4,6 +4,7 @@ import { zod } from 'sveltekit-superforms/adapters';
 import type { RequestHandler } from './$types';
 
 import { db } from '$lib/db';
+import { getUserPasswordHash } from '$lib/server/utils/auth';
 import { hashArgon2, verifyArgon2 } from '$lib/server/utils/hash';
 import { editPasswordSchema } from '$lib/zod/user';
 
@@ -12,7 +13,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   if (!form.valid) return actionResult('failure', { form });
 
   const user = locals.user;
-  if (!user || !user.password) {
+  if (!user) {
     return actionResult(
       'error',
       'You must be logged in to edit your password.',
@@ -21,7 +22,17 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   }
 
   const { currentPassword, newPassword } = form.data;
-  const valid = await verifyArgon2(user.password, currentPassword);
+  const currentPasswordHash = await getUserPasswordHash(user.id);
+
+  if (!currentPasswordHash) {
+    return actionResult(
+      'error',
+      'You must be logged in to edit your password.',
+      401,
+    );
+  }
+
+  const valid = await verifyArgon2(currentPasswordHash, currentPassword);
   if (!valid) {
     setError(form, 'currentPassword', 'Invalid password');
     return actionResult('failure', { form });

--- a/src/routes/api/users/login/+server.ts
+++ b/src/routes/api/users/login/+server.ts
@@ -4,7 +4,7 @@ import { zod } from 'sveltekit-superforms/adapters';
 import type { RequestHandler } from './$types';
 
 import { lucia } from '$lib/server/auth';
-import { createSession, getUser } from '$lib/server/utils/auth';
+import { createSession, getUserWithPassword } from '$lib/server/utils/auth';
 import { verifyArgon2 } from '$lib/server/utils/hash';
 import { linkOAuthAccountWithToken } from '$lib/server/utils/oauth-link-token';
 import { signInSchema } from '$lib/zod/auth';
@@ -17,7 +17,7 @@ export const POST: RequestHandler = async ({ cookies, request }) => {
 
   const { username, password, oauthLinkToken } = form.data;
 
-  const user = await getUser(username);
+  const user = await getUserWithPassword(username);
   if (!user || !user.password) {
     form.message = { type: 'error', text: 'Invalid username or password' };
     return actionResult('failure', { form });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Stop exposing user password hashes in page data and API responses
- Introduces `PublicUser` and `PageUser` types in [`src/lib/db/types.ts`](https://github.com/johanohly/AirTrail/pull/617/files#diff-a97109ac8fce36242938748e3cdcd50fb220907e545e52431549ef3e40ea6384) that omit sensitive fields, and a new [`src/lib/server/utils/user.ts`](https://github.com/johanohly/AirTrail/pull/617/files#diff-20366cecdf412fee2b25766fa5a7dfd254da764cba71bb9bf53d2d0705b6fade) module with `toPublicUser`/`toPageUser` helpers
- Splits `getUser` into separate functions (`getUserWithPassword`, `getUserWithOAuthId`, `getUserPasswordHash`) so password hashes are only fetched in flows that require them
- Updates the root layout load and `user.list` tRPC handler to return only public fields, replacing the previous manual `Omit<User, 'password'>` stripping
- Removes `password` from Lucia user attributes so `locals.user` no longer carries the hash
- `OAuth.svelte` now uses `user.hasOAuthLinked` (a boolean derived server-side) instead of checking `user.oauthId` directly

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ea4cea.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->