### PR TITLE
fix: align username validation

### DIFF
--- a/src/lib/import/airtrail.ts
+++ b/src/lib/import/airtrail.ts
@@ -13,6 +13,7 @@ import {
   flightOptionalInformationSchema,
   flightSeatInformationSchema,
 } from '$lib/zod/flight';
+import { usernameSchema } from '$lib/zod/user';
 import { flightTrackInputSchema } from '$lib/track/schema';
 
 const dateTimePrimitive = z.string().datetime({ offset: true }).nullable();
@@ -52,14 +53,7 @@ const AirTrailFile = z.object({
   users: z
     .object({
       id: z.string().min(3),
-      username: z
-        .string()
-        .min(3, { message: 'Username must be at least 3 characters long' })
-        .max(20, { message: 'Username must be at most 20 characters long' })
-        .regex(/^\w+$/, {
-          message:
-            'Username can only contain letters, numbers, and underscores',
-        }),
+      username: usernameSchema,
       displayName: z.string().min(3),
     })
     .array()

--- a/src/lib/import/legacy-airtrail.ts
+++ b/src/lib/import/legacy-airtrail.ts
@@ -12,6 +12,7 @@ import { api } from '$lib/trpc';
 import { getAircraftByIcao } from '$lib/utils/data/aircraft';
 import { getAirlineByIcao } from '$lib/utils/data/airlines';
 import { getAirportByIcao } from '$lib/utils/data/airports/cache';
+import { usernameSchema } from '$lib/zod/user';
 
 const AirTrailFile = z.object({
   flights: z
@@ -73,14 +74,7 @@ const AirTrailFile = z.object({
   users: z
     .object({
       id: z.string().min(3),
-      username: z
-        .string()
-        .min(3, { message: 'Username must be at least 3 characters long' })
-        .max(20, { message: 'Username must be at most 20 characters long' })
-        .regex(/^\w+$/, {
-          message:
-            'Username can only contain letters, numbers, and underscores',
-        }),
+      username: usernameSchema,
       displayName: z.string().min(3),
     })
     .array()

--- a/src/lib/zod/user.ts
+++ b/src/lib/zod/user.ts
@@ -33,15 +33,18 @@ export type Preferences = z.infer<typeof preferencesSchema>;
 export const updatePreferencesSchema = preferencesSchema.partial();
 export type UpdatePreferences = z.infer<typeof updatePreferencesSchema>;
 
+export const usernameSchema = z
+  .string()
+  .nonempty()
+  .min(3, { message: 'Username must be at least 3 characters long' })
+  .max(20, { message: 'Username must be at most 20 characters long' })
+  .regex(/^[A-Za-z0-9._-]+$/, {
+    message:
+      'Username can only contain letters, numbers, periods, underscores, and hyphens',
+  });
+
 export const userSchema = z.object({
-  username: z
-    .string()
-    .nonempty()
-    .min(3, { message: 'Username must be at least 3 characters long' })
-    .max(20, { message: 'Username must be at most 20 characters long' })
-    .regex(/^\w+$/, {
-      message: 'Username can only contain letters, numbers, and underscores',
-    }),
+  username: usernameSchema,
   password: z.string().nonempty().min(8),
   displayName: z.string().nonempty().min(3),
   role: z.enum(['user', 'admin']).default('user'),

--- a/src/routes/api/oauth/callback/+server.ts
+++ b/src/routes/api/oauth/callback/+server.ts
@@ -19,6 +19,7 @@ import {
   createOAuthLinkToken,
   linkOAuthAccount,
 } from '$lib/server/utils/oauth-link-token';
+import { usernameSchema } from '$lib/zod/user';
 
 const CallbackSchema = z.object({
   url: z.string().url(),
@@ -129,6 +130,15 @@ export const POST: RequestHandler = async ({ cookies, request, locals }) => {
       return error(500, 'Username not provided');
     }
 
+    const username = usernameSchema.safeParse(profile.preferred_username);
+    if (!username.success) {
+      return error(
+        400,
+        username.error.issues[0]?.message ??
+          'Username provided by OAuth provider is invalid',
+      );
+    }
+
     const displayName =
       profile.name ??
       `${profile.given_name || ''} ${profile.family_name || ''}`;
@@ -136,7 +146,7 @@ export const POST: RequestHandler = async ({ cookies, request, locals }) => {
       .insertInto('user')
       .values({
         id: generateId(15),
-        username: profile.preferred_username,
+        username: username.data,
         displayName,
         oauthId: profile.sub,
         role: 'user',


### PR DESCRIPTION
Fixes #613

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align username validation to allow periods and hyphens across user creation and import
> - Extracts a shared `usernameSchema` in [`src/lib/zod/user.ts`](https://github.com/johanohly/AirTrail/pull/618/files#diff-c6f5f934356111ac3ecdf4c8026fdeac06d0688595e91fd7fcfacedaedeb935c) that allows letters, numbers, periods, underscores, and hyphens (regex `^[A-Za-z0-9._-]+$`, length 3–20).
> - Replaces inline username regexes in the AirTrail and legacy AirTrail import schemas with `usernameSchema`, so imported usernames are validated consistently.
> - Adds `usernameSchema` validation to the OAuth callback handler; invalid usernames now return HTTP 400 instead of creating a user with an unvalidated value.
> - Behavioral Change: usernames with periods or hyphens are now accepted where they were previously rejected; OAuth registration with an invalid username now fails with 400 instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d524b21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->