### PR TITLE
fix: AirTrail importer backwards-compatibility

### DIFF
--- a/docs/content/docs/features/export.mdx
+++ b/docs/content/docs/features/export.mdx
@@ -44,7 +44,8 @@ The CSV file contains the following columns:
 ### JSON
 
 <Callout>
-  The JSON format can be reimported into AirTrail using the import feature.
+  The JSON format can be reimported into AirTrail using the import feature. Use
+  the AirTrail importer for v3 exports and AirTrail (pre-v3) for legacy exports.
 </Callout>
 
 The JSON export option provides a more structured format that is ideal for developers or when integrating the data into
@@ -66,16 +67,60 @@ The JSON file follows this structure:
   "flights": [
     {
       "date": "YYYY-MM-DD",
-      "from": "ICAO_CODE",
-      "to": "ICAO_CODE",
+      "datePrecision": "day",
+      "from": {
+        "icao": "ICAO_CODE",
+        "iata": "IATA_CODE",
+        "name": "Airport Name",
+        "municipality": "City",
+        "type": "large_airport",
+        "lat": 55.0,
+        "lon": 12.0,
+        "continent": "EU",
+        "country": "DK",
+        "tz": "Europe/Copenhagen",
+        "custom": false
+      },
+      "to": {
+        "icao": "ICAO_CODE",
+        "iata": "IATA_CODE",
+        "name": "Airport Name",
+        "municipality": "City",
+        "type": "large_airport",
+        "lat": 53.0,
+        "lon": -6.0,
+        "continent": "EU",
+        "country": "IE",
+        "tz": "Europe/Dublin",
+        "custom": false
+      },
       "departure": "ISO_8601_DATETIME",
       "arrival": "ISO_8601_DATETIME",
+      "departureScheduled": "ISO_8601_DATETIME",
+      "arrivalScheduled": "ISO_8601_DATETIME",
+      "takeoffScheduled": "ISO_8601_DATETIME",
+      "takeoffActual": "ISO_8601_DATETIME",
+      "landingScheduled": "ISO_8601_DATETIME",
+      "landingActual": "ISO_8601_DATETIME",
       "duration": flight_duration_in_seconds,
       "flightNumber": "FLIGHT_NUMBER",
       "flightReason": "FLIGHT_REASON",
-      "airline": "ICAO_AIRLINE_CODE",
-      "aircraft": "ICAO_AIRCRAFT_TYPE",
+      "airline": {
+        "name": "Airline Name",
+        "icao": "ICAO_AIRLINE_CODE",
+        "iata": "IATA_AIRLINE_CODE",
+        "iconPath": null,
+        "sourceId": "airline-source-id"
+      },
+      "aircraft": {
+        "name": "Aircraft Type",
+        "icao": "ICAO_AIRCRAFT_TYPE"
+      },
       "aircraftReg": "AIRCRAFT_REGISTRATION",
+      "departureTerminal": "TERMINAL",
+      "departureGate": "GATE",
+      "arrivalTerminal": "TERMINAL",
+      "arrivalGate": "GATE",
       "note": "FLIGHT_NOTE",
       "seats": [
         {

--- a/src/lib/import/airtrail.test.ts
+++ b/src/lib/import/airtrail.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { processAirTrailFile } from './airtrail';
+
+const {
+  getAirportByIcao,
+  getAirlineByIcao,
+  getAirlineByName,
+  getAircraftByIcao,
+  getAircraftByName,
+  userListQuery,
+} = vi.hoisted(() => ({
+  getAirportByIcao: vi.fn(async (icao: string) => ({
+    id: 1,
+    icao,
+    tz: 'UTC',
+  })),
+  getAirlineByIcao: vi.fn(async (icao: string) => ({
+    id: 2,
+    icao,
+    name: `${icao} Airways`,
+  })),
+  getAirlineByName: vi.fn(async (name: string) => ({
+    id: 3,
+    icao: null,
+    name,
+  })),
+  getAircraftByIcao: vi.fn(async (icao: string) => ({
+    id: 4,
+    icao,
+    name: `${icao} Aircraft`,
+  })),
+  getAircraftByName: vi.fn(async (name: string) => ({
+    id: 5,
+    icao: null,
+    name,
+  })),
+  userListQuery: vi.fn(async () => [
+    {
+      id: 'local-user',
+      username: 'john',
+      displayName: 'John Local',
+    },
+  ]),
+}));
+
+vi.mock('$app/state', () => ({
+  page: {
+    data: {
+      user: {
+        id: 'local-user',
+        username: 'john',
+      },
+    },
+  },
+}));
+
+vi.mock('$lib/trpc', () => ({
+  api: {
+    user: {
+      list: {
+        query: userListQuery,
+      },
+    },
+  },
+}));
+
+vi.mock('$lib/utils/data/airports/cache', () => ({
+  getAirportByIcao,
+}));
+
+vi.mock('$lib/utils/data/airlines', () => ({
+  getAirlineByIcao,
+  getAirlineByName,
+}));
+
+vi.mock('$lib/utils/data/aircraft', () => ({
+  getAircraftByIcao,
+  getAircraftByName,
+}));
+
+const baseOptions = {
+  filterOwner: false,
+  airlineFromFlightNumber: false,
+};
+
+const exportedUsers = [
+  {
+    id: 'export-user',
+    username: 'john',
+    displayName: 'John Export',
+  },
+];
+
+const seat = {
+  userId: 'export-user',
+  guestName: null,
+  seat: 'window',
+  seatNumber: '12A',
+  seatClass: 'economy',
+};
+
+const flightBase = {
+  date: '2024-06-14',
+  departure: '2024-06-14T10:00:00.000Z',
+  arrival: '2024-06-14T12:00:00.000Z',
+  duration: 7200,
+  flightNumber: 'SK123',
+  aircraftReg: null,
+  flightReason: 'leisure',
+  note: null,
+  seats: [seat],
+};
+
+const airportObject = (icao: string, id?: number) => ({
+  ...(id ? { id } : {}),
+  type: 'large_airport',
+  name: `${icao} Airport`,
+  municipality: null,
+  lat: 55.0,
+  lon: 12.0,
+  continent: 'EU',
+  country: 'DK',
+  icao,
+  iata: null,
+  tz: 'UTC',
+  custom: false,
+});
+
+describe('processAirTrailFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('imports later v3 JSON exports with nested airport, airline, and aircraft objects', async () => {
+    const content = JSON.stringify({
+      users: exportedUsers,
+      flights: [
+        {
+          ...flightBase,
+          datePrecision: 'month',
+          from: airportObject('EKCH'),
+          to: airportObject('EIDW'),
+          airline: {
+            name: 'Scandinavian Airlines',
+            icao: 'SAS',
+            iata: 'SK',
+          },
+          aircraft: {
+            name: 'Airbus A320neo',
+            icao: 'A20N',
+          },
+          departureScheduled: '2024-06-14T09:45:00.000Z',
+          arrivalScheduled: null,
+          takeoffScheduled: null,
+          takeoffActual: null,
+          landingScheduled: null,
+          landingActual: '2024-06-14T11:58:00.000Z',
+        },
+      ],
+    });
+
+    const result = await processAirTrailFile(content, baseOptions);
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.unknownAirports).toEqual({});
+    expect(result.unknownAirlines).toEqual({});
+    expect(getAirportByIcao).toHaveBeenCalledWith('EKCH');
+    expect(getAirportByIcao).toHaveBeenCalledWith('EIDW');
+    expect(getAirlineByIcao).toHaveBeenCalledWith('SAS');
+    expect(getAircraftByIcao).toHaveBeenCalledWith('A20N');
+
+    const flight = result.flights[0]!;
+    expect(flight.datePrecision).toBe('month');
+    expect(flight.departureScheduled).toBe('2024-06-14T09:45:00.000Z');
+    expect(flight.landingActual).toBe('2024-06-14T11:58:00.000Z');
+    expect(flight.seats).toEqual([
+      {
+        ...seat,
+        userId: 'local-user',
+      },
+    ]);
+  });
+
+  it('imports v3.0 JSON exports with nested database IDs and no timetable fields', async () => {
+    const content = JSON.stringify({
+      users: exportedUsers,
+      flights: [
+        {
+          ...flightBase,
+          fromId: 10,
+          toId: 11,
+          airlineId: 12,
+          aircraftId: 13,
+          from: airportObject('EKCH', 10),
+          to: airportObject('EIDW', 11),
+          airline: {
+            id: 12,
+            name: 'Scandinavian Airlines',
+            icao: 'SAS',
+            iata: 'SK',
+          },
+          aircraft: {
+            id: 13,
+            name: 'Airbus A320neo',
+            icao: 'A20N',
+          },
+        },
+      ],
+    });
+
+    const result = await processAirTrailFile(content, baseOptions);
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0]?.from).toMatchObject({ icao: 'EKCH' });
+    expect(result.flights[0]?.to).toMatchObject({ icao: 'EIDW' });
+    expect(result.flights[0]?.datePrecision).toBe('day');
+    expect(result.flights[0]?.departureScheduled).toBeNull();
+    expect(result.flights[0]?.arrivalScheduled).toBeNull();
+    expect(result.flights[0]?.takeoffScheduled).toBeNull();
+    expect(result.flights[0]?.takeoffActual).toBeNull();
+    expect(result.flights[0]?.landingScheduled).toBeNull();
+    expect(result.flights[0]?.landingActual).toBeNull();
+  });
+
+  it('falls back to names when nested airline or aircraft objects have no ICAO code', async () => {
+    const content = JSON.stringify({
+      users: exportedUsers,
+      flights: [
+        {
+          ...flightBase,
+          from: airportObject('EKCH'),
+          to: airportObject('EIDW'),
+          airline: {
+            name: 'Private Operator',
+            icao: null,
+            iata: null,
+          },
+          aircraft: {
+            name: 'Unknown Aircraft',
+            icao: null,
+          },
+        },
+      ],
+    });
+
+    const result = await processAirTrailFile(content, baseOptions);
+
+    expect(result.flights).toHaveLength(1);
+    expect(getAirlineByName).toHaveBeenCalledWith('Private Operator');
+    expect(getAircraftByName).toHaveBeenCalledWith('Unknown Aircraft');
+    expect(result.flights[0]?.airline).toMatchObject({
+      name: 'Private Operator',
+    });
+    expect(result.flights[0]?.aircraft).toMatchObject({
+      name: 'Unknown Aircraft',
+    });
+  });
+});

--- a/src/lib/import/airtrail.ts
+++ b/src/lib/import/airtrail.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 
 import { page } from '$app/state';
-import { FlightDatePrecisions, type CreateFlight } from '$lib/db/types';
+import type { PlatformOptions } from '$lib/components/modals/settings/pages/import-page';
+import {
+  FlightDatePrecisions,
+  type Airline,
+  type Airport,
+  type CreateFlight,
+} from '$lib/db/types';
 import { api } from '$lib/trpc';
 import { getAircraftByIcao, getAircraftByName } from '$lib/utils/data/aircraft';
 import { getAirlineByIcao, getAirlineByName } from '$lib/utils/data/airlines';
@@ -16,15 +22,25 @@ import {
 import { usernameSchema } from '$lib/zod/user';
 import { flightTrackInputSchema } from '$lib/track/schema';
 
-const dateTimePrimitive = z.string().datetime({ offset: true }).nullable();
+const dateTimePrimitive = z
+  .string()
+  .datetime({ offset: true })
+  .nullable()
+  .optional();
+const airportRefSchema = z.union([
+  flightAirportSchema.omit({ id: true }),
+  z.object({ code: z.string().max(4) }),
+]);
+const airlineRefSchema = airlineSchema.omit({ id: true }).nullable();
+const aircraftRefSchema = aircraftSchema.omit({ id: true }).nullable();
 
 const AirTrailFile = z.object({
   flights: z
     .object({
       date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
       datePrecision: z.enum(FlightDatePrecisions).default('day'),
-      from: flightAirportSchema.omit({ id: true }),
-      to: flightAirportSchema.omit({ id: true }),
+      from: airportRefSchema,
+      to: airportRefSchema,
       departure: z
         .string()
         .datetime({ offset: true, message: 'Invalid datetime' })
@@ -40,8 +56,8 @@ const AirTrailFile = z.object({
       landingScheduled: dateTimePrimitive,
       landingActual: dateTimePrimitive,
       duration: z.number().int().positive().nullable(),
-      airline: airlineSchema.omit({ id: true }).nullable(),
-      aircraft: aircraftSchema.omit({ id: true }).nullable(),
+      airline: airlineRefSchema,
+      aircraft: aircraftRefSchema,
       track: flightTrackInputSchema.nullable().optional(),
     })
     .merge(
@@ -60,7 +76,57 @@ const AirTrailFile = z.object({
     .min(1, 'At least one user is required'),
 });
 
-import type { PlatformOptions } from '$lib/components/modals/settings/pages/import-page';
+type AirportRef = z.infer<typeof airportRefSchema>;
+type AirlineRef = z.infer<typeof airlineRefSchema>;
+type AircraftRef = z.infer<typeof aircraftRefSchema>;
+
+const getAirportCode = (airport: AirportRef) =>
+  'icao' in airport ? airport.icao : airport.code;
+
+const getAirlineCode = (airline: AirlineRef) => airline?.icao ?? null;
+
+const getAircraftCode = (aircraft: AircraftRef) => aircraft?.icao ?? null;
+
+const getAirlineName = (airline: AirlineRef) => airline?.name ?? null;
+
+const getAircraftName = (aircraft: AircraftRef) => aircraft?.name ?? null;
+
+const resolveAirport = async (
+  airport: AirportRef,
+  airportMapping?: Record<string, Airport>,
+) => {
+  const code = getAirportCode(airport);
+  return airportMapping?.[code] ?? (await getAirportByIcao(code));
+};
+
+const resolveAirline = async (
+  airline: AirlineRef,
+  airlineMapping?: Record<string, Airline>,
+) => {
+  if (!airline) return null;
+
+  const code = getAirlineCode(airline);
+  const name = getAirlineName(airline);
+  if (code) {
+    return airlineMapping?.[code] ?? (await getAirlineByIcao(code));
+  }
+  if (name) {
+    return await getAirlineByName(name);
+  }
+
+  return null;
+};
+
+const resolveAircraft = async (aircraft: AircraftRef) => {
+  if (!aircraft) return null;
+
+  const code = getAircraftCode(aircraft);
+  const name = getAircraftName(aircraft);
+  if (code) return await getAircraftByIcao(code);
+  if (name) return await getAircraftByName(name);
+
+  return null;
+};
 
 export const processAirTrailFile = async (
   input: string,
@@ -179,39 +245,25 @@ export const processAirTrailFile = async (
       });
     }
 
-    const mappedFrom = options.airportMapping?.[rawFlight.from.icao];
-    const mappedTo = options.airportMapping?.[rawFlight.to.icao];
-    const from = mappedFrom ?? (await getAirportByIcao(rawFlight.from.icao));
-    const to = mappedTo ?? (await getAirportByIcao(rawFlight.to.icao));
-
-    let airline = null;
-    if (rawFlight.airline) {
-      const mappedAirline = rawFlight.airline.icao
-        ? options.airlineMapping?.[rawFlight.airline.icao]
-        : undefined;
-      airline =
-        mappedAirline ||
-        (rawFlight.airline.icao
-          ? await getAirlineByIcao(rawFlight.airline.icao)
-          : await getAirlineByName(rawFlight.airline.name));
-    }
-
-    let aircraft = null;
-    if (rawFlight.aircraft) {
-      aircraft = rawFlight.aircraft.icao
-        ? await getAircraftByIcao(rawFlight.aircraft.icao)
-        : await getAircraftByName(rawFlight.aircraft.name);
-    }
+    const fromCode = getAirportCode(rawFlight.from);
+    const toCode = getAirportCode(rawFlight.to);
+    const airlineCode = getAirlineCode(rawFlight.airline);
+    const from = await resolveAirport(rawFlight.from, options.airportMapping);
+    const to = await resolveAirport(rawFlight.to, options.airportMapping);
+    const airline = await resolveAirline(
+      rawFlight.airline,
+      options.airlineMapping,
+    );
+    const aircraft = await resolveAircraft(rawFlight.aircraft);
 
     if (!from) {
-      addUnknownFlightIndex(unknownAirports, rawFlight.from.icao, flightIndex);
+      addUnknownFlightIndex(unknownAirports, fromCode, flightIndex);
     }
     if (!to) {
-      addUnknownFlightIndex(unknownAirports, rawFlight.to.icao, flightIndex);
+      addUnknownFlightIndex(unknownAirports, toCode, flightIndex);
     }
-    if (!airline && rawFlight.airline?.icao) {
-      const code = rawFlight.airline.icao;
-      addUnknownFlightIndex(unknownAirlines, code, flightIndex);
+    if (!airline && airlineCode) {
+      addUnknownFlightIndex(unknownAirlines, airlineCode, flightIndex);
     }
 
     flights.push({


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix AirTrail importer to support both v3 and pre-v3 JSON export formats
- Updates the AirTrail importer in [`airtrail.ts`](https://github.com/johanohly/AirTrail/pull/619/files#diff-d71ddff42fef01db48667118b40e70dc13f2f19265f03090584145bbb9d8cbd9) to handle v3 JSON exports where airports, airlines, and aircraft are nested objects rather than flat string codes.
- Adds helper functions (`resolveAirport`, `resolveAirline`, `resolveAircraft`) that resolve entities by ICAO code with optional mapping, falling back to name-based lookup when no ICAO code is present.
- Makes timetable fields (`departureScheduled`, `arrivalScheduled`, etc.) optional in the Zod schema so they can be omitted rather than requiring explicit `null`.
- Adds a test suite in [`airtrail.test.ts`](https://github.com/johanohly/AirTrail/pull/619/files#diff-28ca36a0bd254d74c6fde6639a19dc7dd261551221dcabb8b3580a35d98cbdbe) covering v3 imports with nested objects, v3.0 imports with DB IDs, and name-based fallback resolution.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5a0a477. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->