### PR TITLE
fix: allow scheduled-only future flights

### DIFF
--- a/src/lib/components/modals/add-flight/AddFlightModal.svelte
+++ b/src/lib/components/modals/add-flight/AddFlightModal.svelte
@@ -19,7 +19,7 @@
   } from '$lib/components/ui/modal';
   import { flightAddedState, openModalsState } from '$lib/state.svelte';
   import { trpc } from '$lib/trpc';
-  import { flightSchema } from '$lib/zod/flight';
+  import { flightFormSchema } from '$lib/zod/flight';
 
   let { open = $bindable() }: { open: boolean } = $props();
 
@@ -45,10 +45,10 @@
   };
 
   const form = superForm(
-    defaults<Infer<typeof flightSchema>>(zod(flightSchema)),
+    defaults<Infer<typeof flightFormSchema>>(zod(flightFormSchema)),
     {
       dataType: 'json',
-      validators: zod(flightSchema),
+      validators: zod(flightFormSchema),
       onSubmit({ cancel }) {
         $formData.customFields = toCustomFieldsPayload();
         if (!customFieldsModal?.validate()) {

--- a/src/lib/components/modals/edit-flight/EditFlightModal.svelte
+++ b/src/lib/components/modals/edit-flight/EditFlightModal.svelte
@@ -23,7 +23,7 @@
   import { api, trpc } from '$lib/trpc';
   import { type FlightData } from '$lib/utils';
   import { decomposeToLocal, isUsingAmPm } from '$lib/utils/datetime';
-  import { flightSchema } from '$lib/zod/flight';
+  import { flightFormSchema } from '$lib/zod/flight';
 
   let {
     flight,
@@ -174,11 +174,14 @@
   };
 
   const form = superForm(
-    defaults<Infer<typeof flightSchema>>(schemaFlight, zod(flightSchema)),
+    defaults<Infer<typeof flightFormSchema>>(
+      schemaFlight,
+      zod(flightFormSchema),
+    ),
     {
       dataType: 'json',
       id: Math.random().toString(36).substring(7),
-      validators: zod(flightSchema),
+      validators: zod(flightFormSchema),
       onSubmit({ cancel }) {
         $formData.id = flight.id;
         $formData.customFields = toCustomFieldsPayload();

--- a/src/lib/components/modals/flight-form/FlightForm.svelte
+++ b/src/lib/components/modals/flight-form/FlightForm.svelte
@@ -18,7 +18,7 @@
     form: SuperForm<FlightFormData>;
   } = $props();
 
-  const { form: formData } = form;
+  const { form: formData, errors } = form;
   type TimetableTab = 'scheduled' | 'actual';
 
   const MAX_DURATION_SECONDS = 24 * 60 * 60;
@@ -38,6 +38,28 @@
     'takeoffScheduledTime',
     'takeoffActualTime',
     'landingScheduledTime',
+    'landingActualTime',
+  ] as const;
+
+  const scheduledTimetableFields = [
+    'departureScheduled',
+    'departureScheduledTime',
+    'arrivalScheduled',
+    'arrivalScheduledTime',
+    'takeoffScheduled',
+    'takeoffScheduledTime',
+    'landingScheduled',
+    'landingScheduledTime',
+  ] as const;
+
+  const actualTimetableFields = [
+    'departure',
+    'departureTime',
+    'arrival',
+    'arrivalTime',
+    'takeoffActual',
+    'takeoffActualTime',
+    'landingActual',
     'landingActualTime',
   ] as const;
 
@@ -65,6 +87,45 @@
   let prevHasTimetableData = $state(false);
   let preferredMobileTab = $state<TimetableTab>('actual');
   let preferredMobileTabVersion = $state(0);
+  let revealedTimetableError = $state('');
+
+  const hasError = (field: keyof FlightFormData) => !!$errors[field];
+
+  const timetableErrorTab = $derived.by<TimetableTab | null>(() => {
+    if ($formData.datePrecision !== 'day') return null;
+
+    const hasScheduledErrors = scheduledTimetableFields.some(hasError);
+    if (hasScheduledErrors) return 'scheduled';
+
+    const hasActualErrors = actualTimetableFields.some(hasError);
+    if (hasActualErrors && (showTimetable || hasTimetableData)) {
+      return 'actual';
+    }
+
+    return null;
+  });
+
+  const timetableErrorSignature = $derived.by(() => {
+    return [...scheduledTimetableFields, ...actualTimetableFields]
+      .flatMap((field) =>
+        ($errors[field] ?? []).map((message) => `${field}:${message}`),
+      )
+      .join('|');
+  });
+
+  $effect(() => {
+    if (!timetableErrorTab) {
+      revealedTimetableError = '';
+      return;
+    }
+
+    if (timetableErrorSignature === revealedTimetableError) return;
+    revealedTimetableError = timetableErrorSignature;
+    showTimetable = true;
+    partialDateMode = false;
+    preferredMobileTab = timetableErrorTab;
+    preferredMobileTabVersion += 1;
+  });
 
   const clearDetailedTimetable = () => {
     formData.update((current) => ({

--- a/src/lib/zod/flight.ts
+++ b/src/lib/zod/flight.ts
@@ -49,8 +49,7 @@ export const flightDateTimeSchema = z.object({
   departure: z
     .string()
     .datetime({ offset: true, message: 'Select a departure date' })
-    .nullable()
-    .refine((value) => value !== null, 'Select a departure date'),
+    .nullable(),
   departureTime: timePrimitive,
   departureScheduled: dateTimePrimitive.nullable(),
   departureScheduledTime: timePrimitive,
@@ -132,5 +131,26 @@ export const flightSchema = flightAirportsSchema
   .merge(flightSeatInformationSchema)
   .merge(flightCustomFieldsSchema)
   .merge(flightTrackSchema);
+
+export const flightFormSchema = flightSchema.superRefine((data, ctx) => {
+  if (data.datePrecision !== 'day') {
+    if (!data.departure) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['departure'],
+        message: 'Select a departure date',
+      });
+    }
+    return;
+  }
+
+  if (!data.departure && !data.departureScheduled) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['departure'],
+      message: 'Select a departure date',
+    });
+  }
+});
 
 export type FlightFormData = z.infer<typeof flightSchema>;

--- a/src/lib/zod/flight.ts
+++ b/src/lib/zod/flight.ts
@@ -33,6 +33,36 @@ const timePrimitive = z
 
 const dateTimePrimitive = z.string().datetime({ offset: true });
 
+type FlightDepartureDateFields = {
+  datePrecision: (typeof FlightDatePrecisions)[number];
+  departure: string | null;
+  departureScheduled: string | null;
+};
+
+export const validateFlightDepartureDate = (
+  data: FlightDepartureDateFields,
+  ctx: z.RefinementCtx,
+) => {
+  if (data.datePrecision !== 'day') {
+    if (!data.departure) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['departure'],
+        message: 'Select a departure date',
+      });
+    }
+    return;
+  }
+
+  if (!data.departure && !data.departureScheduled) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['departure'],
+      message: 'Select a departure date',
+    });
+  }
+};
+
 export const flightAirportsSchema = z.object({
   from: flightAirportSchema
     .nullable()
@@ -132,25 +162,8 @@ export const flightSchema = flightAirportsSchema
   .merge(flightCustomFieldsSchema)
   .merge(flightTrackSchema);
 
-export const flightFormSchema = flightSchema.superRefine((data, ctx) => {
-  if (data.datePrecision !== 'day') {
-    if (!data.departure) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['departure'],
-        message: 'Select a departure date',
-      });
-    }
-    return;
-  }
-
-  if (!data.departure && !data.departureScheduled) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['departure'],
-      message: 'Select a departure date',
-    });
-  }
-});
+export const flightFormSchema = flightSchema.superRefine(
+  validateFlightDepartureDate,
+);
 
 export type FlightFormData = z.infer<typeof flightSchema>;

--- a/src/routes/api/flight/save/+server.ts
+++ b/src/routes/api/flight/save/+server.ts
@@ -10,7 +10,7 @@ import { apiError, unauthorized, validateApiKey } from '$lib/server/utils/api';
 import { validateAndSaveFlight } from '$lib/server/utils/flight';
 import { aircraftSchema } from '$lib/zod/aircraft';
 import { airlineSchema } from '$lib/zod/airline';
-import { flightSchema } from '$lib/zod/flight';
+import { flightSchema, validateFlightDepartureDate } from '$lib/zod/flight';
 
 const defaultFlight = {
   // from, to and departure are required
@@ -62,7 +62,8 @@ const saveApiFlightSchema = flightSchema
     z.object({
       airline: airlineSchema.shape.icao,
     }),
-  );
+  )
+  .superRefine(validateFlightDepartureDate);
 
 const dateTimeSchema = z.string().datetime({ offset: true });
 

--- a/src/routes/api/flight/save/form/+server.ts
+++ b/src/routes/api/flight/save/form/+server.ts
@@ -5,11 +5,11 @@ import type { RequestHandler } from './$types';
 
 import { validateAndSaveFlight } from '$lib/server/utils/flight';
 import { handleErrorActionResult } from '$lib/utils/forms';
-import { flightSchema } from '$lib/zod/flight';
+import { flightFormSchema } from '$lib/zod/flight';
 
 export const POST: RequestHandler = async ({ locals, request }) => {
   const formData = await request.formData();
-  const form = await superValidate(formData, zod(flightSchema));
+  const form = await superValidate(formData, zod(flightFormSchema));
   if (!form.valid) {
     return actionResult('failure', { form });
   }


### PR DESCRIPTION
Fixes #602

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow scheduled-only future flights by adding cross-field departure date validation
> - Introduces `flightFormSchema` in [flight.ts](https://github.com/johanohly/AirTrail/pull/620/files#diff-ce7814f051b32649b6647f0b462fb4d0771b2e1f30c2f6c50e2522205019c5ac) that adds cross-field departure validation: if `datePrecision` is not `'day'`, an actual departure is required; if it is `'day'`, at least one of actual or scheduled departure must be provided.
> - Removes the non-null constraint on `departure` from the field-level schema, deferring it to the new cross-field refinement.
> - Updates the add-flight and edit-flight modals and the save API endpoints to use `flightFormSchema` instead of `flightSchema`.
> - When timetable validation errors occur, [FlightForm.svelte](https://github.com/johanohly/AirTrail/pull/620/files#diff-d0a8f782d069ea3d0bfda6c1c512d126ccef9a5cb0bb3d4ff9518a6e17883701) now auto-opens the timetable section and switches to the tab (scheduled or actual) containing the errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf0ca94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->