### PR TITLE
feat: improve statistics drilldowns

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -186,12 +186,16 @@
     );
     if (index >= 0) page = Math.floor(index / flightsPerPage) + 1;
 
-    tick().then(() => {
+    const highlightFlight = () =>
       highlightElement(`#flight-list-row-${flightId}`, {
         duration: 1900,
         scrollOffset: -100,
         pulses: 3,
       }).catch(() => {});
+
+    tick().then(() => {
+      highlightFlight();
+      setTimeout(highlightFlight, 150);
     });
   });
 

--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -51,6 +51,8 @@
     showFilters = true,
     seatUserId,
     showCountryStats = true,
+    onOpenFlight,
+    pauseDrilldownNavigation = false,
   }: {
     open?: boolean;
     flights: FlightData[];
@@ -60,6 +62,8 @@
     showFilters?: boolean;
     seatUserId?: string;
     showCountryStats?: boolean;
+    onOpenFlight?: (flightId: number) => void;
+    pauseDrilldownNavigation?: boolean;
   } = $props();
 
   const showScopeBanner = $derived(flightScopeState.scope !== 'mine');
@@ -190,7 +194,7 @@
 
 <svelte:window
   onpopstate={() => {
-    if (!open) return;
+    if (!open || pauseDrilldownNavigation) return;
     if (activeContinent) {
       activeContinent = null;
     } else if (activeChart) {
@@ -198,6 +202,7 @@
     }
   }}
   onkeydown={(e) => {
+    if (pauseDrilldownNavigation) return;
     if (e.key !== 'Escape') return;
     if (activeContinent || activeChart) {
       history.back();
@@ -215,6 +220,7 @@
   drawerNoPadding={Boolean(activeChart || activeContinent)}
   closeOnEscape={false}
   closeButton={true}
+  handleBackButton={!pauseDrilldownNavigation}
 >
   {#if activeContinent}
     <BarChartDrillDown
@@ -228,6 +234,8 @@
       data={activeChartData}
       flights={completedFlights}
       onBack={() => history.back()}
+      {onOpenFlight}
+      {seatUserId}
     />
   {:else}
     <div class="space-y-4">

--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -52,7 +52,7 @@
     seatUserId,
     showCountryStats = true,
     onOpenFlight,
-    pauseDrilldownNavigation = false,
+    suppressEscapeNavigation = false,
   }: {
     open?: boolean;
     flights: FlightData[];
@@ -63,7 +63,7 @@
     seatUserId?: string;
     showCountryStats?: boolean;
     onOpenFlight?: (flightId: number) => void;
-    pauseDrilldownNavigation?: boolean;
+    suppressEscapeNavigation?: boolean;
   } = $props();
 
   const showScopeBanner = $derived(flightScopeState.scope !== 'mine');
@@ -144,6 +144,10 @@
     countriesByContinentDetails(visitedCountries),
   );
 
+  const pushDrilldownHistory = () => {
+    history.pushState({ statisticsDrilldown: true }, '');
+  };
+
   $effect(() => {
     const closedFromDrilldown =
       wasOpen && !open && (activeChart || activeContinent);
@@ -193,8 +197,8 @@
 </script>
 
 <svelte:window
-  onpopstate={() => {
-    if (!open || pauseDrilldownNavigation) return;
+  onpopstate={(event) => {
+    if (!open || event.state?.statisticsDrilldown) return;
     if (activeContinent) {
       activeContinent = null;
     } else if (activeChart) {
@@ -202,7 +206,7 @@
     }
   }}
   onkeydown={(e) => {
-    if (pauseDrilldownNavigation) return;
+    if (suppressEscapeNavigation) return;
     if (e.key !== 'Escape') return;
     if (activeContinent || activeChart) {
       history.back();
@@ -220,7 +224,6 @@
   drawerNoPadding={Boolean(activeChart || activeContinent)}
   closeOnEscape={false}
   closeButton={true}
-  handleBackButton={!pauseDrilldownNavigation}
 >
   {#if activeContinent}
     <BarChartDrillDown
@@ -320,7 +323,7 @@
         flights={completedFlights}
         onOpenChart={(key) => {
           activeChart = key;
-          history.pushState(null, '');
+          pushDrilldownHistory();
         }}
         {seatUserId}
       />
@@ -337,7 +340,7 @@
             class="cursor-pointer"
             onclick={() => {
               activeChart = 'visited-country-status';
-              history.pushState(null, '');
+              pushDrilldownHistory();
             }}
           >
             <PieChart title="Visited Country Status" data={countryStatusData} />
@@ -348,7 +351,7 @@
           data={countriesByContinentData}
           onBarClick={(continent) => {
             activeContinent = continent;
-            history.pushState(null, '');
+            pushDrilldownHistory();
           }}
         />
       {/if}

--- a/src/lib/components/modals/statistics/charts/ChartDrillDown.svelte
+++ b/src/lib/components/modals/statistics/charts/ChartDrillDown.svelte
@@ -1,32 +1,59 @@
 <script lang="ts">
-  import { ChartColumn } from '@o7/icon/lucide';
+  import {
+    ChartColumn,
+    ChevronDown,
+    Plane,
+    MapPin,
+    Route,
+  } from '@o7/icon/lucide';
   import { PieChart } from 'layerchart';
 
+  import FlightCard from '../../list-flights/FlightCard.svelte';
+
+  import { AirlineIcon } from '$lib/components/display';
+  import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
+  import { ContinentMap, type Airline, type Airport } from '$lib/db/types';
   import {
     type ChartKey,
+    type FlightChartKey,
     FLIGHT_CHARTS,
     COUNTRY_CHARTS,
   } from '$lib/stats/aggregations';
-  import { type FlightData } from '$lib/utils';
+  import { cn, type FlightData, toTitleCase } from '$lib/utils';
+
+  const FLIGHT_PREVIEW_LIMIT = 5;
 
   let {
     chartKey,
     data,
     flights,
     onBack,
+    onOpenFlight,
+    seatUserId,
   }: {
     chartKey: ChartKey;
     data: Record<string, number>;
     flights: FlightData[];
     onBack: () => void;
+    onOpenFlight?: (flightId: number) => void;
+    seatUserId?: string;
   } = $props();
+
+  type RowDetails = {
+    airline?: Airline | null;
+    airport?: Airport | null;
+    routeAirports?: { from: Airport | null; to: Airport | null };
+    subtitle?: string | null;
+    flights: FlightData[];
+  };
 
   const chartDef = $derived(
     chartKey in FLIGHT_CHARTS
       ? FLIGHT_CHARTS[chartKey as keyof typeof FLIGHT_CHARTS]
       : COUNTRY_CHARTS[chartKey as keyof typeof COUNTRY_CHARTS],
   );
+  const isFlightChart = $derived(chartKey in FLIGHT_CHARTS);
   const totalCount = $derived(Object.values(data).reduce((a, b) => a + b, 0));
   const sortedEntries = $derived(
     Object.entries(data).sort(([keyA, a], [keyB, b]) => {
@@ -35,6 +62,9 @@
       return b - a;
     }),
   );
+
+  let expandedKey: string | null = $state(null);
+  let expandedFlightListKeys: string[] = $state([]);
 
   const noData = $derived(totalCount === 0);
   const chartData = $derived.by(() => {
@@ -51,10 +81,228 @@
     if (totalCount === 0) return 0;
     return Math.round((value / totalCount) * 100);
   };
+
+  const colorAt = (index: number) =>
+    [
+      '#3b82f6',
+      '#6366f1',
+      '#8b5cf6',
+      '#a855f7',
+      '#d946ef',
+      '#ec4899',
+      '#f59e0b',
+      '#10b981',
+      '#06b6d4',
+      '#8b5cf6',
+    ][index % 10] as string;
+
+  const colorNextAt = (index: number) =>
+    [
+      '#6366f1',
+      '#8b5cf6',
+      '#a855f7',
+      '#d946ef',
+      '#ec4899',
+      '#f59e0b',
+      '#10b981',
+      '#06b6d4',
+      '#8b5cf6',
+      '#3b82f6',
+    ][index % 10] as string;
+
+  const rowColor = (key: string, index: number) =>
+    key === 'Others' || key === 'No Data' ? '#71717a' : colorAt(index);
+
+  const rowGradient = (key: string, index: number) =>
+    key === 'Others' || key === 'No Data'
+      ? '#71717a'
+      : `linear-gradient(45deg, ${colorAt(index)}, ${colorNextAt(index)})`;
+
+  const codeForAirport = (airport: Airport | null | undefined) =>
+    airport?.iata || airport?.icao || null;
+
+  const routeLabelForFlight = (flight: FlightData) => {
+    const fromCode = codeForAirport(flight.from);
+    const toCode = codeForAirport(flight.to);
+    if (!fromCode || !toCode) return null;
+    return `${fromCode}-${toCode}`;
+  };
+
+  const labelForFlight = (
+    flight: FlightData,
+    key: FlightChartKey,
+  ): string | null => {
+    switch (key) {
+      case 'airlines':
+        return flight.airline?.name ?? 'No Data';
+      case 'aircraft-models':
+        return flight.aircraft?.name ?? 'No Data';
+      case 'aircraft-regs':
+        return flight.aircraftReg ?? 'No Data';
+      case 'reason':
+        return flight.flightReason
+          ? toTitleCase(flight.flightReason)
+          : 'No Data';
+      case 'continents':
+        return flight.to?.continent
+          ? ContinentMap[flight.to.continent]
+          : 'No Data';
+      case 'routes':
+        return routeLabelForFlight(flight);
+      default:
+        return null;
+    }
+  };
+
+  const hasMatchingSeat = (
+    flight: FlightData,
+    field: 'seat' | 'seatClass',
+    key: string,
+  ) => {
+    const seats = seatUserId
+      ? flight.seats.filter((seat) => seat.userId === seatUserId)
+      : flight.seats;
+
+    if (key === 'No Data') {
+      if (seatUserId) {
+        return seats.length === 0 || seats.some((seat) => !seat[field]);
+      }
+      return seats.some((seat) => !seat[field]);
+    }
+
+    return seats.some(
+      (seat) => seat[field] && toTitleCase(seat[field]) === key,
+    );
+  };
+
+  const flightsForRow = (key: string): FlightData[] => {
+    if (!isFlightChart) return [];
+
+    const flightChartKey = chartKey as FlightChartKey;
+
+    switch (flightChartKey) {
+      case 'seat':
+        return flights.filter((flight) => hasMatchingSeat(flight, 'seat', key));
+      case 'seat-class':
+        return flights.filter((flight) =>
+          hasMatchingSeat(flight, 'seatClass', key),
+        );
+      case 'airports':
+        return flights.filter(
+          (flight) =>
+            codeForAirport(flight.from) === key ||
+            codeForAirport(flight.to) === key,
+        );
+      case 'routes':
+        return flights.filter((flight) => routeLabelForFlight(flight) === key);
+      default:
+        return flights.filter(
+          (flight) => labelForFlight(flight, flightChartKey) === key,
+        );
+    }
+  };
+
+  const airportForKey = (key: string) => {
+    for (const flight of flights) {
+      if (codeForAirport(flight.from) === key) return flight.from;
+      if (codeForAirport(flight.to) === key) return flight.to;
+    }
+    return null;
+  };
+
+  const airlineForKey = (key: string) =>
+    flights.find((flight) => flight.airline?.name === key)?.airline ?? null;
+
+  const routeAirportsForKey = (key: string) => {
+    const match = flights.find((flight) => routeLabelForFlight(flight) === key);
+    if (!match) return null;
+    return { from: match.from, to: match.to };
+  };
+
+  const airportSubtitle = (airport: Airport | null) => {
+    if (!airport) return null;
+    const location = [airport.municipality, airport.country?.toUpperCase()]
+      .filter(Boolean)
+      .join(', ');
+    return location || airport.name;
+  };
+
+  const rowDetailsFor = (key: string): RowDetails => {
+    const matchingFlights = flightsForRow(key);
+
+    if (!isFlightChart) {
+      return { flights: matchingFlights };
+    }
+
+    switch (chartKey as FlightChartKey) {
+      case 'airlines': {
+        const airline = airlineForKey(key);
+        return {
+          airline,
+          subtitle: [airline?.iata, airline?.icao].filter(Boolean).join(' / '),
+          flights: matchingFlights,
+        };
+      }
+      case 'airports': {
+        const airport = airportForKey(key);
+        return {
+          airport,
+          subtitle: airportSubtitle(airport),
+          flights: matchingFlights,
+        };
+      }
+      case 'routes': {
+        const routeAirports = routeAirportsForKey(key);
+        return {
+          routeAirports: routeAirports ?? undefined,
+          subtitle: routeAirports
+            ? `${routeAirports.from?.name ?? 'Unknown'} to ${routeAirports.to?.name ?? 'Unknown'}`
+            : null,
+          flights: matchingFlights,
+        };
+      }
+      case 'aircraft-models': {
+        const aircraft = flights.find(
+          (flight) => flight.aircraft?.name === key,
+        )?.aircraft;
+        return {
+          subtitle: aircraft?.icao ?? null,
+          flights: matchingFlights,
+        };
+      }
+      case 'aircraft-regs': {
+        const aircraft = flights.find(
+          (flight) => flight.aircraftReg === key,
+        )?.aircraft;
+        return {
+          subtitle: aircraft?.name ?? null,
+          flights: matchingFlights,
+        };
+      }
+      default:
+        return { flights: matchingFlights };
+    }
+  };
+
+  const rowDetails = $derived.by(
+    () =>
+      Object.fromEntries(
+        sortedEntries.map(([key]) => [key, rowDetailsFor(key)]),
+      ) as Record<string, RowDetails>,
+  );
+
+  const isFlightListExpanded = (key: string) =>
+    expandedFlightListKeys.includes(key);
+
+  const expandFlightList = (key: string) => {
+    if (isFlightListExpanded(key)) {
+      return;
+    }
+    expandedFlightListKeys = [...expandedFlightListKeys, key];
+  };
 </script>
 
 <div class="min-h-[80vh]">
-  <!-- Header -->
   <div class="border-b border-zinc-200 dark:border-zinc-700">
     <div class="flex flex-col justify-center p-6">
       <Button
@@ -74,11 +322,9 @@
     </div>
   </div>
 
-  <!-- Content -->
   <div class="p-6">
     <div class="max-w-7xl mx-auto">
       <div class="grid lg:grid-cols-2 gap-8 items-start">
-        <!-- Chart Section -->
         <div class="space-y-6">
           <div
             class="rounded-xl shadow-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden"
@@ -98,28 +344,12 @@
                   value="value"
                   cRange={noData
                     ? ['#3b82f650']
-                    : chartData.map((d, i) => {
-                        if (d.label === 'Others' || d.label === 'No Data')
-                          return '#71717a';
-                        return [
-                          '#3b82f6',
-                          '#6366f1',
-                          '#8b5cf6',
-                          '#a855f7',
-                          '#d946ef',
-                          '#ec4899',
-                          '#f59e0b',
-                          '#10b981',
-                          '#06b6d4',
-                          '#8b5cf6',
-                        ][i % 10] as string;
-                      })}
+                    : chartData.map((d, i) => rowColor(d.label, i))}
                 />
               </div>
             </div>
           </div>
 
-          <!-- Summary Stats -->
           <div class="grid grid-cols-2 gap-4">
             <div
               class="rounded-lg shadow border border-zinc-200 dark:border-zinc-700 p-4"
@@ -144,7 +374,6 @@
           </div>
         </div>
 
-        <!-- Data List Section -->
         <div
           class="rounded-xl shadow-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden"
         >
@@ -170,116 +399,148 @@
             {:else}
               <div class="divide-y divide-zinc-200 dark:divide-zinc-700">
                 {#each sortedEntries as [key, value], index (key)}
+                  {@const details = rowDetails[key] ?? { flights: [] }}
+                  {@const percentage = getPercentage(value)}
                   <div
-                    class="p-4 hover:bg-zinc-50 dark:hover:bg-zinc-700/50 transition-colors"
+                    class="hover:bg-zinc-50 dark:hover:bg-zinc-700/50 transition-colors"
                   >
-                    <div class="flex items-center justify-between">
-                      <div class="flex items-center gap-3">
-                        <div class="flex-shrink-0">
+                    <button
+                      type="button"
+                      class="w-full p-4 text-left"
+                      onclick={() => {
+                        if (isFlightChart) {
+                          expandedKey = expandedKey === key ? null : key;
+                        }
+                      }}
+                    >
+                      <div class="flex items-center justify-between gap-4">
+                        <div class="flex items-center gap-3 min-w-0">
+                          <div class="flex-shrink-0">
+                            {@render rowIcon(key, index, details)}
+                          </div>
+                          <div class="min-w-0">
+                            <div
+                              class="font-medium text-zinc-900 dark:text-zinc-100 truncate"
+                            >
+                              {key}
+                            </div>
+                            <div
+                              class="text-sm text-zinc-600 dark:text-zinc-400 truncate"
+                            >
+                              {#if details.subtitle}
+                                {details.subtitle}
+                              {:else if key !== 'No Data'}
+                                Rank #{index + 1}
+                              {:else}
+                                Missing details
+                              {/if}
+                            </div>
+                          </div>
+                        </div>
+                        <div class="flex items-center gap-3 shrink-0">
+                          <div class="text-right">
+                            <div
+                              class="font-bold text-lg text-zinc-900 dark:text-zinc-100"
+                            >
+                              {value}
+                            </div>
+                            <div
+                              class="text-sm text-zinc-600 dark:text-zinc-400"
+                            >
+                              {percentage}%
+                            </div>
+                          </div>
+                          {#if isFlightChart}
+                            <ChevronDown
+                              size={20}
+                              class={cn(
+                                'text-zinc-500 transition-transform',
+                                expandedKey === key && 'rotate-180',
+                              )}
+                            />
+                          {/if}
+                        </div>
+                      </div>
+                      <div class="mt-2">
+                        <div
+                          class="w-full bg-zinc-200 dark:bg-zinc-600 rounded-full h-2"
+                        >
                           <div
-                            class="w-3 h-3 rounded-full bg-gradient-to-r"
-                            style="background: {key === 'Others' ||
-                            key === 'No Data'
-                              ? '#71717a'
-                              : `linear-gradient(45deg,
-                                 ${
-                                   [
-                                     '#3b82f6',
-                                     '#6366f1',
-                                     '#8b5cf6',
-                                     '#a855f7',
-                                     '#d946ef',
-                                     '#ec4899',
-                                     '#f59e0b',
-                                     '#10b981',
-                                     '#06b6d4',
-                                     '#8b5cf6',
-                                   ][index % 10]
-                                 },
-                                 ${
-                                   [
-                                     '#6366f1',
-                                     '#8b5cf6',
-                                     '#a855f7',
-                                     '#d946ef',
-                                     '#ec4899',
-                                     '#f59e0b',
-                                     '#10b981',
-                                     '#06b6d4',
-                                     '#8b5cf6',
-                                     '#3b82f6',
-                                   ][index % 10]
-                                 })`}"
+                            class="h-2 rounded-full bg-gradient-to-r transition-all duration-300"
+                            style="width: {percentage}%; background: {rowGradient(
+                              key,
+                              index,
+                            )}"
                           ></div>
                         </div>
-                        <div>
-                          <div
-                            class="font-medium text-zinc-900 dark:text-zinc-100"
-                          >
-                            {key}
-                          </div>
-                          <div class="text-sm text-zinc-600 dark:text-zinc-400">
-                            {#if key !== 'No Data'}
-                              Rank #{index + 1}
-                            {/if}
-                          </div>
-                        </div>
                       </div>
-                      <div class="text-right">
+                    </button>
+
+                    {#if expandedKey === key && isFlightChart}
+                      {@const flightListExpanded = isFlightListExpanded(key)}
+                      {@const visibleFlights = flightListExpanded
+                        ? details.flights
+                        : details.flights.slice(0, FLIGHT_PREVIEW_LIMIT)}
+                      {@const hiddenFlightCount =
+                        details.flights.length - visibleFlights.length}
+                      <div class="px-4 pb-4">
                         <div
-                          class="font-bold text-lg text-zinc-900 dark:text-zinc-100"
+                          class="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 overflow-hidden"
                         >
-                          {value}
-                        </div>
-                        <div class="text-sm text-zinc-600 dark:text-zinc-400">
-                          {getPercentage(value)}%
+                          <div
+                            class="px-4 py-3 flex items-center justify-between gap-3 border-b border-zinc-200 dark:border-zinc-700"
+                          >
+                            <p
+                              class="text-sm font-medium text-zinc-900 dark:text-zinc-100"
+                            >
+                              Matching Flights
+                            </p>
+                            <Badge variant="outline">
+                              {details.flights.length}
+                            </Badge>
+                          </div>
+                          {#if details.flights.length}
+                            <div
+                              class="divide-y divide-zinc-200 dark:divide-zinc-700"
+                            >
+                              {#each visibleFlights as flight (flight.id)}
+                                {#if onOpenFlight}
+                                  <button
+                                    type="button"
+                                    class="w-full p-4 text-left transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                                    onclick={() => onOpenFlight(flight.id)}
+                                  >
+                                    <FlightCard {flight} />
+                                  </button>
+                                {:else}
+                                  <div class="p-4">
+                                    <FlightCard {flight} />
+                                  </div>
+                                {/if}
+                              {/each}
+                              {#if hiddenFlightCount > 0}
+                                <button
+                                  type="button"
+                                  class="flex min-h-14 w-full items-center justify-center px-4 py-3 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                                  onclick={() => expandFlightList(key)}
+                                >
+                                  Show {hiddenFlightCount} more {hiddenFlightCount ===
+                                  1
+                                    ? 'flight'
+                                    : 'flights'}
+                                </button>
+                              {/if}
+                            </div>
+                          {:else}
+                            <p
+                              class="p-4 text-sm text-zinc-600 dark:text-zinc-400"
+                            >
+                              No matching flights found.
+                            </p>
+                          {/if}
                         </div>
                       </div>
-                    </div>
-                    <!-- Progress bar -->
-                    <div class="mt-2">
-                      <div
-                        class="w-full bg-zinc-200 dark:bg-zinc-600 rounded-full h-2"
-                      >
-                        <div
-                          class="h-2 rounded-full bg-gradient-to-r transition-all duration-300"
-                          style="width: {getPercentage(
-                            value,
-                          )}%; background: {key === 'Others' ||
-                          key === 'No Data'
-                            ? '#71717a'
-                            : `linear-gradient(45deg,
-                            ${
-                              [
-                                '#3b82f6',
-                                '#6366f1',
-                                '#8b5cf6',
-                                '#a855f7',
-                                '#d946ef',
-                                '#ec4899',
-                                '#f59e0b',
-                                '#10b981',
-                                '#06b6d4',
-                                '#8b5cf6',
-                              ][index % 10]
-                            },
-                            ${
-                              [
-                                '#6366f1',
-                                '#8b5cf6',
-                                '#a855f7',
-                                '#d946ef',
-                                '#ec4899',
-                                '#f59e0b',
-                                '#10b981',
-                                '#06b6d4',
-                                '#8b5cf6',
-                                '#3b82f6',
-                              ][index % 10]
-                            })`}"
-                        ></div>
-                      </div>
-                    </div>
+                    {/if}
                   </div>
                 {/each}
               </div>
@@ -290,3 +551,73 @@
     </div>
   </div>
 </div>
+
+{#snippet rowIcon(key: string, index: number, details: RowDetails)}
+  {#if details.airline}
+    <div
+      class="size-10 flex items-center justify-center rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+    >
+      <AirlineIcon airline={details.airline} size={30} fallback="plane" />
+    </div>
+  {:else if details.airport}
+    <div
+      class="size-10 flex items-center justify-center rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 overflow-hidden"
+    >
+      {#if details.airport.country}
+        <img
+          src={`https://flagcdn.com/${details.airport.country.toLowerCase()}.svg`}
+          alt=""
+          title={details.airport.country.toUpperCase()}
+          class="h-5 w-7 object-cover"
+          loading="lazy"
+          decoding="async"
+        />
+      {:else}
+        <MapPin size={22} class="text-zinc-500" />
+      {/if}
+    </div>
+  {:else if details.routeAirports}
+    <div class="flex items-center -space-x-1">
+      {@render airportFlag(details.routeAirports.from)}
+      {@render airportFlag(details.routeAirports.to)}
+    </div>
+  {:else if chartKey === 'aircraft-models' || chartKey === 'aircraft-regs'}
+    <div
+      class="size-10 flex items-center justify-center rounded-lg text-white"
+      style="background: {rowGradient(key, index)}"
+    >
+      <Plane size={22} />
+    </div>
+  {:else if chartKey === 'routes'}
+    <div
+      class="size-10 flex items-center justify-center rounded-lg text-white"
+      style="background: {rowGradient(key, index)}"
+    >
+      <Route size={22} />
+    </div>
+  {:else}
+    <div
+      class="w-3 h-3 rounded-full bg-gradient-to-r"
+      style="background: {rowGradient(key, index)}"
+    ></div>
+  {/if}
+{/snippet}
+
+{#snippet airportFlag(airport: Airport | null)}
+  <div
+    class="size-8 flex items-center justify-center rounded-full border-2 border-white dark:border-zinc-900 bg-zinc-100 dark:bg-zinc-800 overflow-hidden"
+  >
+    {#if airport?.country}
+      <img
+        src={`https://flagcdn.com/${airport.country.toLowerCase()}.svg`}
+        alt=""
+        title={airport.country.toUpperCase()}
+        class="h-full w-full object-cover"
+        loading="lazy"
+        decoding="async"
+      />
+    {:else}
+      <MapPin size={16} class="text-zinc-500" />
+    {/if}
+  </div>
+{/snippet}

--- a/src/lib/components/ui/drawer/drawer-content.svelte
+++ b/src/lib/components/ui/drawer/drawer-content.svelte
@@ -31,6 +31,7 @@
         ? 'z-50 fixed bottom-0 left-0 right-0 flex flex-col'
         : 'z-50 fixed bottom-0 left-0 right-0 flex flex-col bg-background rounded-t-[10px] border-t',
       className,
+      'w-full max-w-none',
     )}
     {...restProps}
   >

--- a/src/lib/components/ui/modal/Modal.svelte
+++ b/src/lib/components/ui/modal/Modal.svelte
@@ -137,6 +137,8 @@
   );
 
   function handlePopstate(event: PopStateEvent) {
+    if (!handleBackButton) return;
+
     const isTopmostModal = peekModalHistory() === modalId;
     const wasTriggeredByThisModal = event.state?.modal === modalId;
     if (

--- a/src/lib/components/ui/modal/Modal.svelte
+++ b/src/lib/components/ui/modal/Modal.svelte
@@ -137,8 +137,6 @@
   );
 
   function handlePopstate(event: PopStateEvent) {
-    if (!handleBackButton) return;
-
     const isTopmostModal = peekModalHistory() === modalId;
     const wasTriggeredByThisModal = event.state?.modal === modalId;
     if (

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -22,6 +22,11 @@ export const focusFlightInList = (flightId: number) => {
   flightListFocusState.request += 1;
 };
 
+export const clearFlightListFocus = () => {
+  flightListFocusState.flightId = null;
+  flightListFocusState.request += 1;
+};
+
 export type SettingsTabId =
   | 'general'
   | 'preferences'

--- a/src/lib/utils/highlight.ts
+++ b/src/lib/utils/highlight.ts
@@ -66,6 +66,51 @@ export const cancelHighlight = (target: HighlightTarget) => {
   activeHighlights.get(element)?.();
 };
 
+const canScroll = (element: HTMLElement) => {
+  const style = window.getComputedStyle(element);
+  const overflowY = style.overflowY;
+  return (
+    (overflowY === 'auto' || overflowY === 'scroll') &&
+    element.scrollHeight > element.clientHeight
+  );
+};
+
+const findScrollContainer = (element: HTMLElement) => {
+  let parent = element.parentElement;
+
+  while (parent && parent !== document.body) {
+    if (canScroll(parent)) return parent;
+    parent = parent.parentElement;
+  }
+
+  return null;
+};
+
+const scrollElementIntoView = (
+  element: HTMLElement,
+  scrollOffset: number,
+  behavior: ScrollBehavior,
+) => {
+  const scrollContainer = findScrollContainer(element);
+
+  element.scrollIntoView({
+    block: 'center',
+    inline: 'nearest',
+    behavior,
+  });
+
+  if (!scrollContainer) {
+    if (scrollOffset !== 0) {
+      window.scrollBy({ top: scrollOffset, behavior });
+    }
+    return;
+  }
+
+  if (scrollOffset !== 0) {
+    scrollContainer.scrollBy({ top: scrollOffset, behavior });
+  }
+};
+
 export const highlightElement = (
   target: HighlightTarget,
   options: HighlightOptions = {},
@@ -89,11 +134,7 @@ export const highlightElement = (
     cancelHighlight(element);
 
     if (scroll) {
-      const rect = element.getBoundingClientRect();
-      window.scrollTo({
-        top: rect.top + window.scrollY + scrollOffset,
-        behavior: scrollBehavior,
-      });
+      scrollElementIntoView(element, scrollOffset, scrollBehavior);
     }
 
     const overlay = document.createElement('div');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,7 +19,11 @@
   import { MapDetailsPane } from '$lib/components/map-details';
   import { Map } from '$lib/components/map';
   import { ListFlightsModal, StatisticsModal } from '$lib/components/modals';
-  import { flightScopeState, openModalsState } from '$lib/state.svelte';
+  import {
+    flightScopeState,
+    focusFlightInList,
+    openModalsState,
+  } from '$lib/state.svelte';
   import { trpc } from '$lib/trpc';
   import { prepareFlightData } from '$lib/utils';
 
@@ -76,10 +80,32 @@
 
   const showPassengerDetails = $derived(flightScopeState.scope !== 'mine');
   const showCountryStats = $derived(flightScopeState.scope === 'mine');
+  let flightListOpenedFromStatistics = $state(false);
+  let releaseStatisticsNavigationPauseTimer: ReturnType<
+    typeof setTimeout
+  > | null = null;
 
   $effect(() => {
+    if (openModalsState.listFlights) {
+      if (releaseStatisticsNavigationPauseTimer) {
+        clearTimeout(releaseStatisticsNavigationPauseTimer);
+        releaseStatisticsNavigationPauseTimer = null;
+      }
+      return;
+    }
+
     if (!openModalsState.listFlights) {
       tempFilters = createDefaultTempFilters();
+    }
+
+    if (
+      flightListOpenedFromStatistics &&
+      !releaseStatisticsNavigationPauseTimer
+    ) {
+      releaseStatisticsNavigationPauseTimer = setTimeout(() => {
+        flightListOpenedFromStatistics = false;
+        releaseStatisticsNavigationPauseTimer = null;
+      }, 250);
     }
   });
 
@@ -117,6 +143,12 @@
       toast.error('Failed to delete flight', { id: toastId });
     }
   };
+
+  const openFlightInList = (flightId: number) => {
+    focusFlightInList(flightId);
+    flightListOpenedFromStatistics = true;
+    openModalsState.listFlights = true;
+  };
 </script>
 
 {#if !$rawFlights.isLoading}
@@ -140,6 +172,8 @@
   visitedCountries={showCountryStats ? visitedCountriesData : []}
   seatUserId={effectiveSeatUserId}
   {showCountryStats}
+  onOpenFlight={openFlightInList}
+  pauseDrilldownNavigation={flightListOpenedFromStatistics}
 />
 
 <Map bind:filters bind:tempFilters {flights} {filteredFlights} {flightTracks} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -81,31 +81,11 @@
   const showPassengerDetails = $derived(flightScopeState.scope !== 'mine');
   const showCountryStats = $derived(flightScopeState.scope === 'mine');
   let flightListOpenedFromStatistics = $state(false);
-  let releaseStatisticsNavigationPauseTimer: ReturnType<
-    typeof setTimeout
-  > | null = null;
 
   $effect(() => {
-    if (openModalsState.listFlights) {
-      if (releaseStatisticsNavigationPauseTimer) {
-        clearTimeout(releaseStatisticsNavigationPauseTimer);
-        releaseStatisticsNavigationPauseTimer = null;
-      }
-      return;
-    }
-
     if (!openModalsState.listFlights) {
       tempFilters = createDefaultTempFilters();
-    }
-
-    if (
-      flightListOpenedFromStatistics &&
-      !releaseStatisticsNavigationPauseTimer
-    ) {
-      releaseStatisticsNavigationPauseTimer = setTimeout(() => {
-        flightListOpenedFromStatistics = false;
-        releaseStatisticsNavigationPauseTimer = null;
-      }, 250);
+      flightListOpenedFromStatistics = false;
     }
   });
 
@@ -145,6 +125,7 @@
   };
 
   const openFlightInList = (flightId: number) => {
+    tempFilters = createDefaultTempFilters();
     focusFlightInList(flightId);
     flightListOpenedFromStatistics = true;
     openModalsState.listFlights = true;
@@ -173,7 +154,8 @@
   seatUserId={effectiveSeatUserId}
   {showCountryStats}
   onOpenFlight={openFlightInList}
-  pauseDrilldownNavigation={flightListOpenedFromStatistics}
+  suppressEscapeNavigation={flightListOpenedFromStatistics &&
+    openModalsState.listFlights}
 />
 
 <Map bind:filters bind:tempFilters {flights} {filteredFlights} {flightTracks} />

--- a/src/routes/share/[slug]/+page.svelte
+++ b/src/routes/share/[slug]/+page.svelte
@@ -12,7 +12,7 @@
   import type { AppRouter } from '$lib/server/routes/_app';
   import type { FlightTrackRow } from '$lib/track/schema';
   import { ListFlightsModal, StatisticsModal } from '$lib/components/modals';
-  import { focusFlightInList } from '$lib/state.svelte';
+  import { clearFlightListFocus, focusFlightInList } from '$lib/state.svelte';
   import { trpc } from '$lib/trpc';
   import { prepareFlightData } from '$lib/utils';
 
@@ -99,6 +99,12 @@
     if (!showFlightList) {
       flightListOpenedFromStatistics = false;
     }
+  });
+
+  $effect(() => {
+    return () => {
+      clearFlightListFocus();
+    };
   });
 </script>
 

--- a/src/routes/share/[slug]/+page.svelte
+++ b/src/routes/share/[slug]/+page.svelte
@@ -85,9 +85,6 @@
   let showFlightList = $state(false);
   let showStatistics = $state(false);
   let flightListOpenedFromStatistics = $state(false);
-  let releaseStatisticsNavigationPauseTimer: ReturnType<
-    typeof setTimeout
-  > | null = null;
   let filters: FlightFilters = $state(createDefaultFilters());
 
   const shareSettings = $derived($shareQuery.data?.settings);
@@ -99,22 +96,8 @@
   };
 
   $effect(() => {
-    if (showFlightList) {
-      if (releaseStatisticsNavigationPauseTimer) {
-        clearTimeout(releaseStatisticsNavigationPauseTimer);
-        releaseStatisticsNavigationPauseTimer = null;
-      }
-      return;
-    }
-
-    if (
-      flightListOpenedFromStatistics &&
-      !releaseStatisticsNavigationPauseTimer
-    ) {
-      releaseStatisticsNavigationPauseTimer = setTimeout(() => {
-        flightListOpenedFromStatistics = false;
-        releaseStatisticsNavigationPauseTimer = null;
-      }, 250);
+    if (!showFlightList) {
+      flightListOpenedFromStatistics = false;
     }
   });
 </script>
@@ -206,7 +189,8 @@
       onOpenFlight={shareSettings.showFlightList
         ? openSharedFlightInList
         : undefined}
-      pauseDrilldownNavigation={flightListOpenedFromStatistics}
+      suppressEscapeNavigation={flightListOpenedFromStatistics &&
+        showFlightList}
     />
   {/if}
 {:else if shareSettings}

--- a/src/routes/share/[slug]/+page.svelte
+++ b/src/routes/share/[slug]/+page.svelte
@@ -12,6 +12,7 @@
   import type { AppRouter } from '$lib/server/routes/_app';
   import type { FlightTrackRow } from '$lib/track/schema';
   import { ListFlightsModal, StatisticsModal } from '$lib/components/modals';
+  import { focusFlightInList } from '$lib/state.svelte';
   import { trpc } from '$lib/trpc';
   import { prepareFlightData } from '$lib/utils';
 
@@ -83,9 +84,39 @@
 
   let showFlightList = $state(false);
   let showStatistics = $state(false);
+  let flightListOpenedFromStatistics = $state(false);
+  let releaseStatisticsNavigationPauseTimer: ReturnType<
+    typeof setTimeout
+  > | null = null;
   let filters: FlightFilters = $state(createDefaultFilters());
 
   const shareSettings = $derived($shareQuery.data?.settings);
+
+  const openSharedFlightInList = (flightId: number) => {
+    focusFlightInList(flightId);
+    flightListOpenedFromStatistics = true;
+    showFlightList = true;
+  };
+
+  $effect(() => {
+    if (showFlightList) {
+      if (releaseStatisticsNavigationPauseTimer) {
+        clearTimeout(releaseStatisticsNavigationPauseTimer);
+        releaseStatisticsNavigationPauseTimer = null;
+      }
+      return;
+    }
+
+    if (
+      flightListOpenedFromStatistics &&
+      !releaseStatisticsNavigationPauseTimer
+    ) {
+      releaseStatisticsNavigationPauseTimer = setTimeout(() => {
+        flightListOpenedFromStatistics = false;
+        releaseStatisticsNavigationPauseTimer = null;
+      }, 250);
+    }
+  });
 </script>
 
 <svelte:head>
@@ -172,6 +203,10 @@
       {filters}
       showFilters={false}
       showCountryStats={false}
+      onOpenFlight={shareSettings.showFlightList
+        ? openSharedFlightInList
+        : undefined}
+      pauseDrilldownNavigation={flightListOpenedFromStatistics}
     />
   {/if}
 {:else if shareSettings}


### PR DESCRIPTION
Implements #591

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add expandable flight drilldowns to the statistics modal
> - Drilldown rows in [ChartDrillDown.svelte](https://github.com/johanohly/AirTrail/pull/621/files#diff-943f244d6ee0d7a77e548f5b831f7213726cfb72174f6ea3d3f5b42c1c9174c9) are now expandable, showing matching flights with icons, progress bars, and a paginated flight list preview.
> - Clicking a flight in the drilldown opens the flight list modal focused on that flight, wired through the root and share page components via a new `onOpenFlight` callback.
> - A new `suppressEscapeNavigation` prop on [StatisticsModal.svelte](https://github.com/johanohly/AirTrail/pull/621/files#diff-ad2fff863557bb0584761c7e246e2a4e9c8e935ed45e5aeb4590330f56f80c9e) prevents Escape from closing statistics while the flight list modal is open on top.
> - [highlightElement](https://github.com/johanohly/AirTrail/pull/621/files#diff-e10149f90f64506229d9dede8b50ab9176496d5117a9bb538e69eb79af160824) now scrolls within the nearest scrollable container rather than always using `window.scrollTo`, fixing highlight behavior inside nested scroll regions.
> - The share page respects `shareSettings.showFlightList` before exposing the `onOpenFlight` callback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36e72d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->