### PR TITLE
fix: drop excessive link headers

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -61,4 +61,20 @@ const authHandle: Handle = async ({ event, resolve }) => {
   return resolve(event);
 };
 
-export const handle: Handle = sequence(authHandle);
+/*
+ * https://github.com/sveltejs/kit/issues/11084
+ * Fixed in sveltekit v3, by gating Link header generation behind config.kit.output.linkHeaderPreload
+ */
+const dropExcessiveLinkHeaderHandle: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+
+  if (Number(response.headers.get('Link')?.length) > 3700) {
+    response.headers.delete('Link');
+  }
+  return response;
+};
+
+export const handle: Handle = sequence(
+  authHandle,
+  dropExcessiveLinkHeaderHandle,
+);


### PR DESCRIPTION
Fixes #624

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop oversized `Link` headers exceeding 3700 characters in server hooks
> SvelteKit can generate excessively long `Link` headers for preloading, which causes issues fixed upstream in v3. A new `dropExcessiveLinkHeaderHandle` hook in [hooks.server.ts](https://github.com/johanohly/AirTrail/pull/626/files#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4a) checks the `Link` header length after response generation and removes it if it exceeds 3700 characters. The hook is added to the handle chain after `authHandle`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9596c51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->