### PR TITLE
feat: add system theme option

### DIFF
--- a/src/lib/components/modals/settings/pages/AppearancePage.svelte
+++ b/src/lib/components/modals/settings/pages/AppearancePage.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
   import { page } from '$app/state';
-  import { mode, setMode } from 'mode-watcher';
+  import { setMode, userPrefersMode } from 'mode-watcher';
+  import type { Snippet } from 'svelte';
   import { toast } from 'svelte-sonner';
   import { defaults, type Infer, superForm } from 'sveltekit-superforms';
   import { zod } from 'sveltekit-superforms/adapters';
@@ -21,6 +22,8 @@
   } from '$lib/map/app-style';
   import { appConfig } from '$lib/state.svelte';
   import { mapConfigSchema } from '$lib/zod/config';
+
+  type ColorThemeMode = 'system' | 'light' | 'dark';
 
   const form = superForm(
     defaults<Infer<typeof mapConfigSchema>>(
@@ -69,7 +72,129 @@
       currentDarkStyleUrl !== savedDarkStyleUrl
     );
   });
+
+  const isColorThemeMode = (value: string): value is ColorThemeMode =>
+    value === 'system' || value === 'light' || value === 'dark';
+
+  const setThemeMode = (value: string) => {
+    if (isColorThemeMode(value)) {
+      setMode(value);
+    }
+  };
 </script>
+
+{#snippet mockup(theme: Exclude<ColorThemeMode, 'system'>)}
+  <div
+    class={theme === 'dark'
+      ? 'space-y-2 rounded-sm bg-slate-950 p-2'
+      : 'space-y-2 rounded-sm bg-[#ecedef] p-2'}
+  >
+    <div
+      class={theme === 'dark'
+        ? 'space-y-2 rounded-md bg-slate-800 p-2 shadow-xs'
+        : 'space-y-2 rounded-md bg-white p-2 shadow-xs'}
+    >
+      <div
+        class={theme === 'dark'
+          ? 'h-2 w-[80px] max-w-[70%] rounded-lg bg-slate-400'
+          : 'h-2 w-[80px] max-w-[70%] rounded-lg bg-[#ecedef]'}
+      />
+      <div
+        class={theme === 'dark'
+          ? 'h-2 w-[100px] max-w-[85%] rounded-lg bg-slate-400'
+          : 'h-2 w-[100px] max-w-[85%] rounded-lg bg-[#ecedef]'}
+      />
+    </div>
+    <div
+      class={theme === 'dark'
+        ? 'flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-xs'
+        : 'flex items-center space-x-2 rounded-md bg-white p-2 shadow-xs'}
+    >
+      <div
+        class={theme === 'dark'
+          ? 'h-4 w-4 rounded-full bg-slate-400'
+          : 'h-4 w-4 rounded-full bg-[#ecedef]'}
+      />
+      <div
+        class={theme === 'dark'
+          ? 'h-2 max-w-[100px] flex-1 rounded-lg bg-slate-400'
+          : 'h-2 max-w-[100px] flex-1 rounded-lg bg-[#ecedef]'}
+      />
+    </div>
+    <div
+      class={theme === 'dark'
+        ? 'flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-xs'
+        : 'flex items-center space-x-2 rounded-md bg-white p-2 shadow-xs'}
+    >
+      <div
+        class={theme === 'dark'
+          ? 'h-4 w-4 rounded-full bg-slate-400'
+          : 'h-4 w-4 rounded-full bg-[#ecedef]'}
+      />
+      <div
+        class={theme === 'dark'
+          ? 'h-2 max-w-[100px] flex-1 rounded-lg bg-slate-400'
+          : 'h-2 max-w-[100px] flex-1 rounded-lg bg-[#ecedef]'}
+      />
+    </div>
+  </div>
+{/snippet}
+
+{#snippet themeCard(
+  value: ColorThemeMode,
+  label: string,
+  preview: Snippet,
+  className = '',
+)}
+  <Label
+    class={`min-w-0 w-full cursor-pointer [&:has([data-state=checked])>div]:border-primary ${className}`}
+  >
+    <RadioGroup.Item {value} class="sr-only" />
+    <div
+      class="border-muted items-center overflow-hidden rounded-md border-2 p-1 transition-colors hover:border-primary/40"
+    >
+      {@render preview()}
+    </div>
+    <span class="block w-full p-2 text-center font-normal">{label}</span>
+  </Label>
+{/snippet}
+
+{#snippet lightPreview()}
+  {@render mockup('light')}
+{/snippet}
+
+{#snippet darkPreview()}
+  {@render mockup('dark')}
+{/snippet}
+
+{#snippet systemPreview()}
+  <div class="grid grid-cols-2 overflow-hidden rounded-sm bg-[#ecedef]">
+    <div class="space-y-1 p-1.5">
+      <div class="space-y-1 rounded-md bg-white p-1.5 shadow-xs">
+        <div class="h-1.5 w-[72px] max-w-[70%] rounded-lg bg-[#ecedef]" />
+        <div class="h-1.5 w-[96px] max-w-[85%] rounded-lg bg-[#ecedef]" />
+      </div>
+      <div
+        class="flex items-center space-x-1.5 rounded-md bg-white p-1.5 shadow-xs"
+      >
+        <div class="h-3 w-3 rounded-full bg-[#ecedef]" />
+        <div class="h-1.5 max-w-[88px] flex-1 rounded-lg bg-[#ecedef]" />
+      </div>
+    </div>
+    <div class="space-y-1 bg-slate-950 p-1.5">
+      <div class="space-y-1 rounded-md bg-slate-800 p-1.5 shadow-xs">
+        <div class="h-1.5 w-[72px] max-w-[70%] rounded-lg bg-slate-400" />
+        <div class="h-1.5 w-[96px] max-w-[85%] rounded-lg bg-slate-400" />
+      </div>
+      <div
+        class="flex items-center space-x-1.5 rounded-md bg-slate-800 p-1.5 shadow-xs"
+      >
+        <div class="h-3 w-3 rounded-full bg-slate-400" />
+        <div class="h-1.5 max-w-[88px] flex-1 rounded-lg bg-slate-400" />
+      </div>
+    </div>
+  </div>
+{/snippet}
 
 <PageHeader
   title="Appearance"
@@ -82,66 +207,13 @@
         By default, the application will use the system's theme.
       </p>
       <RadioGroup.Root
-        value={mode.current}
-        onValueChange={(v) => setMode(v)}
-        class="flex flex-col md:flex-row"
+        value={userPrefersMode.current}
+        onValueChange={setThemeMode}
+        class="grid min-w-0 grid-cols-1 sm:grid-cols-2"
       >
-        <Label
-          class="w-full cursor-pointer [&:has([data-state=checked])>div]:border-primary"
-        >
-          <RadioGroup.Item value="dark" class="sr-only" />
-          <div
-            class="border-muted bg-popover hover:bg-accent hover:text-accent-foreground items-center rounded-md border-2 p-1"
-          >
-            <div class="space-y-2 rounded-sm bg-slate-950 p-2">
-              <div class="space-y-2 rounded-md bg-slate-800 p-2 shadow-xs">
-                <div class="h-2 w-[80px] rounded-lg bg-slate-400" />
-                <div class="h-2 w-[100px] rounded-lg bg-slate-400" />
-              </div>
-              <div
-                class="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-xs"
-              >
-                <div class="h-4 w-4 rounded-full bg-slate-400" />
-                <div class="h-2 w-[100px] rounded-lg bg-slate-400" />
-              </div>
-              <div
-                class="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-xs"
-              >
-                <div class="h-4 w-4 rounded-full bg-slate-400" />
-                <div class="h-2 w-[100px] rounded-lg bg-slate-400" />
-              </div>
-            </div>
-          </div>
-          <span class="block w-full p-2 text-center font-normal"> Dark </span>
-        </Label>
-        <Label
-          class="w-full cursor-pointer [&:has([data-state=checked])>div]:border-primary"
-        >
-          <RadioGroup.Item value="light" class="sr-only" />
-          <div
-            class="border-muted hover:border-accent items-center rounded-md border-2 p-1"
-          >
-            <div class="space-y-2 rounded-sm bg-[#ecedef] p-2">
-              <div class="space-y-2 rounded-md bg-white p-2 shadow-xs">
-                <div class="h-2 w-[80px] rounded-lg bg-[#ecedef]" />
-                <div class="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
-              </div>
-              <div
-                class="flex items-center space-x-2 rounded-md bg-white p-2 shadow-xs"
-              >
-                <div class="h-4 w-4 rounded-full bg-[#ecedef]" />
-                <div class="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
-              </div>
-              <div
-                class="flex items-center space-x-2 rounded-md bg-white p-2 shadow-xs"
-              >
-                <div class="h-4 w-4 rounded-full bg-[#ecedef]" />
-                <div class="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
-              </div>
-            </div>
-          </div>
-          <span class="block w-full p-2 text-center font-normal"> Light </span>
-        </Label>
+        {@render themeCard('system', 'System', systemPreview, 'sm:col-span-2')}
+        {@render themeCard('light', 'Light', lightPreview)}
+        {@render themeCard('dark', 'Dark', darkPreview)}
       </RadioGroup.Root>
     </div>
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add 'System' theme option to the appearance settings page
- Adds a third 'System' radio option alongside 'Light' and 'Dark' in [AppearancePage.svelte](https://github.com/johanohly/AirTrail/pull/627/files#diff-47c9a0a1d8961c297912616090fc3dbf5ccb96ab38892ab5e33c6b864e2d4ca7), bound to `userPrefersMode` from `mode-watcher`.
- Replaces the previous plain label-based options with styled preview cards that render mockup UI in the selected theme.
- The system preview shows a split light/dark mockup; a type guard ensures only valid mode values are passed to `setMode`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f7c14c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->