### PR TITLE
fix: correct airport last visit date and add next visit

### DIFF
--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -118,32 +118,26 @@
     </div>
   </div>
 
-  {#if lastVisitLabel || nextVisitLabel}
+  {#if lastVisitLabel && nextVisitLabel}
     <div
       class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-3 text-xs text-muted-foreground"
     >
-      {#if lastVisitLabel}
+      <span>
+        last visit <span class="text-foreground">{lastVisitLabel}</span>
+      </span>
+      <span class="inline-flex items-center gap-2">
+        <span aria-hidden="true">·</span>
         <span>
-          last visit <span class="text-foreground">{lastVisitLabel}</span>
+          next visit <span class="text-foreground">{nextVisitLabel}</span>
         </span>
-      {/if}
-      {#if nextVisitLabel}
-        <span class="inline-flex items-center gap-2">
-          {#if lastVisitLabel}
-            <span aria-hidden="true">·</span>
-          {/if}
-          <span>
-            next visit <span class="text-foreground">{nextVisitLabel}</span>
-          </span>
-        </span>
-      {/if}
+      </span>
     </div>
   {/if}
 
   <div
     class={cn(
       'flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground',
-      lastVisitLabel || nextVisitLabel ? 'mt-1' : 'mt-3',
+      lastVisitLabel && nextVisitLabel ? 'mt-1' : 'mt-3',
     )}
   >
     <span>
@@ -161,5 +155,16 @@
         routes
       </span>
     </span>
+    {#if Boolean(lastVisitLabel) !== Boolean(nextVisitLabel)}
+      <span class="inline-flex items-center gap-2">
+        <span aria-hidden="true">·</span>
+        <span>
+          {lastVisitLabel ? 'last' : 'next'} visit
+          <span class="text-foreground">
+            {lastVisitLabel ?? nextVisitLabel}
+          </span>
+        </span>
+      </span>
+    {/if}
   </div>
 </section>

--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -3,7 +3,11 @@
   import NumberFlow from '@number-flow/svelte';
 
   import { cn, type FlightData } from '$lib/utils';
-  import { formatAsFlightDate, parseLocalizeISO } from '$lib/utils/datetime';
+  import {
+    formatAsFlightDate,
+    getFlightDateRange,
+    parseLocalizeISO,
+  } from '$lib/utils/datetime';
 
   let {
     flights,
@@ -44,9 +48,15 @@
         const exact =
           actual ??
           (scheduled ? parseLocalizeISO(scheduled, tz ?? 'UTC') : null);
-        const start = exact ?? flight.dateStart;
-        const end = exact ?? flight.dateEnd;
-        const date = exact ?? flight.date;
+        const range = exact
+          ? { start: exact, end: exact }
+          : getFlightDateRange(
+              flight.raw.date,
+              flight.datePrecision,
+              tz ?? 'UTC',
+            );
+        const { start, end } = range;
+        const date = exact ?? start;
         if (!start || !end || !date) continue;
 
         const label = formatAsFlightDate(

--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -1,20 +1,70 @@
 <script lang="ts">
   import { PlaneLanding, PlaneTakeoff } from '@o7/icon/lucide';
   import NumberFlow from '@number-flow/svelte';
-  import { isAfter, isBefore } from 'date-fns';
 
   import { cn, type FlightData } from '$lib/utils';
-  import { formatAsFlightDate, nowIn } from '$lib/utils/datetime';
+  import { formatAsFlightDate, parseLocalizeISO } from '$lib/utils/datetime';
 
   let {
     flights,
     airportId,
     airlineCount,
+    now,
   }: {
     flights: FlightData[];
     airportId: number;
     airlineCount: number;
+    now: Date;
   } = $props();
+
+  type Visit = { label: string; time: number };
+
+  const getVisitSummary = (flights: FlightData[], id: number, now: Date) => {
+    let last: Visit | null = null;
+    let next: Visit | null = null;
+
+    for (const flight of flights) {
+      const touches = [
+        [
+          flight.from?.id === id,
+          flight.departure,
+          flight.departureScheduled,
+          flight.from?.tz,
+        ],
+        [
+          flight.to?.id === id,
+          flight.arrival,
+          flight.arrivalScheduled,
+          flight.to?.tz,
+        ],
+      ] as const;
+
+      for (const [matches, actual, scheduled, tz] of touches) {
+        if (!matches) continue;
+        const exact =
+          actual ??
+          (scheduled ? parseLocalizeISO(scheduled, tz ?? 'UTC') : null);
+        const start = exact ?? flight.dateStart;
+        const end = exact ?? flight.dateEnd;
+        const date = exact ?? flight.date;
+        if (!start || !end || !date) continue;
+
+        const label = formatAsFlightDate(
+          date,
+          flight.datePrecision ?? 'day',
+          false,
+          true,
+        );
+
+        if (end < now && (!last || end.getTime() > last.time)) {
+          last = { label, time: end.getTime() };
+        } else if (start > now && (!next || start.getTime() < next.time)) {
+          next = { label, time: start.getTime() };
+        }
+      }
+    }
+    return { last, next };
+  };
 
   const departures = $derived(
     flights.filter((f) => f.from?.id === airportId).length,
@@ -33,58 +83,9 @@
     return set.size;
   });
 
-  // The moment this flight actually touches the airport: landing time when
-  // arriving here, takeoff time when departing from here.
-  const touchTime = (f: FlightData) =>
-    (f.to?.id === airportId
-      ? (f.arrival ?? f.dateEnd)
-      : (f.departure ?? f.dateStart)) ?? f.date;
-
-  const lastVisit = $derived.by(() => {
-    const now = nowIn('UTC');
-    let best: FlightData | null = null;
-    let bestDate: ReturnType<typeof touchTime> = null;
-    for (const f of flights) {
-      const date = touchTime(f);
-      if (
-        date &&
-        isBefore(date, now) &&
-        (!bestDate || isAfter(date, bestDate))
-      ) {
-        bestDate = date;
-        best = f;
-      }
-    }
-    return best;
-  });
-
-  const nextVisit = $derived.by(() => {
-    const now = nowIn('UTC');
-    let best: FlightData | null = null;
-    let bestDate: ReturnType<typeof touchTime> = null;
-    for (const f of flights) {
-      const date = touchTime(f);
-      if (
-        date &&
-        isAfter(date, now) &&
-        (!bestDate || isBefore(date, bestDate))
-      ) {
-        bestDate = date;
-        best = f;
-      }
-    }
-    return best;
-  });
-
-  const formatVisit = (flight: FlightData | null) => {
-    if (!flight) return null;
-    const date = touchTime(flight);
-    if (!date) return null;
-    return formatAsFlightDate(date, flight.datePrecision ?? 'day', false, true);
-  };
-
-  const lastVisitLabel = $derived(formatVisit(lastVisit));
-  const nextVisitLabel = $derived(formatVisit(nextVisit));
+  const visits = $derived(getVisitSummary(flights, airportId, now));
+  const lastVisitLabel = $derived(visits.last?.label ?? null);
+  const nextVisitLabel = $derived(visits.next?.label ?? null);
 </script>
 
 <section class="px-4 py-4">

--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -80,12 +80,7 @@
     if (!flight) return null;
     const date = touchTime(flight);
     if (!date) return null;
-    return formatAsFlightDate(
-      date,
-      flight.datePrecision ?? 'day',
-      false,
-      true,
-    );
+    return formatAsFlightDate(date, flight.datePrecision ?? 'day', false, true);
   };
 
   const lastVisitLabel = $derived(formatVisit(lastVisit));

--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { PlaneLanding, PlaneTakeoff } from '@o7/icon/lucide';
   import NumberFlow from '@number-flow/svelte';
+  import { isAfter, isBefore } from 'date-fns';
 
-  import type { FlightData } from '$lib/utils';
-  import { formatAsFlightDate } from '$lib/utils/datetime';
+  import { cn, type FlightData } from '$lib/utils';
+  import { formatAsFlightDate, nowIn } from '$lib/utils/datetime';
 
   let {
     flights,
@@ -32,28 +33,63 @@
     return set.size;
   });
 
-  const mostRecent = $derived.by(() => {
+  // The moment this flight actually touches the airport: landing time when
+  // arriving here, takeoff time when departing from here.
+  const touchTime = (f: FlightData) =>
+    (f.to?.id === airportId
+      ? (f.arrival ?? f.dateEnd)
+      : (f.departure ?? f.dateStart)) ?? f.date;
+
+  const lastVisit = $derived.by(() => {
+    const now = nowIn('UTC');
     let best: FlightData | null = null;
-    let bestTs = -Infinity;
+    let bestDate: ReturnType<typeof touchTime> = null;
     for (const f of flights) {
-      const ts = f.date?.getTime();
-      if (ts && ts > bestTs) {
-        bestTs = ts;
+      const date = touchTime(f);
+      if (
+        date &&
+        isBefore(date, now) &&
+        (!bestDate || isAfter(date, bestDate))
+      ) {
+        bestDate = date;
         best = f;
       }
     }
     return best;
   });
 
-  const lastVisitLabel = $derived.by(() => {
-    if (!mostRecent?.date) return null;
+  const nextVisit = $derived.by(() => {
+    const now = nowIn('UTC');
+    let best: FlightData | null = null;
+    let bestDate: ReturnType<typeof touchTime> = null;
+    for (const f of flights) {
+      const date = touchTime(f);
+      if (
+        date &&
+        isAfter(date, now) &&
+        (!bestDate || isBefore(date, bestDate))
+      ) {
+        bestDate = date;
+        best = f;
+      }
+    }
+    return best;
+  });
+
+  const formatVisit = (flight: FlightData | null) => {
+    if (!flight) return null;
+    const date = touchTime(flight);
+    if (!date) return null;
     return formatAsFlightDate(
-      mostRecent.date,
-      mostRecent.datePrecision ?? 'day',
+      date,
+      flight.datePrecision ?? 'day',
       false,
       true,
     );
-  });
+  };
+
+  const lastVisitLabel = $derived(formatVisit(lastVisit));
+  const nextVisitLabel = $derived(formatVisit(nextVisit));
 </script>
 
 <section class="px-4 py-4">
@@ -86,8 +122,33 @@
     </div>
   </div>
 
+  {#if lastVisitLabel || nextVisitLabel}
+    <div
+      class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-3 text-xs text-muted-foreground"
+    >
+      {#if lastVisitLabel}
+        <span>
+          last visit <span class="text-foreground">{lastVisitLabel}</span>
+        </span>
+      {/if}
+      {#if nextVisitLabel}
+        <span class="inline-flex items-center gap-2">
+          {#if lastVisitLabel}
+            <span aria-hidden="true">·</span>
+          {/if}
+          <span>
+            next visit <span class="text-foreground">{nextVisitLabel}</span>
+          </span>
+        </span>
+      {/if}
+    </div>
+  {/if}
+
   <div
-    class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-3 text-xs text-muted-foreground"
+    class={cn(
+      'flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground',
+      lastVisitLabel || nextVisitLabel ? 'mt-1' : 'mt-3',
+    )}
   >
     <span>
       <span class="font-semibold text-foreground tabular-nums">
@@ -95,18 +156,14 @@
       </span>
       airlines
     </span>
-    <span aria-hidden="true">·</span>
-    <span>
-      <span class="font-semibold text-foreground tabular-nums">
-        {distinctRoutes}
-      </span>
-      routes
-    </span>
-    {#if lastVisitLabel}
+    <span class="inline-flex items-center gap-2">
       <span aria-hidden="true">·</span>
-      <span
-        >last visit <span class="text-foreground">{lastVisitLabel}</span></span
-      >
-    {/if}
+      <span>
+        <span class="font-semibold text-foreground tabular-nums">
+          {distinctRoutes}
+        </span>
+        routes
+      </span>
+    </span>
   </div>
 </section>

--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -61,7 +61,7 @@
 
         const label = formatAsFlightDate(
           date,
-          flight.datePrecision ?? 'day',
+          exact ? 'day' : (flight.datePrecision ?? 'day'),
           false,
           true,
         );

--- a/src/lib/components/airport-details/AirportStatsCard.svelte
+++ b/src/lib/components/airport-details/AirportStatsCard.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  import { PlaneLanding, PlaneTakeoff } from '@o7/icon/lucide';
   import NumberFlow from '@number-flow/svelte';
+  import { PlaneLanding, PlaneTakeoff } from '@o7/icon/lucide';
 
   import { cn, type FlightData } from '$lib/utils';
-  import {
-    formatAsFlightDate,
-    getFlightDateRange,
-    parseLocalizeISO,
-  } from '$lib/utils/datetime';
+  import { getAirportVisitSummary } from '$lib/utils/data/airport-visits';
 
   let {
     flights,
@@ -20,61 +16,6 @@
     airlineCount: number;
     now: Date;
   } = $props();
-
-  type Visit = { label: string; time: number };
-
-  const getVisitSummary = (flights: FlightData[], id: number, now: Date) => {
-    let last: Visit | null = null;
-    let next: Visit | null = null;
-
-    for (const flight of flights) {
-      const touches = [
-        [
-          flight.from?.id === id,
-          flight.departure,
-          flight.departureScheduled,
-          flight.from?.tz,
-        ],
-        [
-          flight.to?.id === id,
-          flight.arrival,
-          flight.arrivalScheduled,
-          flight.to?.tz,
-        ],
-      ] as const;
-
-      for (const [matches, actual, scheduled, tz] of touches) {
-        if (!matches) continue;
-        const exact =
-          actual ??
-          (scheduled ? parseLocalizeISO(scheduled, tz ?? 'UTC') : null);
-        const range = exact
-          ? { start: exact, end: exact }
-          : getFlightDateRange(
-              flight.raw.date,
-              flight.datePrecision,
-              tz ?? 'UTC',
-            );
-        const { start, end } = range;
-        const date = exact ?? start;
-        if (!start || !end || !date) continue;
-
-        const label = formatAsFlightDate(
-          date,
-          exact ? 'day' : (flight.datePrecision ?? 'day'),
-          false,
-          true,
-        );
-
-        if (end < now && (!last || end.getTime() > last.time)) {
-          last = { label, time: end.getTime() };
-        } else if (start > now && (!next || start.getTime() < next.time)) {
-          next = { label, time: start.getTime() };
-        }
-      }
-    }
-    return { last, next };
-  };
 
   const departures = $derived(
     flights.filter((f) => f.from?.id === airportId).length,
@@ -93,9 +34,9 @@
     return set.size;
   });
 
-  const visits = $derived(getVisitSummary(flights, airportId, now));
-  const lastVisitLabel = $derived(visits.last?.label ?? null);
-  const nextVisitLabel = $derived(visits.next?.label ?? null);
+  const visits = $derived(getAirportVisitSummary(flights, airportId, now));
+  const lastVisitLabel = $derived(visits.last);
+  const nextVisitLabel = $derived(visits.next);
 </script>
 
 <section class="px-4 py-4">

--- a/src/lib/components/airport-details/AirportTimeCard.svelte
+++ b/src/lib/components/airport-details/AirportTimeCard.svelte
@@ -4,17 +4,9 @@
   import { page } from '$app/state';
   import { formatTime, getPreferences } from '$lib/utils/preferences';
 
-  let { tz }: { tz?: string | null } = $props();
+  let { tz, now }: { tz?: string | null; now: Date } = $props();
 
   const prefs = $derived(getPreferences(page.data.user));
-
-  let now = $state(new Date());
-  $effect(() => {
-    const id = setInterval(() => {
-      now = new Date();
-    }, 30_000);
-    return () => clearInterval(id);
-  });
 
   const resolvedTz = $derived(tz ?? 'UTC');
 

--- a/src/lib/components/map-details/AirportDetailsBody.svelte
+++ b/src/lib/components/map-details/AirportDetailsBody.svelte
@@ -18,14 +18,21 @@
     onShowDepartures: (flightId?: number) => void;
     onShowArrivals: (flightId?: number) => void;
   } = $props();
+
+  let now = $state(new Date());
+  $effect(() => {
+    const id = setInterval(() => (now = new Date()), 30_000);
+    return () => clearInterval(id);
+  });
 </script>
 
 <AirportStatsCard
   flights={relatedFlights}
   airportId={airport.id}
   airlineCount={airport.airlines.length}
+  {now}
 />
-<AirportTimeCard tz={airport.tz} />
+<AirportTimeCard tz={airport.tz} {now} />
 <AirportWeatherCard icao={airport.icao} tz={airport.tz} lon={airport.lon} />
 <AirportFlightsCard
   flights={relatedFlights}

--- a/src/lib/utils/data/airport-visits.test.ts
+++ b/src/lib/utils/data/airport-visits.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getAirportVisitSummary,
+  type AirportVisitFlight,
+} from './airport-visits';
+
+const baseFlight = (): AirportVisitFlight => ({
+  from: { id: 1, tz: 'America/Los_Angeles' },
+  to: { id: 2, tz: 'America/New_York' },
+  datePrecision: 'day',
+  duration: 14_400,
+  departure: null,
+  arrival: null,
+  departureScheduled: null,
+  arrivalScheduled: null,
+  takeoffScheduled: null,
+  takeoffActual: null,
+  landingScheduled: null,
+  landingActual: null,
+  raw: { date: '2024-06-14' },
+});
+
+describe('airport visit summary', () => {
+  it('uses day precision for an exact timestamp on a coarse flight date', () => {
+    const flight = {
+      ...baseFlight(),
+      datePrecision: 'month',
+      arrivalScheduled: '2024-06-14T09:45:00.000Z',
+    } satisfies AirportVisitFlight;
+
+    expect(
+      getAirportVisitSummary([flight], 2, new Date('2024-07-01T00:00:00Z'))
+        .last,
+    ).toContain('14');
+  });
+
+  it('derives an untimed arrival from departure and duration', () => {
+    const flight = {
+      ...baseFlight(),
+      departureScheduled: '2024-06-15T06:00:00.000Z',
+    } satisfies AirportVisitFlight;
+
+    expect(
+      getAirportVisitSummary([flight], 2, new Date('2024-07-01T00:00:00Z'))
+        .last,
+    ).toContain('15');
+  });
+
+  it('omits an arrival that cannot be placed on a calendar day', () => {
+    const flight = { ...baseFlight(), duration: null };
+
+    expect(
+      getAirportVisitSummary([flight], 2, new Date('2024-07-01T00:00:00Z')),
+    ).toEqual({ last: null, next: null });
+  });
+
+  it('does not classify an imprecise range that contains now', () => {
+    expect(
+      getAirportVisitSummary(
+        [baseFlight()],
+        1,
+        new Date('2024-06-14T12:00:00Z'),
+      ),
+    ).toEqual({ last: null, next: null });
+  });
+});

--- a/src/lib/utils/data/airport-visits.ts
+++ b/src/lib/utils/data/airport-visits.ts
@@ -1,0 +1,125 @@
+import { TZDate } from '@date-fns/tz';
+
+import type { FlightDatePrecision } from '$lib/db/types';
+import {
+  formatAsFlightDate,
+  getFlightDateRange,
+  parseLocalizeISO,
+} from '$lib/utils/datetime';
+
+type AirportRef = { id: number; tz: string };
+
+export type AirportVisitFlight = {
+  from: AirportRef | null;
+  to: AirportRef | null;
+  datePrecision: FlightDatePrecision;
+  duration: number | null;
+  departure: TZDate | null;
+  arrival: TZDate | null;
+  departureScheduled: string | null;
+  arrivalScheduled: string | null;
+  takeoffScheduled: string | null;
+  takeoffActual: string | null;
+  landingScheduled: string | null;
+  landingActual: string | null;
+  raw: { date: string };
+};
+
+type VisitWindow = {
+  start: TZDate;
+  end: TZDate;
+  precision: FlightDatePrecision;
+};
+
+const parseTime = (value: string | null, tz: string) =>
+  value ? parseLocalizeISO(value, tz) : null;
+
+const exactWindow = (date: TZDate): VisitWindow => ({
+  start: date,
+  end: date,
+  precision: 'day',
+});
+
+const departureTime = (flight: AirportVisitFlight) => {
+  const tz = flight.from?.tz ?? 'UTC';
+  return (
+    flight.departure ??
+    parseTime(flight.takeoffActual, tz) ??
+    parseTime(flight.departureScheduled, tz) ??
+    parseTime(flight.takeoffScheduled, tz)
+  );
+};
+
+const arrivalTime = (flight: AirportVisitFlight, departure: TZDate | null) => {
+  const tz = flight.to?.tz ?? 'UTC';
+  const recorded =
+    flight.arrival ??
+    parseTime(flight.landingActual, tz) ??
+    parseTime(flight.arrivalScheduled, tz) ??
+    parseTime(flight.landingScheduled, tz);
+
+  if (recorded || !departure || flight.duration === null) return recorded;
+  return new TZDate(departure.getTime() + flight.duration * 1_000, tz);
+};
+
+const visitWindow = (
+  flight: AirportVisitFlight,
+  direction: 'departure' | 'arrival',
+): VisitWindow | null => {
+  const departure = departureTime(flight);
+  const exact =
+    direction === 'departure' ? departure : arrivalTime(flight, departure);
+  if (exact) return exactWindow(exact);
+  if (direction === 'arrival') return null;
+
+  const range = getFlightDateRange(
+    flight.raw.date,
+    flight.datePrecision,
+    flight.from?.tz ?? 'UTC',
+  );
+  if (!range.start || !range.end) return null;
+  return {
+    start: range.start,
+    end: range.end,
+    precision: flight.datePrecision,
+  };
+};
+
+type Visit = { label: string; time: number };
+
+export const getAirportVisitSummary = (
+  flights: AirportVisitFlight[],
+  airportId: number,
+  now: Date,
+) => {
+  let last: Visit | null = null;
+  let next: Visit | null = null;
+
+  for (const flight of flights) {
+    const windows = [
+      flight.from?.id === airportId ? visitWindow(flight, 'departure') : null,
+      flight.to?.id === airportId ? visitWindow(flight, 'arrival') : null,
+    ];
+
+    for (const window of windows) {
+      if (!window) continue;
+      const label = formatAsFlightDate(
+        window.start,
+        window.precision,
+        false,
+        true,
+      );
+
+      if (window.end < now && (!last || window.end.getTime() > last.time)) {
+        last = { label, time: window.end.getTime() };
+      } else if (
+        window.start > now &&
+        (!next || window.start.getTime() < next.time)
+      ) {
+        next = { label, time: window.start.getTime() };
+      }
+    }
+  }
+
+  return { last: last?.label ?? null, next: next?.label ?? null };
+};


### PR DESCRIPTION
## Summary

- The airport stats card picked the flight with the max date across *all* related flights, so a future booked flight (e.g. a trip next month) could be shown as the "last visit" instead of the actual most recent past visit.
- `last visit` now only considers flights whose actual arrival/departure time at that airport has already passed.
- Added a `next visit` label that surfaces the nearest upcoming flight to that airport, when one exists.

## Test plan

- [ ] Review an airport with both upcoming and past flights — both "last visit" and "next visit" labels should be displayed.
- [ ] Review an airport with only an upcoming flight — only the "next visit" label should be displayed.
- [ ] Review an airport with only past flights (no upcoming) — only the "last visit" label should be displayed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix airport last visit date and add next visit display in airport details
> - Adds a new `getAirportVisitSummary` utility in [airport-visits.ts](https://github.com/johanohly/AirTrail/pull/640/files#diff-f78e35c45f4169845e6041be891ccaaac491b46eb19dde3a9eee8d4ca86337de) that computes `{ last, next }` visit labels for a given airport from flight data, supporting coarse date ranges and derived arrival times.
> - Updates [AirportStatsCard.svelte](https://github.com/johanohly/AirTrail/pull/640/files#diff-486b96fdd4b8763ba16b48ee13076e824b3f1299f708ce489791b6cf2b20a83b) to use this utility, displaying last and next visit together on a separate line when both exist, or inline with airlines/routes when only one is present.
> - Centralizes the 30-second clock tick in [AirportDetailsBody.svelte](https://github.com/johanohly/AirTrail/pull/640/files#diff-67787c654f6e46096afb4512585df7cd365e4b509660977e895c4ac10a6244a7) and passes `now` as a prop to child components, removing the internal timer from [AirportTimeCard.svelte](https://github.com/johanohly/AirTrail/pull/640/files#diff-cb3b3640bbe880d7fc4f05168686439f747175bc258cb743414d247ba3f16f29).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f855ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->