### PR TITLE
feat: individual flight details pane

### DIFF
--- a/src/lib/components/flight-filters/Filters.svelte
+++ b/src/lib/components/flight-filters/Filters.svelte
@@ -81,7 +81,6 @@
     FlightFilters,
     TempFilters,
   } from '$lib/components/flight-filters/types';
-  import { page } from '$app/state';
   import UserAvatar from '$lib/components/display/UserAvatar.svelte';
   import {
     cn,
@@ -89,7 +88,6 @@
     getSeatPassengerToken,
     type FlightData,
   } from '$lib/utils';
-  import { formatFlightDate, getPreferences } from '$lib/utils/preferences';
   import type { Aircraft, Airline, Airport } from '$lib/db/types';
   import { getModalContext } from '$lib/components/ui/modal/Modal.svelte';
 
@@ -101,8 +99,7 @@
     | ColumnConfig<FlightData, 'multiOption', string[], 'passengers'>
     | ColumnConfig<FlightData, 'option', string, 'airline'>
     | ColumnConfig<FlightData, 'option', string, 'aircraft'>
-    | ColumnConfig<FlightData, 'option', string, 'aircraftRegs'>
-    | ColumnConfig<FlightData, 'option', string, 'flight'>;
+    | ColumnConfig<FlightData, 'option', string, 'aircraftRegs'>;
 
   let {
     flights = $bindable(),
@@ -385,38 +382,6 @@
       }));
   });
 
-  const prefs = $derived(getPreferences(page.data.user));
-
-  const flightOptions = $derived.by(() => {
-    return [...scopedFlights]
-      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
-      .map((flight) => {
-        const number = flight.flightNumber?.trim()
-          ? flight.flightNumber.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2')
-          : null;
-        const route = [
-          flight.from?.iata ?? flight.from?.icao,
-          flight.to?.iata ?? flight.to?.icao,
-        ]
-          .filter(Boolean)
-          .join(' → ');
-        const dateLabel = flight.date
-          ? formatFlightDate(flight.date, flight.datePrecision ?? 'day', prefs)
-          : null;
-        const label = [number ?? route, number ? route : null, dateLabel]
-          .filter(Boolean)
-          .join(' · ');
-        return {
-          value: flight.id.toString(),
-          label: label || `Flight #${flight.id}`,
-          shortLabel: number ?? route ?? `#${flight.id}`,
-          keywords: [number, route].filter(
-            (keyword): keyword is string => !!keyword,
-          ),
-        };
-      });
-  });
-
   const columnsConfig = $derived.by(() => {
     return [
       {
@@ -487,14 +452,6 @@
         accessor: (flight) => flight.aircraftReg ?? '',
         icon: Hash,
         options: columnOptions(aircraftRegOptions),
-      },
-      {
-        id: 'flight',
-        displayName: 'Flight',
-        type: 'option',
-        accessor: (flight) => flight.id.toString(),
-        icon: Plane,
-        options: columnOptions(flightOptions),
       },
     ] satisfies ReadonlyArray<FlightFilterColumnConfig>;
   });

--- a/src/lib/components/flight-filters/Filters.svelte
+++ b/src/lib/components/flight-filters/Filters.svelte
@@ -391,10 +391,9 @@
     return [...scopedFlights]
       .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
       .map((flight) => {
-        const number = flight.flightNumber?.replace(
-          /([a-zA-Z]{2})(\d+)/,
-          '$1 $2',
-        );
+        const number = flight.flightNumber?.trim()
+          ? flight.flightNumber.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2')
+          : null;
         const route = [
           flight.from?.iata ?? flight.from?.icao,
           flight.to?.iata ?? flight.to?.icao,

--- a/src/lib/components/flight-filters/Filters.svelte
+++ b/src/lib/components/flight-filters/Filters.svelte
@@ -75,11 +75,13 @@
     flightFiltersToBits,
     flightSignature,
     hasFlightFilters,
+    matchesLocationFilters,
   } from '$lib/components/flight-filters/model';
   import type {
     FlightFilters,
     TempFilters,
   } from '$lib/components/flight-filters/types';
+  import { page } from '$app/state';
   import UserAvatar from '$lib/components/display/UserAvatar.svelte';
   import {
     cn,
@@ -87,6 +89,7 @@
     getSeatPassengerToken,
     type FlightData,
   } from '$lib/utils';
+  import { formatFlightDate, getPreferences } from '$lib/utils/preferences';
   import type { Aircraft, Airline, Airport } from '$lib/db/types';
   import { getModalContext } from '$lib/components/ui/modal/Modal.svelte';
 
@@ -98,7 +101,8 @@
     | ColumnConfig<FlightData, 'multiOption', string[], 'passengers'>
     | ColumnConfig<FlightData, 'option', string, 'airline'>
     | ColumnConfig<FlightData, 'option', string, 'aircraft'>
-    | ColumnConfig<FlightData, 'option', string, 'aircraftRegs'>;
+    | ColumnConfig<FlightData, 'option', string, 'aircraftRegs'>
+    | ColumnConfig<FlightData, 'option', string, 'flight'>;
 
   let {
     flights = $bindable(),
@@ -188,6 +192,15 @@
           tempFilters.routes.length)
       ),
   );
+
+  // When viewing a route/airport drilldown, scope the filter options to the
+  // flights on that route/airport so only relevant values are offered.
+  const scopedFlights = $derived.by(() => {
+    if (!tempLocationFiltersActive || !tempFilters) return flights ?? [];
+    return (flights ?? []).filter((flight) =>
+      matchesLocationFilters(flight, tempFilters),
+    );
+  });
   const modalCtx = getModalContext();
   const filterContentZIndex = $derived.by(() => {
     const modalZ = modalCtx?.getContentZIndex();
@@ -229,17 +242,17 @@
   }
 
   const departureAirports = $derived.by(() => {
-    return uniqueAirports(flights ?? [], (flight) => flight.from);
+    return uniqueAirports(scopedFlights, (flight) => flight.from);
   });
 
   const arrivalAirports = $derived.by(() => {
-    return uniqueAirports(flights ?? [], (flight) => flight.to);
+    return uniqueAirports(scopedFlights, (flight) => flight.to);
   });
 
   const passengerOptions = $derived.by(() => {
     const options = new Map<string, OptionSource>();
 
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       for (const seat of flight.seats) {
         const value = getSeatPassengerToken(seat);
         const label = getSeatPassengerLabel(seat);
@@ -277,7 +290,7 @@
       }
     >();
 
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       if (!flight.airline) continue;
       const existing = frequencyMap.get(flight.airline.name);
       if (existing) {
@@ -312,7 +325,7 @@
       }
     >();
 
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       if (!flight.aircraft) continue;
       const existing = frequencyMap.get(flight.aircraft.name);
       if (existing) {
@@ -338,7 +351,7 @@
   const aircraftRegOptions = $derived.by(() => {
     const frequencyMap = new Map<string, number>();
 
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       if (!flight.aircraftReg) continue;
       frequencyMap.set(
         flight.aircraftReg,
@@ -358,7 +371,7 @@
   const yearOptions = $derived.by(() => {
     const years = new Set<string>();
 
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       if (flight.date) {
         years.add(flight.date.getFullYear().toString());
       }
@@ -370,6 +383,39 @@
         value: year,
         label: year,
       }));
+  });
+
+  const prefs = $derived(getPreferences(page.data.user));
+
+  const flightOptions = $derived.by(() => {
+    return [...scopedFlights]
+      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
+      .map((flight) => {
+        const number = flight.flightNumber?.replace(
+          /([a-zA-Z]{2})(\d+)/,
+          '$1 $2',
+        );
+        const route = [
+          flight.from?.iata ?? flight.from?.icao,
+          flight.to?.iata ?? flight.to?.icao,
+        ]
+          .filter(Boolean)
+          .join(' → ');
+        const dateLabel = flight.date
+          ? formatFlightDate(flight.date, flight.datePrecision ?? 'day', prefs)
+          : null;
+        const label = [number ?? route, number ? route : null, dateLabel]
+          .filter(Boolean)
+          .join(' · ');
+        return {
+          value: flight.id.toString(),
+          label: label || `Flight #${flight.id}`,
+          shortLabel: number ?? route ?? `#${flight.id}`,
+          keywords: [number, route].filter(
+            (keyword): keyword is string => !!keyword,
+          ),
+        };
+      });
   });
 
   const columnsConfig = $derived.by(() => {
@@ -442,6 +488,14 @@
         accessor: (flight) => flight.aircraftReg ?? '',
         icon: Hash,
         options: columnOptions(aircraftRegOptions),
+      },
+      {
+        id: 'flight',
+        displayName: 'Flight',
+        type: 'option',
+        accessor: (flight) => flight.id.toString(),
+        icon: Plane,
+        options: columnOptions(flightOptions),
       },
     ] satisfies ReadonlyArray<FlightFilterColumnConfig>;
   });

--- a/src/lib/components/flight-filters/MobileFiltersModal.svelte
+++ b/src/lib/components/flight-filters/MobileFiltersModal.svelte
@@ -56,7 +56,7 @@
     getSeatPassengerToken,
     type FlightData,
   } from '$lib/utils';
-  import { getPreferences } from '$lib/utils/preferences';
+  import { formatFlightDate, getPreferences } from '$lib/utils/preferences';
 
   type Screen =
     | { kind: 'home' }
@@ -133,6 +133,7 @@
     { id: 'airline', label: 'Airline', icon: Airlines, type: 'option' },
     { id: 'aircraft', label: 'Aircraft', icon: Plane, type: 'option' },
     { id: 'aircraftRegs', label: 'Tail Number', icon: Hash, type: 'option' },
+    { id: 'flight', label: 'Flight', icon: Plane, type: 'option' },
   ]);
 
   const visibleColumns = $derived(columns.filter((column) => !column.hidden));
@@ -275,6 +276,38 @@
             : null,
         ),
       ),
+      flight: [...(flights ?? [])]
+        .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
+        .map((flight): FilterOption => {
+          const number = flight.flightNumber?.replace(
+            /([a-zA-Z]{2})(\d+)/,
+            '$1 $2',
+          );
+          const route = [
+            flight.from?.iata ?? flight.from?.icao,
+            flight.to?.iata ?? flight.to?.icao,
+          ]
+            .filter(Boolean)
+            .join(' → ');
+          const dateLabel = flight.date
+            ? formatFlightDate(
+                flight.date,
+                flight.datePrecision ?? 'day',
+                prefs,
+              )
+            : null;
+          const label = [number ?? route, number ? route : null, dateLabel]
+            .filter(Boolean)
+            .join(' · ');
+          return {
+            value: flight.id.toString(),
+            label: label || `Flight #${flight.id}`,
+            shortLabel: number ?? route ?? `#${flight.id}`,
+            keywords: [number, route].filter(
+              (keyword): keyword is string => !!keyword,
+            ),
+          };
+        }),
     } satisfies Record<OptionColumnId, FilterOption[]>;
   });
 

--- a/src/lib/components/flight-filters/MobileFiltersModal.svelte
+++ b/src/lib/components/flight-filters/MobileFiltersModal.svelte
@@ -56,7 +56,7 @@
     getSeatPassengerToken,
     type FlightData,
   } from '$lib/utils';
-  import { formatFlightDate, getPreferences } from '$lib/utils/preferences';
+  import { getPreferences } from '$lib/utils/preferences';
 
   type Screen =
     | { kind: 'home' }
@@ -133,7 +133,6 @@
     { id: 'airline', label: 'Airline', icon: Airlines, type: 'option' },
     { id: 'aircraft', label: 'Aircraft', icon: Plane, type: 'option' },
     { id: 'aircraftRegs', label: 'Tail Number', icon: Hash, type: 'option' },
-    { id: 'flight', label: 'Flight', icon: Plane, type: 'option' },
   ]);
 
   const visibleColumns = $derived(columns.filter((column) => !column.hidden));
@@ -276,37 +275,6 @@
             : null,
         ),
       ),
-      flight: [...(flights ?? [])]
-        .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
-        .map((flight): FilterOption => {
-          const number = flight.flightNumber?.trim()
-            ? flight.flightNumber.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2')
-            : null;
-          const route = [
-            flight.from?.iata ?? flight.from?.icao,
-            flight.to?.iata ?? flight.to?.icao,
-          ]
-            .filter(Boolean)
-            .join(' → ');
-          const dateLabel = flight.date
-            ? formatFlightDate(
-                flight.date,
-                flight.datePrecision ?? 'day',
-                prefs,
-              )
-            : null;
-          const label = [number ?? route, number ? route : null, dateLabel]
-            .filter(Boolean)
-            .join(' · ');
-          return {
-            value: flight.id.toString(),
-            label: label || `Flight #${flight.id}`,
-            shortLabel: number ?? route ?? `#${flight.id}`,
-            keywords: [number, route].filter(
-              (keyword): keyword is string => !!keyword,
-            ),
-          };
-        }),
     } satisfies Record<OptionColumnId, FilterOption[]>;
   });
 

--- a/src/lib/components/flight-filters/MobileFiltersModal.svelte
+++ b/src/lib/components/flight-filters/MobileFiltersModal.svelte
@@ -279,10 +279,9 @@
       flight: [...(flights ?? [])]
         .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
         .map((flight): FilterOption => {
-          const number = flight.flightNumber?.replace(
-            /([a-zA-Z]{2})(\d+)/,
-            '$1 $2',
-          );
+          const number = flight.flightNumber?.trim()
+            ? flight.flightNumber.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2')
+            : null;
           const route = [
             flight.from?.iata ?? flight.from?.icao,
             flight.to?.iata ?? flight.to?.icao,

--- a/src/lib/components/flight-filters/MobileFiltersModal.svelte
+++ b/src/lib/components/flight-filters/MobileFiltersModal.svelte
@@ -23,6 +23,7 @@
     createDefaultFilters,
     dateFilterSummary,
     isFilterColumnActive,
+    matchesLocationFilters,
     optionColumnOperator,
     optionColumnValues,
     pluralMultiOptionOperators,
@@ -108,6 +109,13 @@
     hasTempFilters || hasActiveTempFilters(tempFilters),
   );
 
+  const scopedFlights = $derived.by(() => {
+    if (!tempLocationFiltersActive || !tempFilters) return flights ?? [];
+    return (flights ?? []).filter((flight) =>
+      matchesLocationFilters(flight, tempFilters),
+    );
+  });
+
   const columns = $derived<FilterColumn[]>([
     {
       id: 'departureAirports',
@@ -164,7 +172,7 @@
     selector: (flight: FlightData) => FlightData['from'],
   ) {
     const options = new Map<string, FilterOption>();
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       const airport = selector(flight);
       if (!airport) continue;
       const value = airport.id.toString();
@@ -216,7 +224,7 @@
   const optionsByColumn = $derived.by(() => {
     const passengers = new Map<string, FilterOption>();
 
-    for (const flight of flights ?? []) {
+    for (const flight of scopedFlights) {
       for (const seat of flight.seats) {
         const value = getSeatPassengerToken(seat);
         const label = getSeatPassengerLabel(seat);
@@ -241,7 +249,7 @@
       arrivalAirports: uniqueAirportOptions((flight) => flight.to),
       passengers: sortOptions(Array.from(passengers.values())),
       airline: countedOptions(
-        (flights ?? []).map((flight) =>
+        scopedFlights.map((flight) =>
           flight.airline
             ? {
                 value: flight.airline.name,
@@ -256,7 +264,7 @@
         ),
       ),
       aircraft: countedOptions(
-        (flights ?? []).map((flight) =>
+        scopedFlights.map((flight) =>
           flight.aircraft
             ? {
                 value: flight.aircraft.name,
@@ -269,7 +277,7 @@
         ),
       ),
       aircraftRegs: countedOptions(
-        (flights ?? []).map((flight) =>
+        scopedFlights.map((flight) =>
           flight.aircraftReg
             ? { value: flight.aircraftReg, label: flight.aircraftReg }
             : null,

--- a/src/lib/components/flight-filters/model.ts
+++ b/src/lib/components/flight-filters/model.ts
@@ -22,8 +22,7 @@ export type FilterColumnId =
   | 'passengers'
   | 'airline'
   | 'aircraft'
-  | 'aircraftRegs'
-  | 'flight';
+  | 'aircraftRegs';
 
 export type OptionColumnId = Exclude<FilterColumnId, 'date'>;
 export type NonPassengerOptionColumnId = Exclude<OptionColumnId, 'passengers'>;
@@ -96,8 +95,6 @@ export function createDefaultFilters(): FlightFilters {
     aircraftOperator: 'is any of',
     aircraftRegs: [],
     aircraftRegsOperator: 'is any of',
-    flightIds: [],
-    flightIdsOperator: 'is any of',
   };
 }
 
@@ -116,7 +113,6 @@ export function cloneFlightFilters(
     airline: [...source.airline],
     aircraft: [...source.aircraft],
     aircraftRegs: [...source.aircraftRegs],
-    flightIds: [...source.flightIds],
     ...next,
   };
 }
@@ -134,8 +130,7 @@ export function hasFlightFilters(filters: FlightFilters | undefined): boolean {
       filters.passengers.length > 0 ||
       filters.airline.length > 0 ||
       filters.aircraft.length > 0 ||
-      filters.aircraftRegs.length > 0 ||
-      filters.flightIds.length > 0)
+      filters.aircraftRegs.length > 0)
   );
 }
 
@@ -185,7 +180,6 @@ export function optionColumnValues(
   filters: FlightFilters,
   columnId: OptionColumnId,
 ): string[] {
-  if (columnId === 'flight') return filters.flightIds;
   return filters[columnId];
 }
 
@@ -214,8 +208,6 @@ export function rawOptionColumnOperator(
       return filters.aircraftOperator;
     case 'aircraftRegs':
       return filters.aircraftRegsOperator;
-    case 'flight':
-      return filters.flightIdsOperator;
   }
 }
 
@@ -280,10 +272,6 @@ export function setOptionColumnOperator(
       return cloneFlightFilters(filters, {
         aircraftRegsOperator: operator as OptionFilterOperator,
       });
-    case 'flight':
-      return cloneFlightFilters(filters, {
-        flightIdsOperator: operator as OptionFilterOperator,
-      });
   }
 }
 
@@ -339,11 +327,6 @@ export function setOptionColumnValues(
       return cloneFlightFilters(filters, {
         aircraftRegs: values,
         aircraftRegsOperator: operator as OptionFilterOperator,
-      });
-    case 'flight':
-      return cloneFlightFilters(filters, {
-        flightIds: values,
-        flightIdsOperator: operator as OptionFilterOperator,
       });
   }
 }
@@ -573,7 +556,6 @@ export function flightFiltersToBits(source: FlightFilters): FiltersState {
       source.aircraftRegs,
       source.aircraftRegsOperator,
     ),
-    optionFilter('flight', source.flightIds, source.flightIdsOperator),
   ]) {
     if (filter) nextFilters.push(filter);
   }
@@ -636,8 +618,6 @@ function resetBitsManagedFilters(base?: FlightFilters): FlightFilters {
     aircraftOperator: 'is any of',
     aircraftRegs: [],
     aircraftRegsOperator: 'is any of',
-    flightIds: [],
-    flightIdsOperator: 'is any of',
   });
 }
 
@@ -677,10 +657,6 @@ export function bitsFiltersToFlightFilters(
         nextFilters.aircraftRegs = stringValues(filter);
         nextFilters.aircraftRegsOperator =
           filter.operator as OptionFilterOperator;
-        break;
-      case 'flight':
-        nextFilters.flightIds = stringValues(filter);
-        nextFilters.flightIdsOperator = filter.operator as OptionFilterOperator;
         break;
       case 'year':
         nextFilters.years = stringValues(filter);
@@ -739,8 +715,6 @@ export function flightSignature(source: FlightFilters) {
     aircraftOperator: source.aircraftOperator,
     aircraftRegs: source.aircraftRegs,
     aircraftRegsOperator: source.aircraftRegsOperator,
-    flightIds: source.flightIds,
-    flightIdsOperator: source.flightIdsOperator,
   });
 }
 
@@ -937,16 +911,6 @@ export function matchesNonLocationFilters(
       flight.aircraftReg,
       filters.aircraftRegs,
       filters.aircraftRegsOperator,
-    )
-  ) {
-    return false;
-  }
-
-  if (
-    !optionMatches(
-      flight.id.toString(),
-      filters.flightIds,
-      filters.flightIdsOperator,
     )
   ) {
     return false;

--- a/src/lib/components/flight-filters/model.ts
+++ b/src/lib/components/flight-filters/model.ts
@@ -2,12 +2,13 @@ import { CalendarDate } from '@internationalized/date';
 import { isAfter, isBefore } from 'date-fns';
 import type { FilterModel, FiltersState } from 'bits-ui';
 
-import type {
-  FlightFilters,
-  LocationFilters,
-  MultiOptionFilterOperator,
-  OptionFilterOperator,
-  Route,
+import {
+  routeMatchesEndpoints,
+  type FlightFilters,
+  type LocationFilters,
+  type MultiOptionFilterOperator,
+  type OptionFilterOperator,
+  type Route,
 } from './types';
 
 import { getSeatPassengerToken, type FlightData } from '$lib/utils';
@@ -719,12 +720,7 @@ export function flightSignature(source: FlightFilters) {
 }
 
 export function routeMatches(flight: FlightData, route: Route): boolean {
-  const fromId = flight.from?.id.toString();
-  const toId = flight.to?.id.toString();
-  return (
-    (fromId === route.a && toId === route.b) ||
-    (fromId === route.b && toId === route.a)
-  );
+  return routeMatchesEndpoints(flight.from?.id, flight.to?.id, route);
 }
 
 export function optionMatches(

--- a/src/lib/components/flight-filters/model.ts
+++ b/src/lib/components/flight-filters/model.ts
@@ -22,7 +22,8 @@ export type FilterColumnId =
   | 'passengers'
   | 'airline'
   | 'aircraft'
-  | 'aircraftRegs';
+  | 'aircraftRegs'
+  | 'flight';
 
 export type OptionColumnId = Exclude<FilterColumnId, 'date'>;
 export type NonPassengerOptionColumnId = Exclude<OptionColumnId, 'passengers'>;
@@ -96,6 +97,7 @@ export function createDefaultFilters(): FlightFilters {
     aircraftRegs: [],
     aircraftRegsOperator: 'is any of',
     flightIds: [],
+    flightIdsOperator: 'is any of',
   };
 }
 
@@ -183,6 +185,7 @@ export function optionColumnValues(
   filters: FlightFilters,
   columnId: OptionColumnId,
 ): string[] {
+  if (columnId === 'flight') return filters.flightIds;
   return filters[columnId];
 }
 
@@ -211,6 +214,8 @@ export function rawOptionColumnOperator(
       return filters.aircraftOperator;
     case 'aircraftRegs':
       return filters.aircraftRegsOperator;
+    case 'flight':
+      return filters.flightIdsOperator;
   }
 }
 
@@ -275,6 +280,10 @@ export function setOptionColumnOperator(
       return cloneFlightFilters(filters, {
         aircraftRegsOperator: operator as OptionFilterOperator,
       });
+    case 'flight':
+      return cloneFlightFilters(filters, {
+        flightIdsOperator: operator as OptionFilterOperator,
+      });
   }
 }
 
@@ -330,6 +339,11 @@ export function setOptionColumnValues(
       return cloneFlightFilters(filters, {
         aircraftRegs: values,
         aircraftRegsOperator: operator as OptionFilterOperator,
+      });
+    case 'flight':
+      return cloneFlightFilters(filters, {
+        flightIds: values,
+        flightIdsOperator: operator as OptionFilterOperator,
       });
   }
 }
@@ -559,6 +573,7 @@ export function flightFiltersToBits(source: FlightFilters): FiltersState {
       source.aircraftRegs,
       source.aircraftRegsOperator,
     ),
+    optionFilter('flight', source.flightIds, source.flightIdsOperator),
   ]) {
     if (filter) nextFilters.push(filter);
   }
@@ -621,6 +636,8 @@ function resetBitsManagedFilters(base?: FlightFilters): FlightFilters {
     aircraftOperator: 'is any of',
     aircraftRegs: [],
     aircraftRegsOperator: 'is any of',
+    flightIds: [],
+    flightIdsOperator: 'is any of',
   });
 }
 
@@ -660,6 +677,10 @@ export function bitsFiltersToFlightFilters(
         nextFilters.aircraftRegs = stringValues(filter);
         nextFilters.aircraftRegsOperator =
           filter.operator as OptionFilterOperator;
+        break;
+      case 'flight':
+        nextFilters.flightIds = stringValues(filter);
+        nextFilters.flightIdsOperator = filter.operator as OptionFilterOperator;
         break;
       case 'year':
         nextFilters.years = stringValues(filter);
@@ -719,6 +740,7 @@ export function flightSignature(source: FlightFilters) {
     aircraftRegs: source.aircraftRegs,
     aircraftRegsOperator: source.aircraftRegsOperator,
     flightIds: source.flightIds,
+    flightIdsOperator: source.flightIdsOperator,
   });
 }
 
@@ -921,8 +943,11 @@ export function matchesNonLocationFilters(
   }
 
   if (
-    filters.flightIds.length &&
-    !filters.flightIds.includes(flight.id.toString())
+    !optionMatches(
+      flight.id.toString(),
+      filters.flightIds,
+      filters.flightIdsOperator,
+    )
   ) {
     return false;
   }

--- a/src/lib/components/flight-filters/model.ts
+++ b/src/lib/components/flight-filters/model.ts
@@ -95,6 +95,7 @@ export function createDefaultFilters(): FlightFilters {
     aircraftOperator: 'is any of',
     aircraftRegs: [],
     aircraftRegsOperator: 'is any of',
+    flightIds: [],
   };
 }
 
@@ -113,6 +114,7 @@ export function cloneFlightFilters(
     airline: [...source.airline],
     aircraft: [...source.aircraft],
     aircraftRegs: [...source.aircraftRegs],
+    flightIds: [...source.flightIds],
     ...next,
   };
 }
@@ -130,7 +132,8 @@ export function hasFlightFilters(filters: FlightFilters | undefined): boolean {
       filters.passengers.length > 0 ||
       filters.airline.length > 0 ||
       filters.aircraft.length > 0 ||
-      filters.aircraftRegs.length > 0)
+      filters.aircraftRegs.length > 0 ||
+      filters.flightIds.length > 0)
   );
 }
 
@@ -715,6 +718,7 @@ export function flightSignature(source: FlightFilters) {
     aircraftOperator: source.aircraftOperator,
     aircraftRegs: source.aircraftRegs,
     aircraftRegsOperator: source.aircraftRegsOperator,
+    flightIds: source.flightIds,
   });
 }
 
@@ -912,6 +916,13 @@ export function matchesNonLocationFilters(
       filters.aircraftRegs,
       filters.aircraftRegsOperator,
     )
+  ) {
+    return false;
+  }
+
+  if (
+    filters.flightIds.length &&
+    !filters.flightIds.includes(flight.id.toString())
   ) {
     return false;
   }

--- a/src/lib/components/flight-filters/types.ts
+++ b/src/lib/components/flight-filters/types.ts
@@ -43,9 +43,10 @@ export type FlightFilters = LocationFilterValues &
     aircraftOperator: OptionFilterOperator;
     aircraftRegs: string[];
     aircraftRegsOperator: OptionFilterOperator;
-    // Programmatic single-flight isolation (set from the map / list "show on
-    // map" flows), not a user-facing filter-bar column.
+    // Single flight instances. Set from the map / list "show on map" flows and
+    // also selectable from the filter bar's "Flight" column.
     flightIds: string[];
+    flightIdsOperator: OptionFilterOperator;
   };
 
 export type TempFilters = LocationFilterValues;

--- a/src/lib/components/flight-filters/types.ts
+++ b/src/lib/components/flight-filters/types.ts
@@ -43,10 +43,6 @@ export type FlightFilters = LocationFilterValues &
     aircraftOperator: OptionFilterOperator;
     aircraftRegs: string[];
     aircraftRegsOperator: OptionFilterOperator;
-    // Single flight instances. Set from the map / list "show on map" flows and
-    // also selectable from the filter bar's "Flight" column.
-    flightIds: string[];
-    flightIdsOperator: OptionFilterOperator;
   };
 
 export type TempFilters = LocationFilterValues;

--- a/src/lib/components/flight-filters/types.ts
+++ b/src/lib/components/flight-filters/types.ts
@@ -63,6 +63,19 @@ export function normalizeRoute(idA: string, idB: string): Route {
   return idA <= idB ? { a: idA, b: idB } : { a: idB, b: idA };
 }
 
+export function routeMatchesEndpoints(
+  fromId: string | number | null | undefined,
+  toId: string | number | null | undefined,
+  route: Route | null | undefined,
+): boolean {
+  if (fromId == null || toId == null || !route) return false;
+  const from = fromId.toString();
+  const to = toId.toString();
+  return (
+    (from === route.a && to === route.b) || (from === route.b && to === route.a)
+  );
+}
+
 export function hasTempFilters(tempFilters: TempFilters | undefined): boolean {
   return !!(
     tempFilters &&

--- a/src/lib/components/flight-filters/types.ts
+++ b/src/lib/components/flight-filters/types.ts
@@ -43,6 +43,9 @@ export type FlightFilters = LocationFilterValues &
     aircraftOperator: OptionFilterOperator;
     aircraftRegs: string[];
     aircraftRegsOperator: OptionFilterOperator;
+    // Programmatic single-flight isolation (set from the map / list "show on
+    // map" flows), not a user-facing filter-bar column.
+    flightIds: string[];
   };
 
 export type TempFilters = LocationFilterValues;

--- a/src/lib/components/map-details/AirportDetailsActions.svelte
+++ b/src/lib/components/map-details/AirportDetailsActions.svelte
@@ -18,15 +18,22 @@
 
 <DetailsActionButton
   label="Locate airport"
+  shortLabel="Locate"
   icon={Locate}
   onclick={focusMapDetails}
 />
 {#if hasFilters}
   <DetailsActionButton
     label={filterActive ? 'Clear airport filter' : 'Filter map to airport'}
+    shortLabel={filterActive ? 'Clear' : 'Filter'}
     icon={Funnel}
     onclick={onToggleFilter}
     pressed={filterActive}
   />
 {/if}
-<DetailsActionButton label="Close details" icon={X} onclick={closeMapDetails} />
+<DetailsActionButton
+  label="Close details"
+  shortLabel="Close"
+  icon={X}
+  onclick={closeMapDetails}
+/>

--- a/src/lib/components/map-details/DetailsActionButton.svelte
+++ b/src/lib/components/map-details/DetailsActionButton.svelte
@@ -9,11 +9,13 @@
     icon: Icon,
     onclick,
     pressed = false,
+    shortLabel = label,
   }: {
     label: string;
     icon: typeof Locate;
     onclick: () => void;
     pressed?: boolean;
+    shortLabel?: string;
   } = $props();
 </script>
 
@@ -24,13 +26,15 @@
         {...props}
         variant={pressed ? 'secondary' : 'ghost'}
         size="sm"
-        class="h-9 flex-1 px-2 md:size-8 md:flex-none md:px-0"
+        class="h-9 min-w-0 flex-1 gap-1.5 px-1.5 sm:px-2 md:size-8 md:flex-none md:px-0"
         {onclick}
         aria-label={label}
         aria-pressed={pressed || undefined}
       >
         <Icon size={16} />
-        <span class="text-xs md:sr-only">{label}</span>
+        <span class="min-w-0 truncate text-[11px] sm:text-xs md:sr-only">
+          {shortLabel}
+        </span>
       </Button>
     {/snippet}
   </Tooltip.Trigger>

--- a/src/lib/components/map-details/FlightDetailsActions.svelte
+++ b/src/lib/components/map-details/FlightDetailsActions.svelte
@@ -8,7 +8,13 @@
 
 <DetailsActionButton
   label="Locate flight"
+  shortLabel="Locate"
   icon={Locate}
   onclick={focusMapDetails}
 />
-<DetailsActionButton label="Close details" icon={X} onclick={closeMapDetails} />
+<DetailsActionButton
+  label="Close details"
+  shortLabel="Close"
+  icon={X}
+  onclick={closeMapDetails}
+/>

--- a/src/lib/components/map-details/FlightDetailsActions.svelte
+++ b/src/lib/components/map-details/FlightDetailsActions.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { Funnel, Locate, X } from '@o7/icon/lucide';
+
+  import { closeMapDetails, focusMapDetails } from '$lib/state.svelte';
+
+  import DetailsActionButton from './DetailsActionButton.svelte';
+
+  let {
+    hasFilters,
+    filterActive,
+    onToggleFilter,
+  }: {
+    hasFilters: boolean;
+    filterActive: boolean;
+    onToggleFilter: () => void;
+  } = $props();
+</script>
+
+<DetailsActionButton
+  label="Locate flight"
+  icon={Locate}
+  onclick={focusMapDetails}
+/>
+{#if hasFilters}
+  <DetailsActionButton
+    label={filterActive ? 'Show all flights' : 'Isolate flight on map'}
+    icon={Funnel}
+    onclick={onToggleFilter}
+    pressed={filterActive}
+  />
+{/if}
+<DetailsActionButton label="Close details" icon={X} onclick={closeMapDetails} />

--- a/src/lib/components/map-details/FlightDetailsActions.svelte
+++ b/src/lib/components/map-details/FlightDetailsActions.svelte
@@ -1,19 +1,9 @@
 <script lang="ts">
-  import { Funnel, Locate, X } from '@o7/icon/lucide';
+  import { Locate, X } from '@o7/icon/lucide';
 
   import { closeMapDetails, focusMapDetails } from '$lib/state.svelte';
 
   import DetailsActionButton from './DetailsActionButton.svelte';
-
-  let {
-    hasFilters,
-    filterActive,
-    onToggleFilter,
-  }: {
-    hasFilters: boolean;
-    filterActive: boolean;
-    onToggleFilter: () => void;
-  } = $props();
 </script>
 
 <DetailsActionButton
@@ -21,12 +11,4 @@
   icon={Locate}
   onclick={focusMapDetails}
 />
-{#if hasFilters}
-  <DetailsActionButton
-    label={filterActive ? 'Show all flights' : 'Isolate flight on map'}
-    icon={Funnel}
-    onclick={onToggleFilter}
-    pressed={filterActive}
-  />
-{/if}
 <DetailsActionButton label="Close details" icon={X} onclick={closeMapDetails} />

--- a/src/lib/components/map-details/FlightDetailsBody.svelte
+++ b/src/lib/components/map-details/FlightDetailsBody.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { List } from '@o7/icon/lucide';
+
+  import { Button } from '$lib/components/ui/button';
   import { formatAircraft } from '$lib/utils/data/aircraft';
   import {
     formatSeatForUser,
@@ -15,10 +18,12 @@
     flight,
     prefs,
     seatUserId,
+    onShowInList,
   }: {
     flight: FlightData;
     prefs: Preferences;
     seatUserId?: string;
+    onShowInList: () => void;
   } = $props();
 
   const distanceLabel = $derived(
@@ -134,4 +139,16 @@
       No additional details for this flight.
     </p>
   {/if}
+</section>
+
+<section class="px-4 py-3">
+  <Button
+    variant="ghost"
+    size="sm"
+    class="w-full justify-center gap-2 text-muted-foreground hover:text-foreground"
+    onclick={onShowInList}
+  >
+    <List size={16} />
+    Open list
+  </Button>
 </section>

--- a/src/lib/components/map-details/FlightDetailsBody.svelte
+++ b/src/lib/components/map-details/FlightDetailsBody.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { formatAircraft } from '$lib/utils/data/aircraft';
+  import {
+    formatSeatForUser,
+    getSeatPassengerLabel,
+    toTitleCase,
+    type FlightData,
+  } from '$lib/utils';
+  import type { FlightSeat } from '$lib/db/types';
+  import { Duration } from '$lib/utils/datetime';
+  import { convertDistance, distanceUnitLabel } from '$lib/utils/preferences';
+  import type { Preferences } from '$lib/zod/user';
+
+  let {
+    flight,
+    prefs,
+    seatUserId,
+  }: {
+    flight: FlightData;
+    prefs: Preferences;
+    seatUserId?: string;
+  } = $props();
+
+  const distanceLabel = $derived(
+    typeof flight.distance === 'number'
+      ? `${Math.round(convertDistance(flight.distance, prefs))} ${distanceUnitLabel(prefs)}`
+      : null,
+  );
+
+  const durationLabel = $derived(
+    flight.duration ? Duration.fromSeconds(flight.duration).toString() : null,
+  );
+
+  const seatLabel = $derived(formatSeatForUser(flight, seatUserId));
+
+  const seatDescriptor = (seat: FlightSeat) => {
+    const t = (s: string) => toTitleCase(s);
+    if (seat.seat && seat.seatNumber && seat.seatClass) {
+      return `${t(seat.seatClass)} · ${seat.seat} ${seat.seatNumber}`;
+    }
+    if (seat.seat && seat.seatNumber) return `${seat.seat} ${seat.seatNumber}`;
+    if (seat.seat && seat.seatClass)
+      return `${t(seat.seatClass)} · ${seat.seat}`;
+    if (seat.seatNumber) return seat.seatNumber;
+    if (seat.seatClass) return t(seat.seatClass);
+    if (seat.seat) return t(seat.seat);
+    return null;
+  };
+
+  const passengers = $derived(
+    flight.seats
+      .map((seat) => ({
+        name: getSeatPassengerLabel(seat),
+        seat: seatDescriptor(seat),
+      }))
+      .filter((p): p is { name: string; seat: string | null } => !!p.name),
+  );
+
+  const gateLabel = (terminal: string | null, gate: string | null) => {
+    const parts: string[] = [];
+    if (terminal) parts.push(`Terminal ${terminal}`);
+    if (gate) parts.push(`Gate ${gate}`);
+    return parts.length ? parts.join(' · ') : null;
+  };
+
+  const departureGate = $derived(
+    gateLabel(flight.departureTerminal, flight.departureGate),
+  );
+  const arrivalGate = $derived(
+    gateLabel(flight.arrivalTerminal, flight.arrivalGate),
+  );
+
+  type Row = { label: string; value: string };
+  const rows = $derived.by(() => {
+    const r: Row[] = [];
+    if (flight.airline?.name)
+      r.push({ label: 'Airline', value: flight.airline.name });
+    if (flight.aircraft || flight.aircraftReg)
+      r.push({ label: 'Aircraft', value: formatAircraft(flight) });
+    if (distanceLabel) r.push({ label: 'Distance', value: distanceLabel });
+    if (durationLabel) r.push({ label: 'Duration', value: durationLabel });
+    if (seatLabel) r.push({ label: 'Seat', value: seatLabel });
+    if (flight.flightReason)
+      r.push({ label: 'Reason', value: toTitleCase(flight.flightReason) });
+    if (departureGate) r.push({ label: 'Departure', value: departureGate });
+    if (arrivalGate) r.push({ label: 'Arrival', value: arrivalGate });
+    return r;
+  });
+</script>
+
+<section class="flex flex-col gap-3 px-4 py-4">
+  {#if rows.length}
+    <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+      {#each rows as row (row.label)}
+        <dt class="text-muted-foreground">{row.label}</dt>
+        <dd class="text-right font-medium tabular-nums">{row.value}</dd>
+      {/each}
+    </dl>
+  {/if}
+
+  {#if passengers.length}
+    <div class="flex flex-col gap-1.5">
+      <p class="text-xs tracking-wider text-muted-foreground uppercase">
+        Passengers
+      </p>
+      <div class="flex flex-wrap gap-1.5">
+        {#each passengers as passenger, i (i)}
+          <span
+            class="flex items-center gap-1.5 rounded-full border border-border/60 bg-background/40 px-2 py-0.5 text-xs"
+          >
+            {passenger.name}
+            {#if passenger.seat}
+              <span class="text-muted-foreground tabular-nums">
+                {passenger.seat}
+              </span>
+            {/if}
+          </span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  {#if flight.note}
+    <div class="flex flex-col gap-1.5">
+      <p class="text-xs tracking-wider text-muted-foreground uppercase">Note</p>
+      <p class="text-sm whitespace-pre-wrap text-muted-foreground">
+        {flight.note}
+      </p>
+    </div>
+  {/if}
+
+  {#if !rows.length && !passengers.length && !flight.note}
+    <p class="py-1 text-sm text-muted-foreground">
+      No additional details for this flight.
+    </p>
+  {/if}
+</section>

--- a/src/lib/components/map-details/FlightDetailsContent.svelte
+++ b/src/lib/components/map-details/FlightDetailsContent.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { closeMapDetails, mapDetailsState } from '$lib/state.svelte';
+
+  import FlightDetailsActions from './FlightDetailsActions.svelte';
+  import FlightDetailsBody from './FlightDetailsBody.svelte';
+  import FlightDetailsHeader from './FlightDetailsHeader.svelte';
+  import MapDetailsFrame from './MapDetailsFrame.svelte';
+  import type { useFlightDetails } from './useFlightDetails.svelte';
+
+  let {
+    details,
+    hasFilters,
+    seatUserId,
+  }: {
+    details: ReturnType<typeof useFlightDetails>;
+    hasFilters: boolean;
+    seatUserId?: string;
+  } = $props();
+</script>
+
+{#snippet header()}
+  {#if details.flight}
+    <FlightDetailsHeader
+      flight={details.flight}
+      onShowRoute={details.showRoute}
+    />
+  {/if}
+{/snippet}
+
+{#snippet actions()}
+  {#if details.flight}
+    <FlightDetailsActions
+      {hasFilters}
+      filterActive={details.flightFilterActive}
+      onToggleFilter={details.toggleFlightFilter}
+    />
+  {/if}
+{/snippet}
+
+<MapDetailsFrame
+  open={!!details.flight}
+  {header}
+  {actions}
+  onOpenChange={(v) => {
+    if (!v && mapDetailsState.selection?.type === 'flight') {
+      closeMapDetails();
+    }
+  }}
+>
+  {#if details.flight}
+    <FlightDetailsBody
+      flight={details.flight}
+      prefs={details.prefs}
+      {seatUserId}
+    />
+  {/if}
+</MapDetailsFrame>

--- a/src/lib/components/map-details/FlightDetailsContent.svelte
+++ b/src/lib/components/map-details/FlightDetailsContent.svelte
@@ -52,6 +52,7 @@
       flight={details.flight}
       prefs={details.prefs}
       {seatUserId}
+      onShowInList={details.showInList}
     />
   {/if}
 </MapDetailsFrame>

--- a/src/lib/components/map-details/FlightDetailsContent.svelte
+++ b/src/lib/components/map-details/FlightDetailsContent.svelte
@@ -9,11 +9,9 @@
 
   let {
     details,
-    hasFilters,
     seatUserId,
   }: {
     details: ReturnType<typeof useFlightDetails>;
-    hasFilters: boolean;
     seatUserId?: string;
   } = $props();
 </script>
@@ -29,11 +27,7 @@
 
 {#snippet actions()}
   {#if details.flight}
-    <FlightDetailsActions
-      {hasFilters}
-      filterActive={details.flightFilterActive}
-      onToggleFilter={details.toggleFlightFilter}
-    />
+    <FlightDetailsActions />
   {/if}
 {/snippet}
 

--- a/src/lib/components/map-details/FlightDetailsHeader.svelte
+++ b/src/lib/components/map-details/FlightDetailsHeader.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { ChevronRight } from '@o7/icon/lucide';
+
+  import {
+    AirlineIcon,
+    RouteArrow,
+    TimeDisplay,
+  } from '$lib/components/display';
+  import type { FlightData } from '$lib/utils';
+  import { formatAsFlightDate } from '$lib/utils/datetime';
+
+  let {
+    flight,
+    onShowRoute,
+  }: {
+    flight: FlightData;
+    onShowRoute?: () => void;
+  } = $props();
+
+  const flightNumber = $derived(
+    flight.flightNumber?.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2') ?? null,
+  );
+
+  const dateLabel = $derived(
+    flight.date
+      ? formatAsFlightDate(
+          flight.date,
+          flight.datePrecision ?? 'day',
+          false,
+          true,
+        )
+      : null,
+  );
+
+  const canShowRoute = $derived(!!(flight.from && flight.to) && !!onShowRoute);
+
+  const airportCode = (airport: NonNullable<FlightData['from']>) =>
+    airport.iata ?? airport.icao;
+</script>
+
+<div class="flex flex-col gap-3 px-4 py-4">
+  <div class="flex items-center gap-3">
+    <AirlineIcon airline={flight.airline} size={36} fallback="plane" />
+    <div class="min-w-0">
+      <p class="truncate text-lg leading-tight font-semibold tracking-tight">
+        {flightNumber ?? flight.airline?.name ?? 'Flight'}
+      </p>
+      <p class="truncate text-xs text-muted-foreground">
+        {#if flightNumber && flight.airline?.name}
+          {flight.airline.name}{dateLabel ? ` · ${dateLabel}` : ''}
+        {:else}
+          {dateLabel ?? ''}
+        {/if}
+      </p>
+    </div>
+  </div>
+
+  {#snippet endpoint(
+    airport: FlightData['from'],
+    time: FlightData['departure'],
+    align: 'left' | 'right',
+  )}
+    <div
+      class="flex flex-col gap-1 {align === 'right'
+        ? 'items-end text-right'
+        : 'items-start text-left'}"
+    >
+      {#if airport}
+        <div class="flex items-center gap-1.5">
+          <img
+            src="https://flagcdn.com/{airport.country.toLowerCase()}.svg"
+            alt={airport.country}
+            class="h-4 w-6 shrink-0 rounded object-cover shadow-sm"
+          />
+          <span
+            class="text-2xl leading-none font-semibold tracking-tight tabular-nums"
+          >
+            {airportCode(airport)}
+          </span>
+        </div>
+        {#if time}
+          <TimeDisplay
+            date={time}
+            airportTz={airport.tz}
+            airportLabel={airport.iata}
+            side="bottom"
+            class="text-xs text-muted-foreground tabular-nums"
+          />
+        {/if}
+      {:else}
+        <span class="text-2xl font-semibold text-muted-foreground">N/A</span>
+      {/if}
+    </div>
+  {/snippet}
+
+  <button
+    type="button"
+    class="group grid grid-cols-[1fr_auto_1fr] items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors enabled:hover:bg-background/55 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+    disabled={!canShowRoute}
+    onclick={() => onShowRoute?.()}
+    aria-label="Open route details"
+  >
+    {@render endpoint(flight.from, flight.departure, 'left')}
+    <div class="flex flex-col items-center gap-0.5 text-muted-foreground/70">
+      <RouteArrow class="size-5 fill-muted-foreground/70" />
+    </div>
+    {@render endpoint(flight.to, flight.arrival, 'right')}
+  </button>
+</div>

--- a/src/lib/components/map-details/FlightDetailsHeader.svelte
+++ b/src/lib/components/map-details/FlightDetailsHeader.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { ChevronRight } from '@o7/icon/lucide';
 
+  import { page } from '$app/state';
   import {
     AirlineIcon,
     RouteArrow,
     TimeDisplay,
   } from '$lib/components/display';
   import type { FlightData } from '$lib/utils';
-  import { formatAsFlightDate } from '$lib/utils/datetime';
+  import { formatFlightDate, getPreferences } from '$lib/utils/preferences';
 
   let {
     flight,
@@ -17,18 +18,15 @@
     onShowRoute?: () => void;
   } = $props();
 
+  const prefs = $derived(getPreferences(page.data.user));
+
   const flightNumber = $derived(
     flight.flightNumber?.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2') ?? null,
   );
 
   const dateLabel = $derived(
     flight.date
-      ? formatAsFlightDate(
-          flight.date,
-          flight.datePrecision ?? 'day',
-          false,
-          true,
-        )
+      ? formatFlightDate(flight.date, flight.datePrecision ?? 'day', prefs)
       : null,
   );
 

--- a/src/lib/components/map-details/FlightDetailsHeader.svelte
+++ b/src/lib/components/map-details/FlightDetailsHeader.svelte
@@ -21,7 +21,9 @@
   const prefs = $derived(getPreferences(page.data.user));
 
   const flightNumber = $derived(
-    flight.flightNumber?.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2') ?? null,
+    flight.flightNumber?.trim()
+      ? flight.flightNumber.replace(/([a-zA-Z]{2})(\d+)/, '$1 $2')
+      : null,
   );
 
   const dateLabel = $derived(

--- a/src/lib/components/map-details/MapDetailsFrame.svelte
+++ b/src/lib/components/map-details/MapDetailsFrame.svelte
@@ -4,7 +4,7 @@
   import { fly } from 'svelte/transition';
 
   import { Modal } from '$lib/components/ui/modal';
-  import { peekModalHistory } from '$lib/components/ui/modal/Modal.svelte';
+  import { peekModalHistory } from '$lib/components/ui/modal/modal-history';
   import { Separator } from '$lib/components/ui/separator';
   import { isMediumScreen } from '$lib/utils/size';
 

--- a/src/lib/components/map-details/MapDetailsFrame.svelte
+++ b/src/lib/components/map-details/MapDetailsFrame.svelte
@@ -44,7 +44,7 @@
 {#if $isMediumScreen}
   {#if open}
     <div
-      transition:fly={{ x: -420, duration: 260, easing: cubicOut }}
+      in:fly={{ x: -420, duration: 260, easing: cubicOut }}
       class="absolute top-3 left-3 z-20 flex max-w-[calc(100vw-1.5rem)] items-start gap-2"
     >
       <aside

--- a/src/lib/components/map-details/MapDetailsPane.svelte
+++ b/src/lib/components/map-details/MapDetailsPane.svelte
@@ -11,22 +11,29 @@
   import AirportDetailsBody from './AirportDetailsBody.svelte';
   import AirportDetailsContent from './AirportDetailsContent.svelte';
   import AirportDetailsHeader from './AirportDetailsHeader.svelte';
+  import FlightDetailsActions from './FlightDetailsActions.svelte';
+  import FlightDetailsBody from './FlightDetailsBody.svelte';
+  import FlightDetailsContent from './FlightDetailsContent.svelte';
+  import FlightDetailsHeader from './FlightDetailsHeader.svelte';
   import MapDetailsFrame from './MapDetailsFrame.svelte';
   import RouteDetailsActions from './RouteDetailsActions.svelte';
   import RouteDetailsBody from './RouteDetailsBody.svelte';
   import RouteDetailsContent from './RouteDetailsContent.svelte';
   import RouteDetailsHeader from './RouteDetailsHeader.svelte';
   import { useAirportDetails } from './useAirportDetails.svelte';
+  import { useFlightDetails } from './useFlightDetails.svelte';
   import { useRouteDetails } from './useRouteDetails.svelte';
 
   let {
     flights,
     filters = $bindable(),
     tempFilters = $bindable(),
+    seatUserId,
   }: {
     flights: FlightData[];
     filters?: FlightFilters;
     tempFilters?: TempFilters;
+    seatUserId?: string;
   } = $props();
 
   const airport = useAirportDetails(
@@ -41,10 +48,16 @@
     () => tempFilters,
   );
 
+  const flight = useFlightDetails(
+    () => flights,
+    () => filters,
+  );
+
   const mobileOpen = $derived.by(() => {
     const selection = mapDetailsState.selection;
     if (selection?.type === 'airport') return !!airport.airport;
     if (selection?.type === 'route') return !!route.routeAirports;
+    if (selection?.type === 'flight') return !!flight.flight;
     return false;
   });
 </script>
@@ -52,6 +65,7 @@
 {#if $isMediumScreen}
   <AirportDetailsContent details={airport} hasFilters={!!filters} />
   <RouteDetailsContent details={route} hasFilters={!!filters} />
+  <FlightDetailsContent details={flight} hasFilters={!!filters} {seatUserId} />
 {:else}
   {#snippet mobileHeader()}
     {#if mapDetailsState.selection?.type === 'airport' && airport.airport}
@@ -62,6 +76,11 @@
         prefs={route.prefs}
         now={route.now}
         distance={route.distance}
+      />
+    {:else if mapDetailsState.selection?.type === 'flight' && flight.flight}
+      <FlightDetailsHeader
+        flight={flight.flight}
+        onShowRoute={flight.showRoute}
       />
     {/if}
   {/snippet}
@@ -78,6 +97,12 @@
         hasFilters={!!filters}
         filterActive={route.routeFilterActive}
         onToggleFilter={route.toggleRouteFilter}
+      />
+    {:else if mapDetailsState.selection?.type === 'flight' && flight.flight}
+      <FlightDetailsActions
+        hasFilters={!!filters}
+        filterActive={flight.flightFilterActive}
+        onToggleFilter={flight.toggleFlightFilter}
       />
     {/if}
   {/snippet}
@@ -106,6 +131,12 @@
         prefs={route.prefs}
         onShowAll={route.showAllFlights}
         onShowFlight={route.showFlight}
+      />
+    {:else if mapDetailsState.selection?.type === 'flight' && flight.flight}
+      <FlightDetailsBody
+        flight={flight.flight}
+        prefs={flight.prefs}
+        {seatUserId}
       />
     {/if}
   </MapDetailsFrame>

--- a/src/lib/components/map-details/MapDetailsPane.svelte
+++ b/src/lib/components/map-details/MapDetailsPane.svelte
@@ -137,6 +137,7 @@
         flight={flight.flight}
         prefs={flight.prefs}
         {seatUserId}
+        onShowInList={flight.showInList}
       />
     {/if}
   </MapDetailsFrame>

--- a/src/lib/components/map-details/MapDetailsPane.svelte
+++ b/src/lib/components/map-details/MapDetailsPane.svelte
@@ -105,6 +105,7 @@
         lastFlownLabel={route.lastFlownLabel}
         prefs={route.prefs}
         onShowAll={route.showAllFlights}
+        onShowFlight={route.showFlight}
       />
     {/if}
   </MapDetailsFrame>

--- a/src/lib/components/map-details/MapDetailsPane.svelte
+++ b/src/lib/components/map-details/MapDetailsPane.svelte
@@ -48,10 +48,7 @@
     () => tempFilters,
   );
 
-  const flight = useFlightDetails(
-    () => flights,
-    () => filters,
-  );
+  const flight = useFlightDetails(() => flights);
 
   const mobileOpen = $derived.by(() => {
     const selection = mapDetailsState.selection;
@@ -65,7 +62,7 @@
 {#if $isMediumScreen}
   <AirportDetailsContent details={airport} hasFilters={!!filters} />
   <RouteDetailsContent details={route} hasFilters={!!filters} />
-  <FlightDetailsContent details={flight} hasFilters={!!filters} {seatUserId} />
+  <FlightDetailsContent details={flight} {seatUserId} />
 {:else}
   {#snippet mobileHeader()}
     {#if mapDetailsState.selection?.type === 'airport' && airport.airport}
@@ -99,11 +96,7 @@
         onToggleFilter={route.toggleRouteFilter}
       />
     {:else if mapDetailsState.selection?.type === 'flight' && flight.flight}
-      <FlightDetailsActions
-        hasFilters={!!filters}
-        filterActive={flight.flightFilterActive}
-        onToggleFilter={flight.toggleFlightFilter}
-      />
+      <FlightDetailsActions />
     {/if}
   {/snippet}
 

--- a/src/lib/components/map-details/MapDetailsPane.svelte
+++ b/src/lib/components/map-details/MapDetailsPane.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import type {
-    FlightFilters,
-    TempFilters,
-  } from '$lib/components/flight-filters/types';
+  import type { FlightFilters } from '$lib/components/flight-filters/types';
+  import type { NavigateFlights } from '$lib/flight-navigation';
   import { closeMapDetails, mapDetailsState } from '$lib/state.svelte';
   import type { FlightData } from '$lib/utils';
   import { isMediumScreen } from '$lib/utils/size';
@@ -27,28 +25,30 @@
   let {
     flights,
     filters = $bindable(),
-    tempFilters = $bindable(),
     seatUserId,
+    onNavigate,
   }: {
     flights: FlightData[];
     filters?: FlightFilters;
-    tempFilters?: TempFilters;
     seatUserId?: string;
+    onNavigate: NavigateFlights;
   } = $props();
+
+  const navigateFlights: NavigateFlights = (intent) => onNavigate(intent);
 
   const airport = useAirportDetails(
     () => flights,
     () => filters,
-    () => tempFilters,
+    navigateFlights,
   );
 
   const route = useRouteDetails(
     () => flights,
     () => filters,
-    () => tempFilters,
+    navigateFlights,
   );
 
-  const flight = useFlightDetails(() => flights);
+  const flight = useFlightDetails(() => flights, navigateFlights);
 
   const mobileOpen = $derived.by(() => {
     const selection = mapDetailsState.selection;

--- a/src/lib/components/map-details/RouteDetailsActions.svelte
+++ b/src/lib/components/map-details/RouteDetailsActions.svelte
@@ -18,15 +18,22 @@
 
 <DetailsActionButton
   label="Locate route"
+  shortLabel="Locate"
   icon={Locate}
   onclick={focusMapDetails}
 />
 {#if hasFilters}
   <DetailsActionButton
     label={filterActive ? 'Clear route filter' : 'Filter map to route'}
+    shortLabel={filterActive ? 'Clear' : 'Filter'}
     icon={Funnel}
     onclick={onToggleFilter}
     pressed={filterActive}
   />
 {/if}
-<DetailsActionButton label="Close details" icon={X} onclick={closeMapDetails} />
+<DetailsActionButton
+  label="Close details"
+  shortLabel="Close"
+  icon={X}
+  onclick={closeMapDetails}
+/>

--- a/src/lib/components/map-details/RouteDetailsBody.svelte
+++ b/src/lib/components/map-details/RouteDetailsBody.svelte
@@ -5,7 +5,7 @@
   import { AirlineIcon, RouteArrow } from '$lib/components/display';
   import { Button } from '$lib/components/ui/button';
   import { mapDetailsState } from '$lib/state.svelte';
-  import type { FlightData } from '$lib/utils';
+  import { type FlightData } from '$lib/utils';
   import { distanceUnitLabel, formatFlightDate } from '$lib/utils/preferences';
   import type { Preferences } from '$lib/zod/user';
 
@@ -39,6 +39,12 @@
     }
     return flight.aircraft?.name ?? flight.aircraftReg ?? null;
   };
+
+  // A programmatic pane swap (row click) can skip pointerleave, so clear the
+  // shared hover token when the body unmounts to avoid a stuck map highlight.
+  $effect(() => () => {
+    mapDetailsState.hoveredFlightTrackId = null;
+  });
 </script>
 
 {#snippet flightRow(flight: FlightData)}
@@ -51,6 +57,8 @@
     <button
       type="button"
       class="group grid w-full cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-2 py-2.5 text-left transition-colors hover:bg-background/55 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+      onpointerenter={() => (mapDetailsState.hoveredFlightTrackId = flight.id)}
+      onpointerleave={() => (mapDetailsState.hoveredFlightTrackId = null)}
       onclick={() => onShowFlight(flight.id)}
       aria-label="Open flight {flight.from?.iata ??
         flight.from?.icao ??

--- a/src/lib/components/map-details/RouteDetailsBody.svelte
+++ b/src/lib/components/map-details/RouteDetailsBody.svelte
@@ -60,9 +60,9 @@
       onpointerenter={() => (mapDetailsState.hoveredFlightTrackId = flight.id)}
       onpointerleave={() => (mapDetailsState.hoveredFlightTrackId = null)}
       onclick={() => onShowFlight(flight.id)}
-      aria-label="Open flight {flight.from?.iata ??
+      aria-label="Open flight details for {flight.from?.iata ??
         flight.from?.icao ??
-        'N/A'} to {flight.to?.iata ?? flight.to?.icao ?? 'N/A'} in flight list"
+        'N/A'} to {flight.to?.iata ?? flight.to?.icao ?? 'N/A'}"
     >
       <div class="flex w-8 shrink-0 justify-center">
         <AirlineIcon airline={flight.airline} size={28} fallback="plane" />

--- a/src/lib/components/map-details/RouteDetailsBody.svelte
+++ b/src/lib/components/map-details/RouteDetailsBody.svelte
@@ -16,13 +16,15 @@
     lastFlownLabel,
     prefs,
     onShowAll,
+    onShowFlight,
   }: {
     routeFlights: FlightData[];
     airlineCount: number;
     distance: number | null;
     lastFlownLabel: string | null;
     prefs: Preferences;
-    onShowAll: (flightId?: number) => void;
+    onShowAll: () => void;
+    onShowFlight: (flightId: number) => void;
   } = $props();
 
   const formatFlightNumber = (flightNumber: string | null | undefined) => {
@@ -49,7 +51,7 @@
     <button
       type="button"
       class="group grid w-full cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-2 py-2.5 text-left transition-colors hover:bg-background/55 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-      onclick={() => onShowAll(flight.id)}
+      onclick={() => onShowFlight(flight.id)}
       aria-label="Open flight {flight.from?.iata ??
         flight.from?.icao ??
         'N/A'} to {flight.to?.iata ?? flight.to?.icao ?? 'N/A'} in flight list"

--- a/src/lib/components/map-details/RouteDetailsContent.svelte
+++ b/src/lib/components/map-details/RouteDetailsContent.svelte
@@ -55,6 +55,7 @@
       lastFlownLabel={details.lastFlownLabel}
       prefs={details.prefs}
       onShowAll={details.showAllFlights}
+      onShowFlight={details.showFlight}
     />
   {/if}
 </MapDetailsFrame>

--- a/src/lib/components/map-details/useAirportDetails.svelte.ts
+++ b/src/lib/components/map-details/useAirportDetails.svelte.ts
@@ -1,22 +1,12 @@
-import type {
-  FlightFilters,
-  TempFilters,
-} from '$lib/components/flight-filters/types';
-import {
-  setTempArrivalAirport,
-  setTempDepartureAirport,
-} from '$lib/components/flight-filters/types';
-import {
-  focusFlightInList,
-  mapDetailsState,
-  openModalsState,
-} from '$lib/state.svelte';
+import type { FlightFilters } from '$lib/components/flight-filters/types';
+import type { NavigateFlights } from '$lib/flight-navigation';
+import { mapDetailsState } from '$lib/state.svelte';
 import { prepareVisitedAirports, type FlightData } from '$lib/utils';
 
 export function useAirportDetails(
   flights: () => FlightData[],
   filters: () => FlightFilters | undefined,
-  tempFilters: () => TempFilters | undefined,
+  onNavigate: NavigateFlights,
 ) {
   const selectedAirportId = $derived.by(() => {
     const selection = mapDetailsState.selection;
@@ -66,18 +56,28 @@ export function useAirportDetails(
 
   const showDepartures = (flightId?: number) => {
     if (!airport) return;
-    const tf = tempFilters();
-    if (tf) setTempDepartureAirport(tf, airport.id.toString());
-    if (flightId) focusFlightInList(flightId);
-    openModalsState.listFlights = true;
+    onNavigate({
+      destination: 'list',
+      focus: {
+        type: 'airport',
+        airportId: airport.id,
+        direction: 'departure',
+        flightId,
+      },
+    });
   };
 
   const showArrivals = (flightId?: number) => {
     if (!airport) return;
-    const tf = tempFilters();
-    if (tf) setTempArrivalAirport(tf, airport.id.toString());
-    if (flightId) focusFlightInList(flightId);
-    openModalsState.listFlights = true;
+    onNavigate({
+      destination: 'list',
+      focus: {
+        type: 'airport',
+        airportId: airport.id,
+        direction: 'arrival',
+        flightId,
+      },
+    });
   };
 
   return {

--- a/src/lib/components/map-details/useFlightDetails.svelte.ts
+++ b/src/lib/components/map-details/useFlightDetails.svelte.ts
@@ -1,6 +1,10 @@
 import { page } from '$app/state';
 import type { FlightFilters } from '$lib/components/flight-filters/types';
-import { mapDetailsState, openRouteDetails } from '$lib/state.svelte';
+import {
+  mapDetailsState,
+  openFlightInList,
+  openRouteDetails,
+} from '$lib/state.svelte';
 import { type FlightData } from '$lib/utils';
 import { getPreferences } from '$lib/utils/preferences';
 
@@ -62,6 +66,11 @@ export function useFlightDetails(
     });
   };
 
+  const showInList = () => {
+    if (!flight) return;
+    openFlightInList(flight.id);
+  };
+
   return {
     get prefs() {
       return prefs;
@@ -74,5 +83,6 @@ export function useFlightDetails(
     },
     toggleFlightFilter,
     showRoute,
+    showInList,
   };
 }

--- a/src/lib/components/map-details/useFlightDetails.svelte.ts
+++ b/src/lib/components/map-details/useFlightDetails.svelte.ts
@@ -1,5 +1,4 @@
 import { page } from '$app/state';
-import type { FlightFilters } from '$lib/components/flight-filters/types';
 import {
   mapDetailsState,
   openFlightInList,
@@ -8,10 +7,7 @@ import {
 import { type FlightData } from '$lib/utils';
 import { getPreferences } from '$lib/utils/preferences';
 
-export function useFlightDetails(
-  flights: () => FlightData[],
-  filters: () => FlightFilters | undefined,
-) {
+export function useFlightDetails(flights: () => FlightData[]) {
   const prefs = $derived(getPreferences(page.data.user));
 
   const selectedFlightId = $derived.by(() => {
@@ -25,41 +21,10 @@ export function useFlightDetails(
     return flights().find((f) => f.id === id) ?? null;
   });
 
-  const flightFilterActive = $derived.by(() => {
-    const f = filters();
-    if (!f || !flight) return false;
-    return (
-      f.flightIds.length === 1 &&
-      f.flightIds[0] === flight.id.toString() &&
-      f.departureAirports.length === 0 &&
-      f.arrivalAirports.length === 0 &&
-      f.airportsEither.length === 0 &&
-      f.routes.length === 0
-    );
-  });
-
-  const toggleFlightFilter = () => {
-    const f = filters();
-    if (!f || !flight) return;
-
-    if (flightFilterActive) {
-      f.flightIds = [];
-      return;
-    }
-
-    f.departureAirports = [];
-    f.arrivalAirports = [];
-    f.airportsEither = [];
-    f.routes = [];
-    f.flightIds = [flight.id.toString()];
-  };
-
   const showRoute = () => {
     if (!flight?.from || !flight.to) return;
-    // Drop the single-flight isolation so the route's flights are all visible
-    // again, then swap the pane over to the route details.
-    const f = filters();
-    if (f) f.flightIds = [];
+    // Swap the pane over to the route details; the map follows the pane, so it
+    // returns to the whole route's flights on its own.
     openRouteDetails({
       a: flight.from.id.toString(),
       b: flight.to.id.toString(),
@@ -78,10 +43,6 @@ export function useFlightDetails(
     get flight() {
       return flight;
     },
-    get flightFilterActive() {
-      return flightFilterActive;
-    },
-    toggleFlightFilter,
     showRoute,
     showInList,
   };

--- a/src/lib/components/map-details/useFlightDetails.svelte.ts
+++ b/src/lib/components/map-details/useFlightDetails.svelte.ts
@@ -1,0 +1,78 @@
+import { page } from '$app/state';
+import type { FlightFilters } from '$lib/components/flight-filters/types';
+import { mapDetailsState, openRouteDetails } from '$lib/state.svelte';
+import { type FlightData } from '$lib/utils';
+import { getPreferences } from '$lib/utils/preferences';
+
+export function useFlightDetails(
+  flights: () => FlightData[],
+  filters: () => FlightFilters | undefined,
+) {
+  const prefs = $derived(getPreferences(page.data.user));
+
+  const selectedFlightId = $derived.by(() => {
+    const selection = mapDetailsState.selection;
+    return selection?.type === 'flight' ? selection.flightId : null;
+  });
+
+  const flight = $derived.by(() => {
+    const id = selectedFlightId;
+    if (id === null) return null;
+    return flights().find((f) => f.id === id) ?? null;
+  });
+
+  const flightFilterActive = $derived.by(() => {
+    const f = filters();
+    if (!f || !flight) return false;
+    return (
+      f.flightIds.length === 1 &&
+      f.flightIds[0] === flight.id.toString() &&
+      f.departureAirports.length === 0 &&
+      f.arrivalAirports.length === 0 &&
+      f.airportsEither.length === 0 &&
+      f.routes.length === 0
+    );
+  });
+
+  const toggleFlightFilter = () => {
+    const f = filters();
+    if (!f || !flight) return;
+
+    if (flightFilterActive) {
+      f.flightIds = [];
+      return;
+    }
+
+    f.departureAirports = [];
+    f.arrivalAirports = [];
+    f.airportsEither = [];
+    f.routes = [];
+    f.flightIds = [flight.id.toString()];
+  };
+
+  const showRoute = () => {
+    if (!flight?.from || !flight.to) return;
+    // Drop the single-flight isolation so the route's flights are all visible
+    // again, then swap the pane over to the route details.
+    const f = filters();
+    if (f) f.flightIds = [];
+    openRouteDetails({
+      a: flight.from.id.toString(),
+      b: flight.to.id.toString(),
+    });
+  };
+
+  return {
+    get prefs() {
+      return prefs;
+    },
+    get flight() {
+      return flight;
+    },
+    get flightFilterActive() {
+      return flightFilterActive;
+    },
+    toggleFlightFilter,
+    showRoute,
+  };
+}

--- a/src/lib/components/map-details/useFlightDetails.svelte.ts
+++ b/src/lib/components/map-details/useFlightDetails.svelte.ts
@@ -1,13 +1,13 @@
 import { page } from '$app/state';
-import {
-  mapDetailsState,
-  openFlightInList,
-  openRouteDetails,
-} from '$lib/state.svelte';
+import type { NavigateFlights } from '$lib/flight-navigation';
+import { mapDetailsState, openRouteDetails } from '$lib/state.svelte';
 import { type FlightData } from '$lib/utils';
 import { getPreferences } from '$lib/utils/preferences';
 
-export function useFlightDetails(flights: () => FlightData[]) {
+export function useFlightDetails(
+  flights: () => FlightData[],
+  onNavigate: NavigateFlights,
+) {
   const prefs = $derived(getPreferences(page.data.user));
 
   const selectedFlightId = $derived.by(() => {
@@ -33,7 +33,10 @@ export function useFlightDetails(flights: () => FlightData[]) {
 
   const showInList = () => {
     if (!flight) return;
-    openFlightInList(flight.id);
+    onNavigate({
+      destination: 'list',
+      focus: { type: 'flight', flightId: flight.id },
+    });
   };
 
   return {

--- a/src/lib/components/map-details/useRouteDetails.svelte.ts
+++ b/src/lib/components/map-details/useRouteDetails.svelte.ts
@@ -7,7 +7,7 @@ import type {
 import { normalizeRoute } from '$lib/components/flight-filters/types';
 import {
   mapDetailsState,
-  openFlightOnMap,
+  openFlightDetails,
   openRouteInList,
 } from '$lib/state.svelte';
 import { type FlightData } from '$lib/utils';
@@ -119,13 +119,13 @@ export function useRouteDetails(
 
   const showAllFlights = () => {
     if (!selectedRoute) return;
-    openRouteInList(filters(), tempFilters(), selectedRoute);
+    openRouteInList(tempFilters(), selectedRoute);
   };
 
   const showFlight = (flightId: number) => {
-    // Isolate the flight on the map (so the pane's flight is the only one drawn)
-    // and open its Flight Details pane.
-    openFlightOnMap(filters(), tempFilters(), flightId);
+    // Open the flight's details pane; while it's open the map isolates that
+    // flight (a derived view of the pane state, not a persistent filter).
+    openFlightDetails(flightId);
   };
 
   return {

--- a/src/lib/components/map-details/useRouteDetails.svelte.ts
+++ b/src/lib/components/map-details/useRouteDetails.svelte.ts
@@ -5,12 +5,13 @@ import type {
   TempFilters,
 } from '$lib/components/flight-filters/types';
 import {
+  clearTempFilters,
   normalizeRoute,
   setTempRoute,
 } from '$lib/components/flight-filters/types';
 import {
-  closeMapDetails,
   mapDetailsState,
+  openFlightDetails,
   openModalsState,
 } from '$lib/state.svelte';
 import { type FlightData } from '$lib/utils';
@@ -131,8 +132,16 @@ export function useRouteDetails(
   const showFlight = (flightId: number) => {
     const f = filters();
     if (!f) return;
+    // Isolate the flight on the map so the details pane's flight is the only
+    // one drawn, then open the flight details pane focused on it.
+    f.departureAirports = [];
+    f.arrivalAirports = [];
+    f.airportsEither = [];
+    f.routes = [];
     f.flightIds = [flightId.toString()];
-    closeMapDetails();
+    const tf = tempFilters();
+    if (tf) clearTempFilters(tf);
+    openFlightDetails(flightId);
   };
 
   return {

--- a/src/lib/components/map-details/useRouteDetails.svelte.ts
+++ b/src/lib/components/map-details/useRouteDetails.svelte.ts
@@ -1,15 +1,12 @@
 import { page } from '$app/state';
-import type {
-  FlightFilters,
-  Route,
-  TempFilters,
-} from '$lib/components/flight-filters/types';
-import { normalizeRoute } from '$lib/components/flight-filters/types';
 import {
-  mapDetailsState,
-  openFlightDetails,
-  openRouteInList,
-} from '$lib/state.svelte';
+  normalizeRoute,
+  routeMatchesEndpoints,
+  type FlightFilters,
+  type Route,
+} from '$lib/components/flight-filters/types';
+import type { NavigateFlights } from '$lib/flight-navigation';
+import { mapDetailsState, openFlightDetails } from '$lib/state.svelte';
 import { type FlightData } from '$lib/utils';
 import {
   convertDistance,
@@ -20,7 +17,7 @@ import {
 export function useRouteDetails(
   flights: () => FlightData[],
   filters: () => FlightFilters | undefined,
-  tempFilters: () => TempFilters | undefined,
+  onNavigate: NavigateFlights,
 ) {
   const prefs = $derived(getPreferences(page.data.user));
 
@@ -41,12 +38,7 @@ export function useRouteDetails(
   });
 
   const matchesRoute = (flight: FlightData, route: Route) => {
-    const fromId = flight.from?.id.toString();
-    const toId = flight.to?.id.toString();
-    return (
-      (fromId === route.a && toId === route.b) ||
-      (fromId === route.b && toId === route.a)
-    );
+    return routeMatchesEndpoints(flight.from?.id, flight.to?.id, route);
   };
 
   const routeFlights = $derived.by(() => {
@@ -119,7 +111,10 @@ export function useRouteDetails(
 
   const showAllFlights = () => {
     if (!selectedRoute) return;
-    openRouteInList(tempFilters(), selectedRoute);
+    onNavigate({
+      destination: 'list',
+      focus: { type: 'route', route: selectedRoute },
+    });
   };
 
   const showFlight = (flightId: number) => {

--- a/src/lib/components/map-details/useRouteDetails.svelte.ts
+++ b/src/lib/components/map-details/useRouteDetails.svelte.ts
@@ -9,7 +9,7 @@ import {
   setTempRoute,
 } from '$lib/components/flight-filters/types';
 import {
-  focusFlightInList,
+  closeMapDetails,
   mapDetailsState,
   openModalsState,
 } from '$lib/state.svelte';
@@ -120,11 +120,19 @@ export function useRouteDetails(
     f.routes = [normalizeRoute(selectedRoute.a, selectedRoute.b)];
   };
 
-  const showAllFlights = (flightId?: number) => {
+  const showAllFlights = () => {
     const tf = tempFilters();
+    const f = filters();
+    if (f) f.flightIds = [];
     if (selectedRoute && tf) setTempRoute(tf, selectedRoute);
-    if (flightId) focusFlightInList(flightId);
     openModalsState.listFlights = true;
+  };
+
+  const showFlight = (flightId: number) => {
+    const f = filters();
+    if (!f) return;
+    f.flightIds = [flightId.toString()];
+    closeMapDetails();
   };
 
   return {
@@ -157,5 +165,6 @@ export function useRouteDetails(
     },
     toggleRouteFilter,
     showAllFlights,
+    showFlight,
   };
 }

--- a/src/lib/components/map-details/useRouteDetails.svelte.ts
+++ b/src/lib/components/map-details/useRouteDetails.svelte.ts
@@ -4,15 +4,11 @@ import type {
   Route,
   TempFilters,
 } from '$lib/components/flight-filters/types';
-import {
-  clearTempFilters,
-  normalizeRoute,
-  setTempRoute,
-} from '$lib/components/flight-filters/types';
+import { normalizeRoute } from '$lib/components/flight-filters/types';
 import {
   mapDetailsState,
-  openFlightDetails,
-  openModalsState,
+  openFlightOnMap,
+  openRouteInList,
 } from '$lib/state.svelte';
 import { type FlightData } from '$lib/utils';
 import {
@@ -122,26 +118,14 @@ export function useRouteDetails(
   };
 
   const showAllFlights = () => {
-    const tf = tempFilters();
-    const f = filters();
-    if (f) f.flightIds = [];
-    if (selectedRoute && tf) setTempRoute(tf, selectedRoute);
-    openModalsState.listFlights = true;
+    if (!selectedRoute) return;
+    openRouteInList(filters(), tempFilters(), selectedRoute);
   };
 
   const showFlight = (flightId: number) => {
-    const f = filters();
-    if (!f) return;
-    // Isolate the flight on the map so the details pane's flight is the only
-    // one drawn, then open the flight details pane focused on it.
-    f.departureAirports = [];
-    f.arrivalAirports = [];
-    f.airportsEither = [];
-    f.routes = [];
-    f.flightIds = [flightId.toString()];
-    const tf = tempFilters();
-    if (tf) clearTempFilters(tf);
-    openFlightDetails(flightId);
+    // Isolate the flight on the map (so the pane's flight is the only one drawn)
+    // and open its Flight Details pane.
+    openFlightOnMap(filters(), tempFilters(), flightId);
   };
 
   return {

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -18,6 +18,7 @@
 
   import {
     normalizeRoute,
+    type FlightFilters,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
   import {
@@ -55,7 +56,9 @@
     closeMapDetails,
     mapDetailsState,
     openAirportDetails,
+    openFlightOnMap,
     openRouteDetails,
+    openRouteInList,
   } from '$lib/state.svelte';
   import type { FlightTrackRow } from '$lib/track/schema';
   import { type FlightData, prepareVisitedAirports } from '$lib/utils';
@@ -114,11 +117,13 @@
     flights,
     flightArcs,
     flightTracks = [],
+    filters = $bindable(),
     tempFilters = $bindable(),
   }: {
     flights: FlightData[];
     flightArcs: FlightArc[];
     flightTracks?: FlightTrackRow[];
+    filters?: FlightFilters;
     tempFilters?: TempFilters;
   } = $props();
 
@@ -160,6 +165,10 @@
 
   const flightTrackPaths = $derived.by(() => {
     return buildFlightTrackPaths(flights, flightArcs, activeFlightTracks);
+  });
+
+  const flightById = $derived.by(() => {
+    return new Map(flights.map((flight) => [flight.id, flight]));
   });
 
   const flightTrackLayerData = $derived.by(() =>
@@ -251,22 +260,34 @@
   };
 
   const handleArcClick = (e: PickingInfo<FlightArc>) => {
-    if (e.object && tempFilters) {
-      const route = normalizeRoute(
-        e.object.from.id.toString(),
-        e.object.to.id.toString(),
-      );
+    if (!e.object || !tempFilters) return;
+    const route = normalizeRoute(
+      e.object.from.id.toString(),
+      e.object.to.id.toString(),
+    );
+    // While this route's pane is open, clicking its point-to-point line opens
+    // the flight list drilled down to the whole route; otherwise open (or
+    // switch to) that route's details and drop any single-flight isolation.
+    if (selectedRoute && routeMatchesArc(e.object, selectedRoute)) {
+      openRouteInList(filters, tempFilters, route);
+    } else {
+      if (filters) filters.flightIds = [];
       openRouteDetails(route);
     }
   };
 
   const handleTrackClick = (e: PickingInfo<FlightTrackPath>) => {
-    if (e.object && tempFilters) {
-      const route = normalizeRoute(
-        e.object.from.id.toString(),
-        e.object.to.id.toString(),
+    if (!e.object || !tempFilters) return;
+    // While this route's pane is open, clicking a specific flight's track opens
+    // its Flight Details pane (same as clicking the flight in the route pane);
+    // otherwise open the route details and drop any single-flight isolation.
+    if (selectedRoute && routeMatchesArc(e.object, selectedRoute)) {
+      openFlightOnMap(filters, tempFilters, e.object.flightId);
+    } else {
+      if (filters) filters.flightIds = [];
+      openRouteDetails(
+        normalizeRoute(e.object.from.id.toString(), e.object.to.id.toString()),
       );
-      openRouteDetails(route);
     }
   };
 
@@ -323,6 +344,26 @@
   const selectedRoute = $derived.by(() => {
     const selection = mapDetailsState.selection;
     return selection?.type === 'route' ? selection.route : null;
+  });
+
+  // Hovering a flight row in the route pane sets mapDetailsState.hoveredFlightTrackId
+  // but no map hover. Synthesise a hovered arc/track for that flight so the map
+  // highlights its line the same way a direct map hover would.
+  const effectiveHoveredArc = $derived.by(() => {
+    if (hoveredArc) return hoveredArc;
+    const id = mapDetailsState.hoveredFlightTrackId;
+    if (id == null) return undefined;
+    const flight = flightById.get(id);
+    if (!flight?.from || !flight.to) return undefined;
+    const route = normalizeRoute(
+      flight.from.id.toString(),
+      flight.to.id.toString(),
+    );
+    const arc = flightArcs.find((candidate) => routeMatchesArc(candidate, route));
+    if (!arc) return undefined;
+    // A tracked flight is emphasised via its track (carries flightId); a
+    // point-to-point flight is emphasised via its route's straight arc.
+    return trackFlightIds.has(id) ? { ...arc, flightId: id } : arc;
   });
 
   const selectedRouteAirportIds = $derived.by(() => {
@@ -513,6 +554,7 @@
       getSourceColor: [
         hoveredArc,
         hoveredAirport,
+        mapDetailsState.hoveredFlightTrackId,
         selectedAirportId,
         selectedRoute,
         mapPreferences.arcColor,
@@ -521,6 +563,7 @@
       getTargetColor: [
         hoveredArc,
         hoveredAirport,
+        mapDetailsState.hoveredFlightTrackId,
         selectedAirportId,
         selectedRoute,
         mapPreferences.arcColor,
@@ -559,7 +602,7 @@
 
   const getRouteInteraction = (arc: FlightArc) =>
     resolveRouteInteraction(arc, {
-      hoveredArc,
+      hoveredArc: effectiveHoveredArc,
       hoveredAirportId: hoveredAirport?.id,
       selectedAirportId,
       selectedRoute,
@@ -633,6 +676,7 @@
               standardColor: [
                 hoveredArc,
                 hoveredAirport,
+                mapDetailsState.hoveredFlightTrackId,
                 selectedAirportId,
                 selectedRoute,
                 mapPreferences.arcColor,
@@ -641,6 +685,7 @@
               altitudeColor: [
                 hoveredArc,
                 hoveredAirport,
+                mapDetailsState.hoveredFlightTrackId,
                 selectedAirportId,
                 selectedRoute,
                 isDarkMode,

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -18,7 +18,6 @@
 
   import {
     normalizeRoute,
-    type FlightFilters,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
   import {
@@ -56,7 +55,7 @@
     closeMapDetails,
     mapDetailsState,
     openAirportDetails,
-    openFlightOnMap,
+    openFlightDetails,
     openRouteDetails,
     openRouteInList,
   } from '$lib/state.svelte';
@@ -117,13 +116,11 @@
     flights,
     flightArcs,
     flightTracks = [],
-    filters = $bindable(),
     tempFilters = $bindable(),
   }: {
     flights: FlightData[];
     flightArcs: FlightArc[];
     flightTracks?: FlightTrackRow[];
-    filters?: FlightFilters;
     tempFilters?: TempFilters;
   } = $props();
 
@@ -267,11 +264,10 @@
     );
     // While this route's pane is open, clicking its point-to-point line opens
     // the flight list drilled down to the whole route; otherwise open (or
-    // switch to) that route's details and drop any single-flight isolation.
+    // switch to) that route's details.
     if (selectedRoute && routeMatchesArc(e.object, selectedRoute)) {
-      openRouteInList(filters, tempFilters, route);
+      openRouteInList(tempFilters, route);
     } else {
-      if (filters) filters.flightIds = [];
       openRouteDetails(route);
     }
   };
@@ -279,12 +275,12 @@
   const handleTrackClick = (e: PickingInfo<FlightTrackPath>) => {
     if (!e.object || !tempFilters) return;
     // While this route's pane is open, clicking a specific flight's track opens
-    // its Flight Details pane (same as clicking the flight in the route pane);
-    // otherwise open the route details and drop any single-flight isolation.
+    // its Flight Details pane (same as clicking the flight in the route pane) —
+    // which isolates that flight on the map for as long as the pane is open;
+    // otherwise open the route details.
     if (selectedRoute && routeMatchesArc(e.object, selectedRoute)) {
-      openFlightOnMap(filters, tempFilters, e.object.flightId);
+      openFlightDetails(e.object.flightId);
     } else {
-      if (filters) filters.flightIds = [];
       openRouteDetails(
         normalizeRoute(e.object.from.id.toString(), e.object.to.id.toString()),
       );

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -20,6 +20,7 @@
     normalizeRoute,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
+  import type { NavigateFlights } from '$lib/flight-navigation';
   import {
     buildArcFrequencyPercentileByRoute,
     buildFlightTrackPaths,
@@ -57,7 +58,6 @@
     openAirportDetails,
     openFlightDetails,
     openRouteDetails,
-    openRouteInList,
   } from '$lib/state.svelte';
   import type { FlightTrackRow } from '$lib/track/schema';
   import { type FlightData, prepareVisitedAirports } from '$lib/utils';
@@ -117,11 +117,13 @@
     flightArcs,
     flightTracks = [],
     tempFilters = $bindable(),
+    onNavigate,
   }: {
     flights: FlightData[];
     flightArcs: FlightArc[];
     flightTracks?: FlightTrackRow[];
     tempFilters?: TempFilters;
+    onNavigate?: NavigateFlights;
   } = $props();
 
   const visitedAirports = $derived.by(() => {
@@ -266,7 +268,10 @@
     // the flight list drilled down to the whole route; otherwise open (or
     // switch to) that route's details.
     if (selectedRoute && routeMatchesArc(e.object, selectedRoute)) {
-      openRouteInList(tempFilters, route);
+      onNavigate?.({
+        destination: 'list',
+        focus: { type: 'route', route },
+      });
     } else {
       openRouteDetails(route);
     }
@@ -335,6 +340,11 @@
   const selectedAirportId = $derived.by(() => {
     const selection = mapDetailsState.selection;
     return selection?.type === 'airport' ? selection.airportId : null;
+  });
+
+  const selectedFlightId = $derived.by(() => {
+    const selection = mapDetailsState.selection;
+    return selection?.type === 'flight' ? selection.flightId : null;
   });
 
   const selectedRoute = $derived.by(() => {
@@ -484,7 +494,10 @@
   };
 
   const getVisibleArcWidth = (d: FlightArc) => {
-    const width = getArcWidth(d);
+    const width =
+      selectedFlightId === null
+        ? getArcWidth(d)
+        : UNIFORM_ARC_WIDTH[mapPreferences.arcThicknessScale];
     return routeMatchesArc(d, selectedRoute) ? Math.max(width + 1.5, 3) : width;
   };
 
@@ -570,6 +583,7 @@
       getWidth: [
         mapPreferences.arcThickness,
         mapPreferences.arcThicknessScale,
+        selectedFlightId,
         selectedRoute,
         arcFrequencyPercentileByRoute,
       ],
@@ -644,6 +658,7 @@
   const flightTrackWidthUpdateTriggers = $derived([
     mapPreferences.arcThickness,
     mapPreferences.arcThicknessScale,
+    selectedFlightId,
     selectedRoute,
     arcFrequencyPercentileByRoute,
   ]);

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -359,7 +359,9 @@
       flight.from.id.toString(),
       flight.to.id.toString(),
     );
-    const arc = flightArcs.find((candidate) => routeMatchesArc(candidate, route));
+    const arc = flightArcs.find((candidate) =>
+      routeMatchesArc(candidate, route),
+    );
     if (!arc) return undefined;
     // A tracked flight is emphasised via its track (carries flightId); a
     // point-to-point flight is emphasised via its route's straight arc.

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -34,11 +34,14 @@
   } from '$lib/components/flight-filters/model';
   import {
     hasTempFilters as hasActiveTempFilters,
+    routeMatchesEndpoints,
     type FlightFilters,
     type Route,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
   import * as Popover from '$lib/components/ui/popover';
+  import type { NavigateFlights } from '$lib/flight-navigation';
+  import { AIRPORT_DETAIL_LAYER_IDS } from '$lib/map/airport-style';
   import {
     getDefaultAppMapStyleUrl,
     getAppMapImages,
@@ -55,7 +58,6 @@
     OPENAIP_TILE_URL_TEMPLATE,
     type OpenAipTheme,
   } from '$lib/map/openaip';
-  import { AIRPORT_DETAIL_LAYER_IDS } from '$lib/map/airport-style';
   import { registerPmtilesProtocol } from '$lib/map/pmtiles';
   import {
     bindRuntimeMapImages,
@@ -88,12 +90,14 @@
     flightTracks = [],
     filters = $bindable(),
     tempFilters = $bindable(),
+    onNavigate,
   }: {
     flights: FlightData[];
     filteredFlights: FlightData[];
     flightTracks?: FlightTrackRow[];
     filters?: FlightFilters;
     tempFilters?: TempFilters;
+    onNavigate?: NavigateFlights;
   } = $props();
 
   const showScopeBanner = $derived(flightScopeState.scope !== 'mine');
@@ -278,12 +282,7 @@
     item: { from: { id: number }; to: { id: number } },
     route: Route,
   ) => {
-    const fromId = item.from.id.toString();
-    const toId = item.to.id.toString();
-    return (
-      (fromId === route.a && toId === route.b) ||
-      (fromId === route.b && toId === route.a)
-    );
+    return routeMatchesEndpoints(item.from.id, item.to.id, route);
   };
 
   const activeAirportFilter = $derived.by(() => {
@@ -754,6 +753,7 @@
       {flightArcs}
       {flightTracks}
       bind:tempFilters
+      {onNavigate}
     />
   </MapLibre>
 

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -317,7 +317,16 @@
       previousFilteredCount > 0 &&
       !hasTempFilters
     ) {
-      fitFlights();
+      // Defer the fit to the next frame. When this change coincides with a
+      // details pane closing (e.g. "Show on map" from the flight list), the
+      // selection effect runs a padding easeTo in the same update that keeps
+      // the current center; running the fit synchronously here would be
+      // cancelled by it. Deferring lets the fit issue the final camera command.
+      requestAnimationFrame(() => {
+        // A pane re-claimed the camera in the meantime — let it win.
+        if (mapDetailsState.selection) return;
+        fitFlights();
+      });
     }
 
     // If there are temp filters, we don't want to fit as that means the user

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -472,7 +472,7 @@
     {#if flights.length}
       <Control position="top-right">
         <ControlGroup>
-          <ControlButton onclick={fitFlights} title="Show all flights">
+          <ControlButton onclick={fitFlights} title="Fit visible flights">
             <Fullscreen size={20} />
           </ControlButton>
           {#if filters}

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -478,18 +478,25 @@
         targetZoom = 13;
       } else {
         // route or flight — both fit a single great-circle arc between two
-        // airports. For a flight, derive its route from its endpoints.
-        const arcRoute =
-          selection.type === 'route'
-            ? selection.route
-            : (() => {
-                const f = flights.find((fl) => fl.id === selection.flightId);
-                if (!f?.from || !f?.to) return null;
-                return { a: f.from.id.toString(), b: f.to.id.toString() };
-              })();
-        if (!arcRoute) return;
-
-        const arc = allFlightArcs.find((item) => routeMatches(item, arcRoute));
+        // airports, resolved by airport ID straight from the flights. The
+        // deduplicated arc list (allFlightArcs) is keyed by airport *name*, so
+        // two distinct airport pairs sharing a name collapse into one arc under
+        // the first pair's IDs; an ID lookup there would miss the second pair
+        // and leave the map unfocused.
+        const arc = (() => {
+          if (selection.type === 'flight') {
+            const f = flights.find((fl) => fl.id === selection.flightId);
+            return f?.from && f.to ? { from: f.from, to: f.to } : null;
+          }
+          const route = selection.route;
+          const f = flights.find(
+            (fl) =>
+              fl.from != null &&
+              fl.to != null &&
+              routeMatches({ from: fl.from, to: fl.to }, route),
+          );
+          return f?.from && f.to ? { from: f.from, to: f.to } : null;
+        })();
         if (!arc) return;
 
         if (mapPreferences.projection === 'globe') {

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -477,9 +477,19 @@
         targetCenter = [airport.lon, airport.lat];
         targetZoom = 13;
       } else {
-        const arc = allFlightArcs.find((item) =>
-          routeMatches(item, selection.route),
-        );
+        // route or flight — both fit a single great-circle arc between two
+        // airports. For a flight, derive its route from its endpoints.
+        const arcRoute =
+          selection.type === 'route'
+            ? selection.route
+            : (() => {
+                const f = flights.find((fl) => fl.id === selection.flightId);
+                if (!f?.from || !f?.to) return null;
+                return { a: f.from.id.toString(), b: f.to.id.toString() };
+              })();
+        if (!arcRoute) return;
+
+        const arc = allFlightArcs.find((item) => routeMatches(item, arcRoute));
         if (!arc) return;
 
         if (mapPreferences.projection === 'globe') {

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -733,6 +733,7 @@
       flights={filteredFlights}
       {flightArcs}
       {flightTracks}
+      bind:filters
       bind:tempFilters
     />
   </MapLibre>

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -162,8 +162,21 @@
     });
   };
 
+  // While the flight details panel is open, the map isolates that one flight;
+  // dismissing the panel returns the map to the full filtered set. This is a
+  // derived view of the panel state, not a persistent filter.
+  const highlightedFlightId = $derived(
+    mapDetailsState.selection?.type === 'flight'
+      ? mapDetailsState.selection.flightId
+      : null,
+  );
+  const drawnFlights = $derived(
+    highlightedFlightId !== null
+      ? flights.filter((flight) => flight.id === highlightedFlightId)
+      : filteredFlights,
+  );
   const flightArcs = $derived.by(() => {
-    return prepareFlightArcData(filteredFlights);
+    return prepareFlightArcData(drawnFlights);
   });
   const trackFlightIds = $derived(
     new Set(flightTracks.map((track) => track.flightId)),
@@ -737,10 +750,9 @@
     {/if}
 
     <AirportsArcsLayer
-      flights={filteredFlights}
+      flights={drawnFlights}
       {flightArcs}
       {flightTracks}
-      bind:filters
       bind:tempFilters
     />
   </MapLibre>

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Funnel, Fullscreen, Undo2 } from '@o7/icon/lucide';
-  import maplibregl from 'maplibre-gl';
+  import type { Map as MapLibreMap } from 'maplibre-gl';
   import { mode } from 'mode-watcher';
   import { onDestroy, onMount, untrack } from 'svelte';
   import {
@@ -13,10 +13,10 @@
     NavigationControl,
   } from 'svelte-maplibre';
 
+  import FlightTrackLegend from './FlightTrackLegend.svelte';
   import MapAppearanceControl from './MapAppearanceControl.svelte';
   import MapFallback from './MapFallback.svelte';
   import MapStatusShelf from './MapStatusShelf.svelte';
-  import FlightTrackLegend from './FlightTrackLegend.svelte';
   import OpenAipOverlay from './OpenAipOverlay.svelte';
   import RainViewerLayer from './RainViewerLayer.svelte';
   import TimeOfDayLayer from './TimeOfDayLayer.svelte';
@@ -41,13 +41,18 @@
   } from '$lib/components/flight-filters/types';
   import * as Popover from '$lib/components/ui/popover';
   import type { NavigateFlights } from '$lib/flight-navigation';
+  import { includeFocusedRouteOnMap } from '$lib/flight-visibility';
   import { AIRPORT_DETAIL_LAYER_IDS } from '$lib/map/airport-style';
   import {
     getDefaultAppMapStyleUrl,
     getAppMapImages,
     getConfiguredAppMapStyleUrl,
   } from '$lib/map/app-style';
-  import { globeCameraForArcs } from '$lib/map/globe-fit';
+  import {
+    createMapCameraController,
+    type CameraFocusTarget,
+    type MapCameraController,
+  } from '$lib/map/camera-controller';
   import { hasFallbackFlightArcs } from '$lib/map/flight-layer-data';
   import {
     initMapPreferences,
@@ -72,7 +77,6 @@
   } from '$lib/state.svelte';
   import type { FlightTrackRow } from '$lib/track/schema';
   import {
-    calculateBounds,
     cn,
     prepareFlightArcData,
     prepareVisitedAirports,
@@ -103,19 +107,11 @@
   const showScopeBanner = $derived(flightScopeState.scope !== 'mine');
   const alignStatusWithDetails = $derived(!!mapDetailsState.selection);
 
-  let map: maplibregl.Map | undefined = $state.raw(undefined);
+  let map: MapLibreMap | undefined = $state.raw(undefined);
+  let cameraController: MapCameraController | undefined = $state.raw(undefined);
   let canRenderMap = $state(!browser);
-  type CameraSnapshot = {
-    center: [number, number];
-    zoom: number;
-    bearing: number;
-    pitch: number;
-  };
-  let previousCamera: CameraSnapshot | null = $state(null);
   let filterDrawerOpen = $state(false);
   let showPreviousView = $state(false);
-  let programmaticCameraMove = false;
-  let handledFocusRequest = $state(-1);
   const currentTheme = $derived(mode.current ?? 'light');
   const style = $derived(
     getConfiguredAppMapStyleUrl(
@@ -155,32 +151,25 @@
       : 'none',
   );
 
-  const resetUnsupportedCamera = (m: maplibregl.Map) => {
-    const bearing = mapRotationEnabled ? m.getBearing() : 0;
-    if (m.getPitch() === 0 && m.getBearing() === bearing) return;
-    m.easeTo({
-      pitch: 0,
-      bearing,
-      duration: 0,
-      essential: true,
-    });
-  };
-
-  // While the flight details panel is open, the map isolates that one flight;
-  // dismissing the panel returns the map to the full filtered set. This is a
-  // derived view of the panel state, not a persistent filter.
-  const highlightedFlightId = $derived(
-    mapDetailsState.selection?.type === 'flight'
-      ? mapDetailsState.selection.flightId
-      : null,
-  );
-  const drawnFlights = $derived(
-    highlightedFlightId !== null
-      ? flights.filter((flight) => flight.id === highlightedFlightId)
-      : filteredFlights,
-  );
+  // Details focus is a temporary view, not a persistent filter. Flight details
+  // isolate one flight. Route details retain the filtered map and add any
+  // flights on the focused route that the persistent filters excluded.
+  const drawnFlights = $derived.by(() => {
+    const selection = mapDetailsState.selection;
+    if (selection?.type === 'flight') {
+      return flights.filter((flight) => flight.id === selection.flightId);
+    }
+    return includeFocusedRouteOnMap(
+      filteredFlights,
+      flights,
+      selection?.type === 'route' ? selection.route : null,
+    );
+  });
   const flightArcs = $derived.by(() => {
     return prepareFlightArcData(drawnFlights);
+  });
+  const overviewFlightArcs = $derived.by(() => {
+    return prepareFlightArcData(filteredFlights);
   });
   const trackFlightIds = $derived(
     new Set(flightTracks.map((track) => track.flightId)),
@@ -201,79 +190,20 @@
       : { top: 40, right: 20, bottom: window.innerHeight * 0.55, left: 20 };
   };
 
+  let automaticFitRequest = $state(0);
+  const requestAutomaticFit = () => {
+    automaticFitRequest += 1;
+  };
+
   export const fitFlights = () => {
-    if (!map || !flightArcs) return;
-
-    // Add breathing-room margin on top of any current panel padding so this
-    // also looks reasonable when a details panel is open. Set via setPadding
-    // (no `padding` option on fitBounds) to avoid maplibre's double-counting.
-    const base = detailsPanePadding();
-    const padding = {
-      top: base.top + 60,
-      right: base.right + 60,
-      bottom: base.bottom + 60,
-      left: base.left + 60,
-    };
-
-    // On the globe a bounding-box fit can be unsatisfiable (flights spanning
-    // more than a hemisphere make fitBounds silently give up), so fit a
-    // spherical cap around the flights instead.
-    if (mapPreferences.projection === 'globe') {
-      const canvas = map.getCanvas();
-      const camera = globeCameraForArcs(flightArcs, {
-        width: canvas.clientWidth,
-        height: canvas.clientHeight,
-        padding,
-      });
-      if (!camera) return;
-      map.setPadding(padding);
-      map.flyTo({
-        center: camera.center,
-        zoom: camera.zoom,
-        essential: true,
-      });
-      return;
-    }
-
-    const bounds = calculateBounds(flightArcs);
-    if (!bounds) return;
-
-    map.setPadding(padding);
-    map.fitBounds(bounds);
-  };
-
-  const snapshotCamera = (): CameraSnapshot | null => {
-    if (!map) return null;
-    const center = map.getCenter();
-    return {
-      center: [center.lng, center.lat],
-      zoom: map.getZoom(),
-      bearing: map.getBearing(),
-      pitch: map.getPitch(),
-    };
-  };
-
-  const markProgrammaticMove = () => {
-    if (!map) return;
-    programmaticCameraMove = true;
-    map.once('moveend', () => {
-      programmaticCameraMove = false;
+    cameraController?.fit(flightArcs, {
+      projection: mapPreferences.projection,
+      padding: detailsPanePadding(),
     });
   };
 
   const restorePreviousView = () => {
-    if (!map || !previousCamera) return;
-    markProgrammaticMove();
-    map.easeTo({
-      center: previousCamera.center,
-      zoom: previousCamera.zoom,
-      bearing: mapRotationEnabled ? previousCamera.bearing : 0,
-      pitch: 0,
-      duration: 650,
-      essential: true,
-    });
-    previousCamera = null;
-    showPreviousView = false;
+    cameraController?.restore(mapRotationEnabled);
   };
 
   const showClear = $derived(filters ? hasFlightFilters(filters) : false);
@@ -316,7 +246,7 @@
     if (!flights.length) return;
 
     if (filteredFlights.length) {
-      fitFlights();
+      requestAutomaticFit();
     }
 
     flightAddedState.added = false;
@@ -329,16 +259,7 @@
       previousFilteredCount > 0 &&
       !hasTempFilters
     ) {
-      // Defer the fit to the next frame. When this change coincides with a
-      // details pane closing (e.g. "Show on map" from the flight list), the
-      // selection effect runs a padding easeTo in the same update that keeps
-      // the current center; running the fit synchronously here would be
-      // cancelled by it. Deferring lets the fit issue the final camera command.
-      requestAnimationFrame(() => {
-        // A pane re-claimed the camera in the meantime — let it win.
-        if (mapDetailsState.selection) return;
-        fitFlights();
-      });
+      requestAutomaticFit();
     }
 
     // If there are temp filters, we don't want to fit as that means the user
@@ -408,31 +329,8 @@
         m.keyboard.disableRotation();
         m.touchZoomRotate.disableRotation();
       }
-      resetUnsupportedCamera(m);
+      cameraController?.normalizeOrientation(mapRotationEnabled);
     });
-  });
-
-  $effect(() => {
-    const m = map;
-    if (!m) return;
-
-    const clearPreviousView = () => {
-      if (programmaticCameraMove) return;
-      previousCamera = null;
-      showPreviousView = false;
-    };
-
-    m.on('dragstart', clearPreviousView);
-    m.on('zoomstart', clearPreviousView);
-    m.on('rotatestart', clearPreviousView);
-    m.on('pitchstart', clearPreviousView);
-
-    return () => {
-      m.off('dragstart', clearPreviousView);
-      m.off('zoomstart', clearPreviousView);
-      m.off('rotatestart', clearPreviousView);
-      m.off('pitchstart', clearPreviousView);
-    };
   });
 
   // Drive edge padding + camera focus from details-pane state.
@@ -445,49 +343,27 @@
   // airport/route after a deselect), use easeTo so `padding` is interpolated
   // smoothly — flyTo treats padding as an end-state and would snap.
   //
-  // Route fits go through cameraForBounds. maplibre's cameraForBounds adds
-  // edge + option padding for screen size but uses ONLY option for the
-  // center offset, so different (edge, option) splits with the same total
-  // produce different centers. The route compute path pins the split by
-  // temporarily setting persistent to target around the cameraForBounds
-  // call, so a reselect after a deselect computes the same center as the
-  // original open and `cameraMoved` correctly reports false.
-  //
-  // untrack guards every map mutation: svelte-maplibre's bind:map re-emits on
-  // internal map events, so a tracked mutation here would loop.
-  let prevHasSelection = false;
-  let prevMediumScreen: boolean | null = null;
-  let paddingInitialized = false;
   $effect(() => {
     const selection = mapDetailsState.selection;
     const focusRequest = mapDetailsState.focusRequest;
-    const mediumScreen = $isMediumScreen;
-    if (!map) return;
+    const controller = cameraController;
+    if (!controller) return;
 
-    const hasSelection = !!selection;
     const padding = detailsPanePadding();
-    const needsFocus = hasSelection && focusRequest !== handledFocusRequest;
-    const paddingChanged =
-      paddingInitialized &&
-      (prevHasSelection !== hasSelection || prevMediumScreen !== mediumScreen);
+    let focusTarget: CameraFocusTarget | undefined;
 
-    prevHasSelection = hasSelection;
-    prevMediumScreen = mediumScreen;
-    paddingInitialized = true;
-
-    if (needsFocus && selection) {
-      handledFocusRequest = focusRequest;
-
-      let targetCenter: [number, number];
-      let targetZoom: number;
-
+    if (selection) {
       if (selection.type === 'airport') {
         const airport = allVisitedAirports.find(
           (a) => a.id === selection.airportId,
         );
-        if (!airport) return;
-        targetCenter = [airport.lon, airport.lat];
-        targetZoom = 13;
+        if (airport) {
+          focusTarget = {
+            type: 'point',
+            center: [airport.lon, airport.lat],
+            zoom: 13,
+          };
+        }
       } else {
         // route or flight — both fit a single great-circle arc between two
         // airports, resolved by airport ID straight from the flights. The
@@ -509,88 +385,42 @@
           );
           return f?.from && f.to ? { from: f.from, to: f.to } : null;
         })();
-        if (!arc) return;
-
-        if (mapPreferences.projection === 'globe') {
-          // Same spherical-cap fit as fitFlights: cameraForBounds can
-          // silently fail on the globe for very long routes. The fit is a
-          // pure function of arc + padding, so a reselect after a deselect
-          // computes the same camera and `cameraMoved` stays false.
-          const canvas = map.getCanvas();
-          const camera = globeCameraForArcs([arc], {
-            width: canvas.clientWidth,
-            height: canvas.clientHeight,
-            padding,
-          });
-          if (!camera) return;
-          targetCenter = camera.center;
-          targetZoom = camera.zoom;
-        } else {
-          const bounds = calculateBounds([arc]);
-          if (!bounds) return;
-
-          // cameraForBounds uses (edge + option) for screen size but ONLY
-          // option for the center offset, so the same total split differently
-          // produces different centers. Pin the split to edge=target/option=0
-          // by setting persistent to target while computing — paired
-          // setPadding calls within the same JS task produce no render
-          // between, so no flicker.
-          const target = untrack(() => {
-            const saved = map!.getPadding();
-            map!.setPadding(padding);
-            const t = map!.cameraForBounds(bounds);
-            map!.setPadding(saved);
-            return t;
-          });
-          if (!target) return;
-          if (!target.center || target.zoom === undefined) return;
-          const center = maplibregl.LngLat.convert(target.center);
-          targetCenter = [center.lng, center.lat];
-          targetZoom = target.zoom;
+        if (arc) {
+          focusTarget = {
+            type: 'arcs',
+            arcs: [arc],
+            projection: mapPreferences.projection,
+          };
         }
       }
-
-      const currentCenter = map.getCenter();
-      const cameraMoved =
-        Math.abs(currentCenter.lng - targetCenter[0]) > 1e-4 ||
-        Math.abs(currentCenter.lat - targetCenter[1]) > 1e-4 ||
-        Math.abs(map.getZoom() - targetZoom) > 1e-2;
-
-      previousCamera = snapshotCamera();
-      showPreviousView = !!previousCamera;
-      markProgrammaticMove();
-
-      untrack(() => {
-        if (cameraMoved) {
-          map!.flyTo({
-            center: targetCenter,
-            zoom: targetZoom,
-            padding,
-            duration: 1200,
-            essential: true,
-          });
-        } else {
-          map!.easeTo({
-            center: targetCenter,
-            zoom: targetZoom,
-            padding,
-            duration: 300,
-            essential: true,
-          });
-        }
-      });
-      return;
     }
 
-    if (paddingChanged) {
-      untrack(() => {
-        map!.easeTo({
-          padding,
-          duration: 300,
-          essential: true,
-        });
-      });
-    }
+    controller.reconcile({
+      selectionActive: !!selection,
+      focusRequest,
+      focusTarget,
+      padding,
+      projection: mapPreferences.projection,
+      overviewArcs: overviewFlightArcs,
+      automaticFitRequest,
+    });
+  });
+
+  $effect(() => {
+    const m = map;
+    if (!m) return;
+
+    const controller = createMapCameraController(m, {
+      onPreviousViewChange: (available) => {
+        showPreviousView = available;
+      },
+    });
+    cameraController = controller;
+
+    return () => {
+      controller.destroy();
+      if (cameraController === controller) cameraController = undefined;
+    };
   });
 
   onMount(() => {
@@ -614,8 +444,8 @@
   <MapLibre
     onload={() => {
       map?.touchPitch.disable();
-      if (map) resetUnsupportedCamera(map);
-      fitFlights();
+      cameraController?.normalizeOrientation(mapRotationEnabled);
+      requestAutomaticFit();
     }}
     bind:map
     {style}
@@ -729,7 +559,7 @@
       }}
     />
 
-    {#if flightTracks.length > 0 && mapPreferences.routeDisplay === 'tracks' && mapPreferences.flightTrackStyle === 'altitude'}
+    {#if flightTracks.length > 0 && mapPreferences.routeDisplay === 'tracks' && mapPreferences.flightTrackStyle === 'altitude' && !showPreviousView}
       <FlightTrackLegend />
     {/if}
 

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -426,6 +426,9 @@
         bind:selectedFlights
         onEdit={readonly ? undefined : handleMobileEdit}
         onDelete={readonly ? undefined : handleDelete}
+        onShowOnMap={readonly
+          ? undefined
+          : (flight) => showFlightOnMap(flight.id)}
         {readonly}
       />
       <div class="h-[130px] sm:h-[90px]"></div>

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -44,6 +44,7 @@
     formatSeatForUser,
     getFlightPassengerLabels,
     highlightElement,
+    scrollElementIntoView,
     type FlightData,
   } from '$lib/utils';
   import { formatAircraft } from '$lib/utils/data/aircraft';
@@ -188,17 +189,25 @@
     );
     if (index >= 0) page = Math.floor(index / flightsPerPage) + 1;
 
-    const highlightFlight = () =>
-      highlightElement(`#flight-list-row-${flightId}`, {
-        duration: 1900,
-        scrollOffset: -100,
-        pulses: 3,
-      }).catch(() => {});
+    // Poll until the row is mounted (on mobile the list opens in a drawer that
+    // animates in, so it isn't in the DOM for the first few frames), then scroll
+    // to it and highlight. Re-scroll once more after a beat because the desktop
+    // grid paginates via auto-animate, so the row's position isn't final yet.
+    const focusRow = (attempts = 0) => {
+      const row = document.getElementById(`flight-list-row-${flightId}`);
+      if (row && row.getBoundingClientRect().height > 0) {
+        highlightElement(row, {
+          duration: 1900,
+          pulses: 3,
+          scrollOffset: 0,
+        }).catch(() => {});
+        setTimeout(() => scrollElementIntoView(row), 300);
+        return;
+      }
+      if (attempts < 25) setTimeout(() => focusRow(attempts + 1), 80);
+    };
 
-    tick().then(() => {
-      highlightFlight();
-      setTimeout(highlightFlight, 150);
-    });
+    tick().then(() => focusRow());
   });
 
   // Mobile edit state

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -34,10 +34,10 @@
   import { LabelledSeparator, Separator } from '$lib/components/ui/separator';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
-    closeMapDetails,
     flightAddedState,
     flightListFocusState,
     flightScopeState,
+    openFlightDetails,
   } from '$lib/state.svelte';
   import {
     cn,
@@ -258,7 +258,7 @@
     }
   };
 
-  const showFlightOnMap = (flightId: number) => {
+  const showFlightOnMap = async (flightId: number) => {
     if (!filters) return;
     // Clear the persistent location filters as well: during a temp-filter
     // drilldown the visible rows are matched against tempFilters, so they can
@@ -268,10 +268,14 @@
     filters.arrivalAirports = [];
     filters.airportsEither = [];
     filters.routes = [];
-    closeMapDetails();
     filters.flightIds = [flightId.toString()];
     if (tempFilters) clearTempFilterValues(tempFilters);
+    // Close the list first, then open the flight pane on the next tick. Opening
+    // it before the modal tears down lets the modal's history/focus-trap
+    // teardown swallow the newly-opened pane.
     open = false;
+    await tick();
+    openFlightDetails(flightId);
   };
 
   const hasTempFilters = $derived.by(() => hasActiveTempFilters(tempFilters));

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -259,20 +259,12 @@
   };
 
   const showFlightOnMap = async (flightId: number) => {
-    if (!filters) return;
-    // Clear the persistent location filters as well: during a temp-filter
-    // drilldown the visible rows are matched against tempFilters, so they can
-    // violate the persistent location criteria. Leaving those set would
-    // intersect with flightIds to an empty map that hides the selected flight.
-    filters.departureAirports = [];
-    filters.arrivalAirports = [];
-    filters.airportsEither = [];
-    filters.routes = [];
-    filters.flightIds = [flightId.toString()];
+    // Leave any list drilldown behind, then close the list and open the flight's
+    // pane on the next tick — opening it before the modal tears down lets the
+    // modal's history/focus-trap teardown swallow the newly-opened pane. While
+    // the pane is open the map isolates this flight on its own (a derived view
+    // of the pane state); dismissing it returns the map to the filtered view.
     if (tempFilters) clearTempFilterValues(tempFilters);
-    // Close the list first, then open the flight pane on the next tick. Opening
-    // it before the modal tears down lets the modal's history/focus-trap
-    // teardown swallow the newly-opened pane.
     open = false;
     await tick();
     openFlightDetails(flightId);

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -4,6 +4,7 @@
   import autoAnimate from '@formkit/auto-animate';
   import {
     ArrowLeftRight,
+    MapPin,
     Plane,
     PlaneTakeoff,
     PlaneLanding,
@@ -254,6 +255,13 @@
       await deleteFlight?.(deleteFlightData.id);
       deleteFlightData = null;
     }
+  };
+
+  const showFlightOnMap = (flightId: number) => {
+    if (!filters) return;
+    filters.flightIds = [flightId.toString()];
+    if (tempFilters) clearTempFilterValues(tempFilters);
+    open = false;
   };
 
   const hasTempFilters = $derived.by(() => hasActiveTempFilters(tempFilters));
@@ -628,6 +636,16 @@
 
 {#snippet actions(flight)}
   <div class="flex items-center gap-2">
+    <Button
+      variant="outline"
+      size="icon"
+      disabled={selecting}
+      aria-label="Show on map"
+      title="Show on map"
+      onclick={() => showFlightOnMap(flight.id)}
+    >
+      <MapPin size="20" />
+    </Button>
     {#key flight}
       <EditFlightModal {flight} triggerDisabled={selecting} />
     {/key}

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -34,6 +34,7 @@
   import { LabelledSeparator, Separator } from '$lib/components/ui/separator';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
+    closeMapDetails,
     flightAddedState,
     flightListFocusState,
     flightScopeState,
@@ -259,6 +260,15 @@
 
   const showFlightOnMap = (flightId: number) => {
     if (!filters) return;
+    // Clear the persistent location filters as well: during a temp-filter
+    // drilldown the visible rows are matched against tempFilters, so they can
+    // violate the persistent location criteria. Leaving those set would
+    // intersect with flightIds to an empty map that hides the selected flight.
+    filters.departureAirports = [];
+    filters.arrivalAirports = [];
+    filters.airportsEither = [];
+    filters.routes = [];
+    closeMapDetails();
     filters.flightIds = [flightId.toString()];
     if (tempFilters) clearTempFilterValues(tempFilters);
     open = false;

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { tick } from 'svelte';
-
   import autoAnimate from '@formkit/auto-animate';
   import {
     ArrowLeftRight,
@@ -11,6 +9,7 @@
     X,
   } from '@o7/icon/lucide';
   import { isBefore, isAfter } from 'date-fns';
+  import { tick } from 'svelte';
 
   import DeleteFlightModal from './DeleteFlightModal.svelte';
   import EmptyFlightsState from './EmptyFlightsState.svelte';
@@ -22,25 +21,28 @@
   import {
     clearTempFilters as clearTempFilterValues,
     hasTempFilters as hasActiveTempFilters,
+    routeMatchesEndpoints,
     type FlightFilters,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
   import { AddFlightModal, EditFlightModal } from '$lib/components/modals';
-  import { Button } from '$lib/components/ui/button';
   import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
   import { Card } from '$lib/components/ui/card';
   import { Modal } from '$lib/components/ui/modal';
   import { ScrollArea } from '$lib/components/ui/scroll-area';
   import { LabelledSeparator, Separator } from '$lib/components/ui/separator';
   import * as Tooltip from '$lib/components/ui/tooltip';
+  import type { NavigateFlights } from '$lib/flight-navigation';
+  import { canShowFlightOnMap } from '$lib/flight-visibility';
   import {
     flightAddedState,
     flightListFocusState,
     flightScopeState,
-    openFlightDetails,
   } from '$lib/state.svelte';
   import {
     cn,
+    cancelHighlight,
     formatSeatForUser,
     getFlightPassengerLabels,
     highlightElement,
@@ -58,20 +60,24 @@
     tempFilters = $bindable<TempFilters | undefined>(),
     flights,
     filteredFlights,
+    focusedFlightOutsideFilters = false,
     deleteFlight,
     readonly = false,
     seatUserId,
     showPassengerDetails = false,
+    onNavigate,
   }: {
     open?: boolean;
     filters?: FlightFilters;
     tempFilters?: TempFilters;
     flights: FlightData[];
     filteredFlights: FlightData[];
+    focusedFlightOutsideFilters?: boolean;
     deleteFlight?: (id: number) => Promise<void>;
     readonly?: boolean;
     seatUserId?: string;
     showPassengerDetails?: boolean;
+    onNavigate?: NavigateFlights;
   } = $props();
 
   const prefs = $derived(getPreferences(appPage.data.user));
@@ -166,7 +172,7 @@
 
   let selecting = $state(false);
   let selectedFlights = $state<number[]>([]);
-  let handledFocusRequest = $state(0);
+  let handledFocusRequest = 0;
 
   // Add flight state
   let addFlightOpen = $state(false);
@@ -184,6 +190,17 @@
     handledFocusRequest = flightListFocusState.request;
     if (!flightId) return;
 
+    let cancelled = false;
+    let highlightedRow: HTMLElement | null = null;
+    const timers = new Set<ReturnType<typeof setTimeout>>();
+    const schedule = (callback: () => void, delay: number) => {
+      const timer = setTimeout(() => {
+        timers.delete(timer);
+        if (!cancelled) callback();
+      }, delay);
+      timers.add(timer);
+    };
+
     const index = formattedFlights.findIndex(
       (flight) => flight.id === flightId,
     );
@@ -196,18 +213,28 @@
     const focusRow = (attempts = 0) => {
       const row = document.getElementById(`flight-list-row-${flightId}`);
       if (row && row.getBoundingClientRect().height > 0) {
+        highlightedRow = row;
         highlightElement(row, {
           duration: 1900,
           pulses: 3,
           scrollOffset: 0,
         }).catch(() => {});
-        setTimeout(() => scrollElementIntoView(row), 300);
+        schedule(() => scrollElementIntoView(row), 300);
         return;
       }
-      if (attempts < 25) setTimeout(() => focusRow(attempts + 1), 80);
+      if (attempts < 25) schedule(() => focusRow(attempts + 1), 80);
     };
 
-    tick().then(() => focusRow());
+    tick().then(() => {
+      if (!cancelled) focusRow();
+    });
+
+    return () => {
+      cancelled = true;
+      for (const timer of timers) clearTimeout(timer);
+      timers.clear();
+      if (highlightedRow) cancelHighlight(highlightedRow);
+    };
   });
 
   // Mobile edit state
@@ -267,16 +294,12 @@
     }
   };
 
-  const showFlightOnMap = async (flightId: number) => {
-    // Leave any list drilldown behind, then close the list and open the flight's
-    // pane on the next tick — opening it before the modal tears down lets the
-    // modal's history/focus-trap teardown swallow the newly-opened pane. While
-    // the pane is open the map isolates this flight on its own (a derived view
-    // of the pane state); dismissing it returns the map to the filtered view.
-    if (tempFilters) clearTempFilterValues(tempFilters);
-    open = false;
-    await tick();
-    openFlightDetails(flightId);
+  const showFlightOnMap = (flight: FlightData) => {
+    if (!canShowFlightOnMap(flight)) return;
+    onNavigate?.({
+      destination: 'map',
+      focus: { type: 'flight', flightId: flight.id },
+    });
   };
 
   const hasTempFilters = $derived.by(() => hasActiveTempFilters(tempFilters));
@@ -320,11 +343,8 @@
   const tempFilterRoute = $derived.by(() => {
     if (!tempFilters?.routes.length) return null;
     const route = tempFilters.routes[0]!;
-    const flight = flights.find(
-      (f) =>
-        (f.from?.id.toString() === route.a &&
-          f.to?.id.toString() === route.b) ||
-        (f.from?.id.toString() === route.b && f.to?.id.toString() === route.a),
+    const flight = flights.find((f) =>
+      routeMatchesEndpoints(f.from?.id, f.to?.id, route),
     );
     if (!flight?.from || !flight.to) return null;
     return {
@@ -385,6 +405,12 @@
         <h2 class="text-3xl font-bold tracking-tight">All Flights</h2>
       {/if}
 
+      {#if focusedFlightOutsideFilters}
+        <p class="text-xs text-muted-foreground">
+          Selected flight is shown outside the active filters.
+        </p>
+      {/if}
+
       {#if filters}
         <Toolbar
           bind:filters
@@ -427,9 +453,7 @@
         bind:selectedFlights
         onEdit={readonly ? undefined : handleMobileEdit}
         onDelete={readonly ? undefined : handleDelete}
-        onShowOnMap={readonly
-          ? undefined
-          : (flight) => showFlightOnMap(flight.id)}
+        onShowOnMap={readonly || !onNavigate ? undefined : showFlightOnMap}
         {readonly}
       />
       <div class="h-[130px] sm:h-[90px]"></div>
@@ -654,16 +678,18 @@
 
 {#snippet actions(flight)}
   <div class="flex items-center gap-2">
-    <Button
-      variant="outline"
-      size="icon"
-      disabled={selecting}
-      aria-label="Show on map"
-      title="Show on map"
-      onclick={() => showFlightOnMap(flight.id)}
-    >
-      <MapPin size="20" />
-    </Button>
+    {#if onNavigate && canShowFlightOnMap(flight)}
+      <Button
+        variant="outline"
+        size="icon"
+        disabled={selecting}
+        aria-label="Show on map"
+        title="Show on map"
+        onclick={() => showFlightOnMap(flight)}
+      >
+        <MapPin size="20" />
+      </Button>
+    {/if}
     {#key flight}
       <EditFlightModal {flight} triggerDisabled={selecting} />
     {/key}

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -31,6 +31,7 @@
     selectedFlights = $bindable<number[]>([]),
     onEdit,
     onDelete,
+    onShowOnMap,
     readonly = false,
   }: {
     flightsByYear: YearGroup[];
@@ -38,6 +39,7 @@
     selectedFlights?: number[];
     onEdit?: (flight: Flight) => void;
     onDelete?: (flight: Flight) => void;
+    onShowOnMap?: (flight: Flight) => void;
     readonly?: boolean;
   } = $props();
 
@@ -79,6 +81,9 @@
               disabled={selecting || readonly}
               onEdit={readonly ? undefined : () => onEdit?.(flight)}
               onDelete={readonly ? undefined : () => onDelete?.(flight)}
+              onShowOnMap={readonly || !onShowOnMap
+                ? undefined
+                : () => onShowOnMap?.(flight)}
             >
               {#snippet children({ isInteracting })}
                 <button

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -81,7 +81,10 @@
               disabled={selecting || readonly}
               onEdit={readonly ? undefined : () => onEdit?.(flight)}
               onDelete={readonly ? undefined : () => onDelete?.(flight)}
-              onShowOnMap={readonly || !onShowOnMap
+              onShowOnMap={readonly ||
+              !onShowOnMap ||
+              !flight.from ||
+              !flight.to
                 ? undefined
                 : () => onShowOnMap?.(flight)}
             >

--- a/src/lib/components/modals/list-flights/SwipeableFlightRow.svelte
+++ b/src/lib/components/modals/list-flights/SwipeableFlightRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { SquarePen, Trash2 } from '@o7/icon/lucide';
+  import { MapPin, SquarePen, Trash2 } from '@o7/icon/lucide';
 
   import { getDrawerContext } from '$lib/components/ui/drawer/drawer.svelte';
   import { cn } from '$lib/utils';
@@ -13,11 +13,13 @@
     disabled = false,
     onEdit,
     onDelete,
+    onShowOnMap,
     children,
   }: {
     disabled?: boolean;
     onEdit?: () => void;
     onDelete?: () => void;
+    onShowOnMap?: () => void;
     children: Snippet<[{ isInteracting: boolean }]>;
   } = $props();
 
@@ -329,6 +331,15 @@
     }
     triggerAction(onDelete);
   };
+
+  const handleShowOnMapClick = (e: MouseEvent) => {
+    if (hasMoved || actionPending) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+    triggerAction(onShowOnMap);
+  };
 </script>
 
 <div class="relative overflow-hidden" bind:this={rowElement}>
@@ -343,6 +354,17 @@
     style:touch-action="none"
     onpointerdown={handlePointerDown}
   >
+    {#if onShowOnMap}
+      <button
+        type="button"
+        class="flex-1 flex flex-col items-center justify-center gap-1 text-muted-foreground hover:text-primary hover:bg-primary/10 active:bg-primary/15 transition-colors"
+        onclick={handleShowOnMapClick}
+      >
+        <MapPin size={22} />
+        <span class="text-xs font-medium">Map</span>
+      </button>
+      <div class="w-px bg-border"></div>
+    {/if}
     <button
       type="button"
       class="flex-1 flex flex-col items-center justify-center gap-1 text-muted-foreground hover:text-primary hover:bg-primary/10 active:bg-primary/15 transition-colors"

--- a/src/lib/components/modals/list-flights/SwipeableFlightRow.svelte
+++ b/src/lib/components/modals/list-flights/SwipeableFlightRow.svelte
@@ -338,7 +338,12 @@
       e.stopPropagation();
       return;
     }
-    triggerAction(onShowOnMap);
+    // Unlike Edit/Delete (which open a sub-modal over the retained list and get
+    // reset via resetAllRows on close), "Map" closes the whole list and has no
+    // reset path — so it must NOT go through triggerAction, which would strand
+    // the row in actionPending forever. Reset the revealed row and fire directly.
+    resetPosition();
+    onShowOnMap?.();
   };
 </script>
 

--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -18,6 +18,7 @@
   import { Button } from '$lib/components/ui/button';
   import { flightScopeState } from '$lib/state.svelte';
   import { Modal } from '$lib/components/ui/modal';
+  import type { ModalHistoryHandle } from '$lib/components/ui/modal/modal-history';
   import ResponsiveFilters from '$lib/components/flight-filters/ResponsiveFilters.svelte';
   import type { FlightFilters } from '$lib/components/flight-filters/types';
   import { type VisitedCountry, wasVisited } from '$lib/db/types';
@@ -47,7 +48,6 @@
     seatUserId,
     showCountryStats = true,
     onOpenFlight,
-    suppressEscapeNavigation = false,
   }: {
     open?: boolean;
     flights: FlightData[];
@@ -58,7 +58,6 @@
     seatUserId?: string;
     showCountryStats?: boolean;
     onOpenFlight?: (flightId: number) => void;
-    suppressEscapeNavigation?: boolean;
   } = $props();
 
   const showScopeBanner = $derived(flightScopeState.scope !== 'mine');
@@ -111,6 +110,7 @@
   // Expanded chart state
   let activeChart: ChartKey | null = $state(null);
   let activeContinent: string | null = $state(null);
+  let modalHistory: ModalHistoryHandle | undefined = $state();
   let wasOpen = $state(false);
   const ctx = $derived.by(() => ({ userId: seatUserId }));
 
@@ -140,7 +140,23 @@
   );
 
   const pushDrilldownHistory = () => {
-    history.pushState({ statisticsDrilldown: true }, '');
+    modalHistory?.push({ activeChart, activeContinent });
+  };
+
+  const restoreDrilldown = (state: unknown) => {
+    const drilldown = state as
+      | { activeChart?: unknown; activeContinent?: unknown }
+      | undefined;
+    const chart = drilldown?.activeChart;
+    activeChart =
+      typeof chart === 'string' &&
+      (chart in FLIGHT_CHARTS || chart in COUNTRY_CHARTS)
+        ? (chart as ChartKey)
+        : null;
+    activeContinent =
+      typeof drilldown?.activeContinent === 'string'
+        ? drilldown.activeContinent
+        : null;
   };
 
   $effect(() => {
@@ -151,7 +167,6 @@
     if (closedFromDrilldown) {
       activeChart = null;
       activeContinent = null;
-      history.back();
     }
 
     if (open) {
@@ -191,47 +206,28 @@
   });
 </script>
 
-<svelte:window
-  onpopstate={(event) => {
-    if (!open || event.state?.statisticsDrilldown) return;
-    if (activeContinent) {
-      activeContinent = null;
-    } else if (activeChart) {
-      activeChart = null;
-    }
-  }}
-  onkeydown={(e) => {
-    if (suppressEscapeNavigation) return;
-    if (e.key !== 'Escape') return;
-    if (activeContinent || activeChart) {
-      history.back();
-    } else if (open) {
-      open = false;
-    }
-  }}
-/>
-
 <Modal
   bind:open
+  bind:historyHandle={modalHistory}
   class="max-w-full h-full overflow-y-auto rounded-none!"
   dialogOnly
   dialogNoPadding={Boolean(activeChart || activeContinent)}
   drawerNoPadding={Boolean(activeChart || activeContinent)}
-  closeOnEscape={false}
   closeButton={true}
+  onHistoryStateChange={restoreDrilldown}
 >
   {#if activeContinent}
     <BarChartDrillDown
       continent={activeContinent}
       countries={countriesByContinentDetailsData[activeContinent] || []}
-      onBack={() => history.back()}
+      onBack={() => modalHistory?.back()}
     />
   {:else if activeChart}
     <ChartDrillDown
       chartKey={activeChart}
       data={activeChartData}
       flights={completedFlights}
-      onBack={() => history.back()}
+      onBack={() => modalHistory?.back()}
       {onOpenFlight}
       {seatUserId}
     />

--- a/src/lib/components/ui/modal/Modal.svelte
+++ b/src/lib/components/ui/modal/Modal.svelte
@@ -18,34 +18,11 @@
   export const getModalContext = () =>
     getContext<ModalContext>(ModalContextKey);
 
-  // Global modal stack for proper back button handling with nested modals
-  const modalHistoryStack: string[] = [];
   let modalLayerCounter = 0;
-
-  export function pushModalHistory(id: string): void {
-    modalHistoryStack.push(id);
-  }
-
-  export function popModalHistory(): string | undefined {
-    return modalHistoryStack.pop();
-  }
-
-  export function peekModalHistory(): string | undefined {
-    return modalHistoryStack[modalHistoryStack.length - 1];
-  }
-
-  export function removeFromModalHistory(id: string): boolean {
-    const index = modalHistoryStack.indexOf(id);
-    if (index !== -1) {
-      modalHistoryStack.splice(index, 1);
-      return true;
-    }
-    return false;
-  }
 </script>
 
 <script lang="ts">
-  import { setContext, type Snippet, onMount } from 'svelte';
+  import { onDestroy, setContext, type Snippet } from 'svelte';
   import { browser } from '$app/environment';
 
   import * as Dialog from '$lib/components/ui/dialog';
@@ -53,6 +30,15 @@
   import { cn } from '$lib/utils';
   import { isMediumScreen } from '$lib/utils/size';
   import { generateUUID } from '$lib/utils/string';
+  import {
+    backModalHistory,
+    closeModalHistory,
+    escapeModalHistory,
+    openModalHistory,
+    pushModalHistoryState,
+    unregisterModalHistory,
+    type ModalHistoryHandle,
+  } from './modal-history';
 
   type ModalPreset = 'default' | 'alert';
 
@@ -80,6 +66,8 @@
     shouldScaleBackground = true,
     handleBackButton = true,
     onOpenChange,
+    onHistoryStateChange,
+    historyHandle = $bindable(),
     children,
   }: {
     open: boolean;
@@ -99,6 +87,8 @@
     shouldScaleBackground?: boolean;
     handleBackButton?: boolean;
     onOpenChange?: (open: boolean) => void;
+    onHistoryStateChange?: (state: unknown) => void;
+    historyHandle?: ModalHistoryHandle;
     children: Snippet;
   } = $props();
 
@@ -123,8 +113,15 @@
   const useDialog = isMediumScreen;
 
   const modalId = generateUUID();
-  let historyPushed = $state(false);
-  let closingFromPopstate = $state(false);
+  const localHistoryHandle: ModalHistoryHandle = {
+    push: (state) => pushModalHistoryState(modalId, state),
+    back: () => backModalHistory(modalId),
+  };
+  const handleDialogEscape = (event: KeyboardEvent) => {
+    event.preventDefault();
+    escapeModalHistory(modalId);
+  };
+  historyHandle = localHistoryHandle;
   let previousOpen = $state(open);
   let layer = $state(0);
   let layerAssigned = $state(false);
@@ -135,26 +132,6 @@
   const contentStyle = $derived(
     layerAssigned ? `z-index: ${1001 + layer * 20};` : undefined,
   );
-
-  function handlePopstate(event: PopStateEvent) {
-    const isTopmostModal = peekModalHistory() === modalId;
-    const wasTriggeredByThisModal = event.state?.modal === modalId;
-    if (
-      historyPushed &&
-      open &&
-      !closingFromPopstate &&
-      isTopmostModal &&
-      !wasTriggeredByThisModal
-    ) {
-      closingFromPopstate = true;
-      historyPushed = false;
-      popModalHistory();
-      open = false;
-      setTimeout(() => {
-        closingFromPopstate = false;
-      }, 0);
-    }
-  }
 
   $effect(() => {
     if (open && !layerAssigned) {
@@ -175,29 +152,22 @@
   $effect(() => {
     if (!browser || !handleBackButton) return;
 
-    if (open && !historyPushed) {
-      history.pushState({ modal: modalId }, '');
-      pushModalHistory(modalId);
-      historyPushed = true;
-    } else if (!open && historyPushed && !closingFromPopstate) {
-      historyPushed = false;
-      removeFromModalHistory(modalId);
-      history.back();
+    if (open) {
+      openModalHistory(
+        modalId,
+        () => {
+          open = false;
+        },
+        { closeOnEscape, onStateChange: onHistoryStateChange },
+      );
+    } else {
+      closeModalHistory(modalId);
     }
   });
 
-  onMount(() => {
-    if (!browser || !handleBackButton) return;
-
-    window.addEventListener('popstate', handlePopstate);
-
-    return () => {
-      window.removeEventListener('popstate', handlePopstate);
-      if (historyPushed) {
-        removeFromModalHistory(modalId);
-        history.back();
-      }
-    };
+  onDestroy(() => {
+    if (historyHandle === localHistoryHandle) historyHandle = undefined;
+    unregisterModalHistory(modalId);
   });
 </script>
 
@@ -212,7 +182,12 @@
       )}
       closeButton={resolvedCloseButton}
       preventScroll={false}
-      escapeKeydownBehavior={closeOnEscape ? 'close' : 'ignore'}
+      escapeKeydownBehavior={handleBackButton
+        ? 'close'
+        : closeOnEscape
+          ? 'close'
+          : 'ignore'}
+      onEscapeKeydown={handleBackButton ? handleDialogEscape : undefined}
       interactOutsideBehavior={closeOnOutsideClick ? 'close' : 'ignore'}
       {overlayClass}
       {overlayStyle}

--- a/src/lib/components/ui/modal/modal-history.test.ts
+++ b/src/lib/components/ui/modal/modal-history.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createModalHistoryController } from './modal-history';
+
+const createAdapter = () => {
+  let listener: ((event: { state?: unknown }) => void) | undefined;
+  let keydownListener:
+    | ((event: {
+        key: string;
+        defaultPrevented?: boolean;
+        preventDefault: () => void;
+        stopPropagation: () => void;
+      }) => void)
+    | undefined;
+  const pushState = vi.fn();
+  const back = vi.fn();
+  return {
+    adapter: {
+      pushState,
+      back,
+      listen: (callback: typeof listener) => {
+        listener = callback;
+        return () => {
+          listener = undefined;
+        };
+      },
+      listenKeydown: (callback: typeof keydownListener) => {
+        keydownListener = callback;
+        return () => {
+          keydownListener = undefined;
+        };
+      },
+    },
+    pushState,
+    back,
+    pop(state: unknown = null) {
+      listener?.({ state });
+    },
+    keydown(key: string, defaultPrevented = false) {
+      const event = {
+        key,
+        defaultPrevented,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+      keydownListener?.(event);
+      return event;
+    },
+  };
+};
+
+describe('modal history controller', () => {
+  it('closes the top modal on browser back', () => {
+    const fake = createAdapter();
+    const close = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('settings', close);
+
+    fake.pop();
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(controller.peek()).toBeUndefined();
+    expect(fake.back).not.toHaveBeenCalled();
+  });
+
+  it('serializes a programmatic close of nested modals', () => {
+    const fake = createAdapter();
+    const closeParent = vi.fn();
+    const closeChild = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('parent', closeParent);
+    controller.open('child', closeChild);
+
+    controller.close('parent');
+    expect(closeChild).toHaveBeenCalledOnce();
+    expect(fake.back).toHaveBeenCalledTimes(1);
+
+    fake.pop({ modal: 'parent' });
+    expect(controller.peek()).toBe('parent');
+    expect(fake.back).toHaveBeenCalledTimes(2);
+
+    fake.pop();
+    expect(controller.peek()).toBeUndefined();
+    expect(closeParent).not.toHaveBeenCalled();
+  });
+
+  it('does not restore state into a parent that is also closing', () => {
+    const fake = createAdapter();
+    const restoreParent = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('statistics', vi.fn(), {
+      onStateChange: restoreParent,
+    });
+    controller.pushState('statistics', { activeChart: 'routes' });
+    controller.open('list', vi.fn());
+
+    controller.close('statistics');
+    fake.pop({
+      modal: 'statistics',
+      modalState: { activeChart: 'routes' },
+      modalDepth: 1,
+    });
+
+    expect(restoreParent).not.toHaveBeenCalled();
+
+    fake.pop({ modal: 'statistics', modalDepth: 0 });
+    fake.pop();
+    expect(controller.peek()).toBeUndefined();
+  });
+
+  it('keeps a modal open when leaving its internal history entry', () => {
+    const fake = createAdapter();
+    const close = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('statistics', close);
+
+    fake.pop({ modal: 'statistics' });
+
+    expect(close).not.toHaveBeenCalled();
+    expect(controller.peek()).toBe('statistics');
+  });
+
+  it('unwinds internal entries before completing a programmatic close', () => {
+    const fake = createAdapter();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('statistics', vi.fn());
+
+    controller.close('statistics');
+    fake.pop({ modal: 'statistics', modalState: { activeChart: 'routes' } });
+
+    expect(fake.back).toHaveBeenCalledTimes(2);
+    expect(controller.peek()).toBe('statistics');
+
+    fake.pop();
+
+    expect(controller.peek()).toBeUndefined();
+  });
+
+  it('queues a new modal until a pending close traversal completes', () => {
+    const fake = createAdapter();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('list', vi.fn());
+
+    controller.close('list');
+    controller.open('details', vi.fn());
+
+    expect(fake.pushState).toHaveBeenCalledTimes(1);
+    expect(fake.pushState).toHaveBeenLastCalledWith(
+      { modal: 'list', modalState: undefined, modalDepth: 0 },
+      '',
+    );
+    expect(controller.peek()).toBe('details');
+
+    fake.pop();
+
+    expect(fake.pushState).toHaveBeenCalledTimes(2);
+    expect(fake.pushState).toHaveBeenLastCalledWith(
+      { modal: 'details', modalState: undefined, modalDepth: 0 },
+      '',
+    );
+    expect(controller.peek()).toBe('details');
+  });
+
+  it('resolves transition waiters after history traversal and queue flushing', async () => {
+    const fake = createAdapter();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('list', vi.fn());
+
+    const closing = controller.close('list');
+    controller.open('details', vi.fn());
+    let settled = false;
+    closing.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    fake.pop();
+    await closing;
+
+    expect(settled).toBe(true);
+    expect(controller.peek()).toBe('details');
+    expect(fake.pushState).toHaveBeenCalledTimes(2);
+  });
+
+  it('queues a reopened modal until its old entry finishes closing', () => {
+    const fake = createAdapter();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('details', vi.fn());
+
+    controller.close('details');
+    controller.open('details', vi.fn());
+
+    expect(fake.pushState).toHaveBeenCalledTimes(1);
+    fake.pop();
+    expect(fake.pushState).toHaveBeenCalledTimes(2);
+    expect(controller.peek()).toBe('details');
+  });
+
+  it('restores modal-local state through the controller', () => {
+    const fake = createAdapter();
+    const restore = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('statistics', vi.fn(), { onStateChange: restore });
+    controller.pushState('statistics', { activeChart: 'routes' });
+
+    expect(fake.pushState).toHaveBeenLastCalledWith(
+      {
+        modal: 'statistics',
+        modalState: { activeChart: 'routes' },
+        modalDepth: 1,
+      },
+      '',
+    );
+
+    controller.back('statistics');
+    fake.pop({ modal: 'statistics' });
+
+    expect(fake.back).toHaveBeenCalledOnce();
+    expect(restore).toHaveBeenCalledWith(undefined);
+    expect(controller.peek()).toBe('statistics');
+  });
+
+  it('backs out of local state before a queued modal reaches history', () => {
+    const fake = createAdapter();
+    const restore = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('list', vi.fn());
+    controller.close('list');
+    controller.open('statistics', vi.fn(), { onStateChange: restore });
+    controller.pushState('statistics', { activeChart: 'routes' });
+
+    controller.back('statistics');
+
+    expect(restore).toHaveBeenCalledWith(undefined);
+    expect(fake.back).toHaveBeenCalledOnce();
+    fake.pop();
+    expect(fake.pushState).toHaveBeenCalledTimes(2);
+    expect(fake.pushState).toHaveBeenLastCalledWith(
+      { modal: 'statistics', modalState: undefined, modalDepth: 0 },
+      '',
+    );
+  });
+
+  it('restores depth when browser Forward re-enters local state', () => {
+    const fake = createAdapter();
+    const close = vi.fn();
+    const restore = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('statistics', close, { onStateChange: restore });
+    controller.pushState('statistics', { activeChart: 'routes' });
+
+    fake.pop({ modal: 'statistics', modalDepth: 0 });
+    fake.pop({
+      modal: 'statistics',
+      modalState: { activeChart: 'routes' },
+      modalDepth: 1,
+    });
+    controller.back('statistics');
+
+    expect(restore).toHaveBeenLastCalledWith({ activeChart: 'routes' });
+    expect(fake.back).toHaveBeenCalledOnce();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('dispatches Escape only to the top modal', () => {
+    const fake = createAdapter();
+    const closeParent = vi.fn();
+    const closeChild = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('parent', closeParent);
+    controller.open('child', closeChild);
+
+    const event = fake.keydown('Escape');
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    expect(closeChild).toHaveBeenCalledOnce();
+    expect(closeParent).not.toHaveBeenCalled();
+  });
+
+  it('accepts targeted Escape only from the top modal layer', () => {
+    const fake = createAdapter();
+    const closeParent = vi.fn();
+    const closeChild = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('parent', closeParent);
+    controller.open('child', closeChild);
+
+    expect(controller.escape('parent')).toBe(false);
+    expect(closeParent).not.toHaveBeenCalled();
+    expect(closeChild).not.toHaveBeenCalled();
+
+    expect(controller.escape('child')).toBe(true);
+    expect(closeChild).toHaveBeenCalledOnce();
+    expect(closeParent).not.toHaveBeenCalled();
+  });
+
+  it('uses Escape to leave internal state before closing the modal', () => {
+    const fake = createAdapter();
+    const close = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('statistics', close);
+    controller.pushState('statistics', { activeChart: 'routes' });
+
+    fake.keydown('Escape');
+
+    expect(fake.back).toHaveBeenCalledOnce();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('leaves Escape to a nested control that already handled it', () => {
+    const fake = createAdapter();
+    const close = vi.fn();
+    const controller = createModalHistoryController(fake.adapter);
+    controller.open('add-flight', close);
+
+    const event = fake.keydown('Escape', true);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/ui/modal/modal-history.ts
+++ b/src/lib/components/ui/modal/modal-history.ts
@@ -1,0 +1,390 @@
+type PopStateLike = { state?: unknown };
+type KeydownLike = {
+  key: string;
+  defaultPrevented?: boolean;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+};
+
+type HistoryAdapter = {
+  pushState: (data: unknown, unused: string) => void;
+  back: () => void;
+  listen: (callback: (event: PopStateLike) => void) => () => void;
+  listenKeydown?: (callback: (event: KeydownLike) => void) => () => void;
+};
+
+type ModalHistoryEntryBase = {
+  id: string;
+  closeFromHistory: () => void;
+  closeOnEscape: boolean;
+  onStateChange?: (state: unknown) => void;
+};
+
+type ActiveModalHistoryEntry = ModalHistoryEntryBase & {
+  status: 'active';
+  internalDepth: number;
+};
+
+type ClosingModalHistoryEntry = ModalHistoryEntryBase & {
+  status: 'closing';
+  internalDepth: number;
+  traversing: boolean;
+};
+
+type QueuedModalHistoryEntry = ModalHistoryEntryBase & {
+  status: 'queued';
+  queuedStates: unknown[];
+};
+
+type ModalHistoryEntry =
+  | ActiveModalHistoryEntry
+  | ClosingModalHistoryEntry
+  | QueuedModalHistoryEntry;
+
+type ModalHistoryOptions = {
+  closeOnEscape?: boolean;
+  onStateChange?: (state: unknown) => void;
+};
+
+type ModalBrowserState = {
+  modal?: unknown;
+  modalState?: unknown;
+  modalDepth?: unknown;
+};
+
+export type ModalHistoryHandle = {
+  push: (state: unknown) => void;
+  back: () => void;
+};
+
+export const createModalHistoryController = (adapter: HistoryAdapter) => {
+  const stack: ModalHistoryEntry[] = [];
+  const idleWaiters = new Set<() => void>();
+
+  const stateFromEvent = (event: PopStateLike) =>
+    (event.state as ModalBrowserState | null | undefined) ?? undefined;
+
+  const removeEntry = (id: string) => {
+    const index = stack.findIndex((entry) => entry.id === id);
+    if (index !== -1) stack.splice(index, 1);
+  };
+
+  const removeQueuedEntry = (id: string) => {
+    const index = stack.findIndex(
+      (entry) => entry.id === id && entry.status === 'queued',
+    );
+    if (index !== -1) stack.splice(index, 1);
+    return index !== -1;
+  };
+
+  const topBrowserEntry = () =>
+    stack.findLast((entry) => entry.status !== 'queued');
+
+  const hasClosingEntry = () =>
+    stack.some((entry) => entry.status === 'closing');
+
+  const settleIdleWaiters = () => {
+    if (hasClosingEntry()) return;
+    for (const resolve of idleWaiters) resolve();
+    idleWaiters.clear();
+  };
+
+  const whenIdle = () => {
+    if (!hasClosingEntry()) return Promise.resolve();
+    return new Promise<void>((resolve) => idleWaiters.add(resolve));
+  };
+
+  const notifyDestination = (destination: ModalBrowserState | undefined) => {
+    if (typeof destination?.modal !== 'string') return;
+    const entry = stack.findLast(
+      (candidate) =>
+        candidate.id === destination.modal && candidate.status === 'active',
+    );
+    if (!entry) return;
+    entry.onStateChange?.(destination.modalState);
+  };
+
+  const activateEntry = (entry: QueuedModalHistoryEntry) => {
+    adapter.pushState(
+      { modal: entry.id, modalState: undefined, modalDepth: 0 },
+      '',
+    );
+    let internalDepth = 0;
+    for (const state of entry.queuedStates) {
+      internalDepth += 1;
+      adapter.pushState(
+        { modal: entry.id, modalState: state, modalDepth: internalDepth },
+        '',
+      );
+    }
+    const index = stack.indexOf(entry);
+    if (index !== -1) {
+      stack[index] = { ...entry, status: 'active', internalDepth };
+    }
+  };
+
+  const flushQueuedEntries = () => {
+    if (hasClosingEntry()) return;
+    for (const entry of [...stack]) {
+      if (entry.status === 'queued') activateEntry(entry);
+    }
+    settleIdleWaiters();
+  };
+
+  const drainClosingEntries = () => {
+    const top = topBrowserEntry();
+    if (!top || top.status !== 'closing') {
+      flushQueuedEntries();
+      return;
+    }
+    if (top.traversing) return;
+    top.traversing = true;
+    adapter.back();
+  };
+
+  const stopListening = adapter.listen((event) => {
+    const destination = stateFromEvent(event);
+    const destinationModal = destination?.modal;
+
+    const traversingEntry = stack.find(
+      (entry) => entry.status === 'closing' && entry.traversing,
+    );
+    if (traversingEntry) {
+      if (destinationModal === traversingEntry.id) {
+        adapter.back();
+        return;
+      }
+
+      removeEntry(traversingEntry.id);
+      notifyDestination(destination);
+      drainClosingEntries();
+      return;
+    }
+
+    const top = topBrowserEntry();
+    if (!top) return;
+
+    if (destinationModal === top.id) {
+      const destinationDepth = destination?.modalDepth;
+      top.internalDepth =
+        typeof destinationDepth === 'number' &&
+        Number.isInteger(destinationDepth) &&
+        destinationDepth >= 0
+          ? destinationDepth
+          : Math.max(0, top.internalDepth - 1);
+      top.onStateChange?.(destination?.modalState);
+      return;
+    }
+
+    removeEntry(top.id);
+    top.closeFromHistory();
+    notifyDestination(destination);
+    flushQueuedEntries();
+  });
+
+  const escape = (id?: string) => {
+    const top = stack.at(-1);
+    if (!top || (id !== undefined && top.id !== id)) return false;
+
+    if (top.status === 'queued' && top.queuedStates.length > 0) {
+      top.queuedStates.pop();
+      top.onStateChange?.(top.queuedStates.at(-1));
+    } else if (top.status !== 'queued' && top.internalDepth > 0) {
+      adapter.back();
+    } else if (top.closeOnEscape) {
+      top.closeFromHistory();
+    }
+    return true;
+  };
+
+  const stopListeningKeydown =
+    adapter.listenKeydown?.((event) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      if (!escape()) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+    }) ?? (() => {});
+
+  const open = (
+    id: string,
+    closeFromHistory: () => void,
+    options: ModalHistoryOptions = {},
+  ) => {
+    const queued = stack.find(
+      (entry): entry is QueuedModalHistoryEntry =>
+        entry.id === id && entry.status === 'queued',
+    );
+    if (queued) {
+      queued.closeFromHistory = closeFromHistory;
+      queued.closeOnEscape = options.closeOnEscape ?? true;
+      queued.onStateChange = options.onStateChange;
+      return;
+    }
+
+    const existing = stack.find(
+      (entry) => entry.id === id && entry.status !== 'queued',
+    );
+    if (existing) {
+      if (existing.status === 'closing') {
+        stack.push({
+          id,
+          status: 'queued',
+          closeFromHistory,
+          closeOnEscape: options.closeOnEscape ?? true,
+          onStateChange: options.onStateChange,
+          queuedStates: [],
+        });
+        return;
+      }
+      existing.closeFromHistory = closeFromHistory;
+      existing.closeOnEscape = options.closeOnEscape ?? true;
+      existing.onStateChange = options.onStateChange;
+      return;
+    }
+
+    const entry: ModalHistoryEntry = {
+      id,
+      status: 'queued',
+      closeFromHistory,
+      closeOnEscape: options.closeOnEscape ?? true,
+      onStateChange: options.onStateChange,
+      queuedStates: [],
+    };
+    stack.push(entry);
+    if (!hasClosingEntry()) activateEntry(entry);
+  };
+
+  const close = (id: string) => {
+    if (removeQueuedEntry(id)) return whenIdle();
+
+    const index = stack.findIndex(
+      (entry) => entry.id === id && entry.status === 'active',
+    );
+    if (index === -1) return whenIdle();
+
+    for (let i = stack.length - 1; i >= index; i -= 1) {
+      const entry = stack[i]!;
+      if (entry.status !== 'active') continue;
+      stack[i] = { ...entry, status: 'closing', traversing: false };
+      if (i > index) entry.closeFromHistory();
+    }
+    drainClosingEntries();
+    return whenIdle();
+  };
+
+  const unregister = (id: string) => {
+    if (removeQueuedEntry(id)) return;
+    const entry = stack.find(
+      (candidate) => candidate.id === id && candidate.status !== 'queued',
+    );
+    if (!entry) return;
+    entry.closeFromHistory = () => {};
+    if (entry.status === 'active') close(id);
+  };
+
+  const pushState = (id: string, state: unknown) => {
+    const queued = stack.find(
+      (entry): entry is QueuedModalHistoryEntry =>
+        entry.id === id && entry.status === 'queued',
+    );
+    if (queued) {
+      queued.queuedStates.push(state);
+      return;
+    }
+
+    const top = topBrowserEntry();
+    if (top?.id !== id || top.status !== 'active') return;
+    top.internalDepth += 1;
+    adapter.pushState(
+      { modal: id, modalState: state, modalDepth: top.internalDepth },
+      '',
+    );
+  };
+
+  const back = (id: string) => {
+    const top = stack.at(-1);
+    if (top?.id !== id) return;
+    if (top.status === 'queued' && top.queuedStates.length > 0) {
+      top.queuedStates.pop();
+      top.onStateChange?.(top.queuedStates.at(-1));
+    } else if (top.status !== 'queued' && top.internalDepth > 0) {
+      adapter.back();
+    }
+  };
+
+  return {
+    open,
+    close,
+    unregister,
+    pushState,
+    back,
+    escape,
+    whenIdle,
+
+    peek() {
+      return stack.at(-1)?.id;
+    },
+
+    destroy() {
+      stopListening();
+      stopListeningKeydown();
+      stack.length = 0;
+      settleIdleWaiters();
+    },
+  };
+};
+
+let browserController:
+  | ReturnType<typeof createModalHistoryController>
+  | undefined;
+
+const getBrowserController = () => {
+  if (typeof window === 'undefined') return undefined;
+  browserController ??= createModalHistoryController({
+    pushState: (data, unused) =>
+      history.pushState(
+        {
+          ...(history.state as Record<string, unknown> | null),
+          ...(data as Record<string, unknown>),
+        },
+        unused,
+      ),
+    back: () => history.back(),
+    listen: (callback) => {
+      window.addEventListener('popstate', callback);
+      return () => window.removeEventListener('popstate', callback);
+    },
+    listenKeydown: (callback) => {
+      window.addEventListener('keydown', callback);
+      return () => window.removeEventListener('keydown', callback);
+    },
+  });
+  return browserController;
+};
+
+export const openModalHistory = (
+  id: string,
+  closeFromHistory: () => void,
+  options?: ModalHistoryOptions,
+) => getBrowserController()?.open(id, closeFromHistory, options);
+
+export const closeModalHistory = (id: string) =>
+  getBrowserController()?.close(id);
+
+export const unregisterModalHistory = (id: string) =>
+  getBrowserController()?.unregister(id);
+
+export const pushModalHistoryState = (id: string, state: unknown) =>
+  getBrowserController()?.pushState(id, state);
+
+export const backModalHistory = (id: string) =>
+  getBrowserController()?.back(id);
+
+export const escapeModalHistory = (id: string) =>
+  getBrowserController()?.escape(id);
+
+export const peekModalHistory = () => getBrowserController()?.peek();
+
+export const waitForModalHistoryIdle = () =>
+  getBrowserController()?.whenIdle() ?? Promise.resolve();

--- a/src/lib/flight-navigation.test.ts
+++ b/src/lib/flight-navigation.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createDefaultTempFilters } from '$lib/components/flight-filters/types';
+import {
+  createFlightNavigator,
+  planFlightNavigation,
+} from './flight-navigation';
+import {
+  canShowFlightOnMap,
+  includeFocusedFlightInList,
+  includeFocusedRouteOnMap,
+} from './flight-visibility';
+
+const flight = (id: number, from: number | null, to: number | null) => ({
+  id,
+  from: from === null ? null : { id: from },
+  to: to === null ? null : { id: to },
+});
+
+const createNavigator = (statisticsOpen = false) => {
+  let state = {
+    tempFilters: createDefaultTempFilters(),
+    focusedListFlightId: null as number | null,
+    listOpen: false,
+    statisticsOpen,
+  };
+  const events: string[] = [];
+  const focusFlightInList = vi.fn();
+  const openFlightDetails = vi.fn();
+  const navigate = createFlightNavigator({
+    getState: () => state,
+    commitState: (next) => {
+      state = next;
+      events.push(
+        `commit:list=${next.listOpen},statistics=${next.statisticsOpen}`,
+      );
+    },
+    focusFlightInList,
+    waitForModalClose: async () => {
+      events.push('wait');
+    },
+    openFlightDetails: (flightId) => {
+      openFlightDetails(flightId);
+      events.push(`details:${flightId}`);
+    },
+  });
+
+  return {
+    navigate,
+    focusFlightInList,
+    openFlightDetails,
+    events,
+    state: () => ({
+      ...state,
+      statsOpen: state.statisticsOpen,
+    }),
+  };
+};
+
+describe('flight navigation', () => {
+  it('keeps excluded flights on the focused route drawable', () => {
+    const visible = [flight(1, 1, 2), flight(2, 3, 4)];
+    const all = [...visible, flight(3, 2, 1), flight(4, 5, 6)];
+
+    expect(
+      includeFocusedRouteOnMap(visible, all, { a: '1', b: '2' }).map(
+        (item) => item.id,
+      ),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('preserves the filtered array when no route is focused', () => {
+    const visible = [flight(1, 1, 2)];
+
+    expect(includeFocusedRouteOnMap(visible, visible, null)).toBe(visible);
+  });
+
+  it('includes a focused list flight outside persistent filters', () => {
+    expect(
+      includeFocusedFlightInList(
+        [flight(1, 1, 2)],
+        [flight(1, 1, 2), flight(2, 3, 4)],
+        2,
+      ),
+    ).toMatchObject({
+      focusedFlightOutsideFilters: true,
+      flights: [{ id: 1 }, { id: 2 }],
+    });
+  });
+
+  it('only maps flights with both endpoints', () => {
+    expect(canShowFlightOnMap(flight(1, 1, 2))).toBe(true);
+    expect(canShowFlightOnMap(flight(2, null, 2))).toBe(false);
+    expect(canShowFlightOnMap(flight(3, 1, null))).toBe(false);
+  });
+
+  it('plans navigation without mutating the current state', () => {
+    const current = {
+      tempFilters: createDefaultTempFilters(),
+      focusedListFlightId: null,
+      listOpen: false,
+      statisticsOpen: true,
+    };
+
+    const transition = planFlightNavigation(
+      {
+        destination: 'list',
+        focus: { type: 'route', route: { a: '1', b: '2' } },
+      },
+      current,
+    );
+
+    expect(current.tempFilters.routes).toEqual([]);
+    expect(transition.state).toMatchObject({
+      listOpen: true,
+      statisticsOpen: true,
+      tempFilters: { routes: [{ a: '1', b: '2' }] },
+    });
+  });
+
+  it('opens a route-focused list with only the route temp filter', async () => {
+    const harness = createNavigator();
+
+    await harness.navigate({
+      destination: 'list',
+      focus: { type: 'route', route: { a: '1', b: '2' } },
+    });
+
+    expect(harness.state()).toMatchObject({
+      focusedListFlightId: null,
+      listOpen: true,
+      tempFilters: {
+        departureAirports: [],
+        arrivalAirports: [],
+        airportsEither: [],
+        routes: [{ a: '1', b: '2' }],
+      },
+    });
+  });
+
+  it.each(['departure', 'arrival'] as const)(
+    'opens an airport-focused list for %s flights',
+    async (direction) => {
+      const harness = createNavigator();
+
+      await harness.navigate({
+        destination: 'list',
+        focus: {
+          type: 'airport',
+          airportId: 42,
+          direction,
+          flightId: 7,
+        },
+      });
+
+      expect(harness.state()).toMatchObject({
+        focusedListFlightId: 7,
+        listOpen: true,
+        tempFilters: {
+          departureAirports: direction === 'departure' ? ['42'] : [],
+          arrivalAirports: direction === 'arrival' ? ['42'] : [],
+          routes: [],
+        },
+      });
+      expect(harness.focusFlightInList).toHaveBeenCalledWith(7);
+    },
+  );
+
+  it('opens a flight-focused list outside temporary filters', async () => {
+    const harness = createNavigator();
+
+    await harness.navigate({
+      destination: 'list',
+      focus: { type: 'flight', flightId: 9 },
+    });
+
+    expect(harness.state()).toMatchObject({
+      focusedListFlightId: 9,
+      listOpen: true,
+      tempFilters: createDefaultTempFilters(),
+    });
+    expect(harness.focusFlightInList).toHaveBeenCalledWith(9);
+  });
+
+  it('closes modal history before opening flight details on the map', async () => {
+    const harness = createNavigator(true);
+
+    await harness.navigate({
+      destination: 'map',
+      focus: { type: 'flight', flightId: 11 },
+    });
+
+    expect(harness.state()).toMatchObject({
+      listOpen: false,
+      statsOpen: false,
+      tempFilters: createDefaultTempFilters(),
+    });
+    expect(harness.openFlightDetails).toHaveBeenCalledWith(11);
+    expect(harness.events).toEqual([
+      'commit:list=false,statistics=false',
+      'wait',
+      'details:11',
+    ]);
+  });
+});

--- a/src/lib/flight-navigation.ts
+++ b/src/lib/flight-navigation.ts
@@ -1,0 +1,110 @@
+import {
+  createDefaultTempFilters,
+  setTempArrivalAirport,
+  setTempDepartureAirport,
+  setTempRoute,
+  type Route,
+  type TempFilters,
+} from '$lib/components/flight-filters/types';
+
+export type FlightListFocus =
+  | { type: 'flight'; flightId: number }
+  | { type: 'route'; route: Route }
+  | {
+      type: 'airport';
+      airportId: number;
+      direction: 'departure' | 'arrival';
+      flightId?: number;
+    };
+
+export type FlightNavigationIntent =
+  | { destination: 'list'; focus: FlightListFocus }
+  | {
+      destination: 'map';
+      focus: { type: 'flight'; flightId: number };
+    };
+
+export type NavigateFlights = (
+  intent: FlightNavigationIntent,
+) => void | Promise<void>;
+
+export type FlightNavigationState = {
+  tempFilters: TempFilters;
+  focusedListFlightId: number | null;
+  listOpen: boolean;
+  statisticsOpen: boolean;
+};
+
+type FlightNavigationTransition = {
+  state: FlightNavigationState;
+  focusFlightId?: number;
+  detailFlightId?: number;
+};
+
+export type FlightNavigatorDependencies = {
+  getState: () => FlightNavigationState;
+  commitState: (state: FlightNavigationState) => void;
+  focusFlightInList: (flightId: number) => void;
+  waitForModalClose: () => Promise<void>;
+  openFlightDetails: (flightId: number) => void;
+};
+
+export const planFlightNavigation = (
+  intent: FlightNavigationIntent,
+  current: FlightNavigationState,
+): FlightNavigationTransition => {
+  const tempFilters = createDefaultTempFilters();
+
+  if (intent.destination === 'map') {
+    return {
+      state: {
+        tempFilters,
+        focusedListFlightId: null,
+        listOpen: false,
+        statisticsOpen: false,
+      },
+      detailFlightId: intent.focus.flightId,
+    };
+  }
+
+  const focus = intent.focus;
+  let focusFlightId: number | undefined;
+  if (focus.type === 'route') {
+    setTempRoute(tempFilters, focus.route);
+  } else if (focus.type === 'airport') {
+    const setAirport =
+      focus.direction === 'departure'
+        ? setTempDepartureAirport
+        : setTempArrivalAirport;
+    setAirport(tempFilters, focus.airportId.toString());
+    focusFlightId = focus.flightId;
+  } else {
+    focusFlightId = focus.flightId;
+  }
+
+  return {
+    state: {
+      tempFilters,
+      focusedListFlightId: focusFlightId ?? null,
+      listOpen: true,
+      statisticsOpen: current.statisticsOpen,
+    },
+    focusFlightId,
+  };
+};
+
+export const createFlightNavigator = (
+  dependencies: FlightNavigatorDependencies,
+): NavigateFlights => {
+  return async (intent) => {
+    const transition = planFlightNavigation(intent, dependencies.getState());
+    dependencies.commitState(transition.state);
+    if (transition.focusFlightId !== undefined) {
+      dependencies.focusFlightInList(transition.focusFlightId);
+    }
+    if (transition.detailFlightId === undefined) return;
+
+    await dependencies.waitForModalClose();
+    dependencies.openFlightDetails(transition.detailFlightId);
+  };
+};

--- a/src/lib/flight-visibility.ts
+++ b/src/lib/flight-visibility.ts
@@ -1,0 +1,64 @@
+import {
+  routeMatchesEndpoints,
+  type Route,
+} from '$lib/components/flight-filters/types';
+
+export const canShowFlightOnMap = (flight: {
+  from: unknown | null;
+  to: unknown | null;
+}) => flight.from !== null && flight.to !== null;
+
+export const includeFocusedRouteOnMap = <
+  T extends {
+    id: number;
+    from: { id: number } | null;
+    to: { id: number } | null;
+  },
+>(
+  filteredFlights: T[],
+  allFlights: T[],
+  route: Route | null,
+) => {
+  if (!route) return filteredFlights;
+
+  const visibleIds = new Set(filteredFlights.map((flight) => flight.id));
+  const routeFlights = allFlights.filter((flight) => {
+    if (!flight.from || !flight.to || visibleIds.has(flight.id)) return false;
+    return routeMatchesEndpoints(flight.from.id, flight.to.id, route);
+  });
+
+  return routeFlights.length
+    ? [...filteredFlights, ...routeFlights]
+    : filteredFlights;
+};
+
+export const includeFocusedFlightInList = <T extends { id: number }>(
+  filteredFlights: T[],
+  allFlights: T[],
+  focusedFlightId: number | null,
+) => {
+  if (
+    focusedFlightId === null ||
+    filteredFlights.some((flight) => flight.id === focusedFlightId)
+  ) {
+    return {
+      flights: filteredFlights,
+      focusedFlightOutsideFilters: false,
+    };
+  }
+
+  const focusedFlight = allFlights.find(
+    (flight) => flight.id === focusedFlightId,
+  );
+  if (!focusedFlight) {
+    return {
+      flights: filteredFlights,
+      focusedFlightOutsideFilters: false,
+    };
+  }
+
+  return {
+    flights: [...filteredFlights, focusedFlight],
+    focusedFlightOutsideFilters: true,
+  };
+};

--- a/src/lib/map/camera-controller.test.ts
+++ b/src/lib/map/camera-controller.test.ts
@@ -1,0 +1,581 @@
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createMapCameraController,
+  type CameraFocusTarget,
+  type CameraPadding,
+} from './camera-controller';
+import type { GlobeFitArc } from './globe-fit';
+
+type CameraCall = {
+  name: string;
+  options?: Record<string, unknown>;
+  eventData?: Record<string, unknown>;
+};
+
+const padding = (top = 0, right = 0, bottom = 0, left = 0): CameraPadding => ({
+  top,
+  right,
+  bottom,
+  left,
+});
+
+const arc = {
+  from: { id: 1, lat: 55.6, lon: 12.6 },
+  to: { id: 2, lat: 40.7, lon: -74 },
+} as GlobeFitArc;
+
+const updatedArc = {
+  from: { id: 3, lat: 1, lon: 3 },
+  to: { id: 4, lat: 2, lon: 4 },
+} as GlobeFitArc;
+
+const createFrameScheduler = () => {
+  let callback: FrameRequestCallback | null = null;
+  const request = vi.fn((next: FrameRequestCallback) => {
+    callback = next;
+    return 1;
+  });
+  const cancel = vi.fn();
+
+  return {
+    scheduler: { request, cancel },
+    flush() {
+      const next = callback;
+      callback = null;
+      if (!next) throw new Error('No camera frame was scheduled');
+      next(0);
+    },
+    request,
+    cancel,
+  };
+};
+
+const createFakeMap = () => {
+  const calls: CameraCall[] = [];
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+  let center = { lng: 0, lat: 0 };
+  let zoom = 2;
+  let bearing = 15;
+  let pitch = 0;
+  let currentPadding = padding();
+  let cameraForBoundsError: Error | null = null;
+
+  const recordTransition = (
+    name: string,
+    options: Record<string, unknown>,
+    eventData?: Record<string, unknown>,
+  ) => {
+    calls.push({ name, options, eventData });
+    const nextCenter = options.center as [number, number] | undefined;
+    if (nextCenter) center = { lng: nextCenter[0], lat: nextCenter[1] };
+    if (typeof options.zoom === 'number') zoom = options.zoom;
+    if (typeof options.bearing === 'number') bearing = options.bearing;
+    if (typeof options.pitch === 'number') pitch = options.pitch;
+    if (options.padding) currentPadding = options.padding as CameraPadding;
+  };
+
+  const fake = {
+    getCenter: () => center,
+    getZoom: () => zoom,
+    getBearing: () => bearing,
+    getPitch: () => pitch,
+    getPadding: () => currentPadding,
+    getCanvas: () => ({ clientWidth: 1200, clientHeight: 800 }),
+    setPadding(next: CameraPadding) {
+      calls.push({ name: 'setPadding', options: next });
+      currentPadding = next;
+      return fake;
+    },
+    cameraForBounds() {
+      calls.push({ name: 'cameraForBounds' });
+      if (cameraForBoundsError) throw cameraForBoundsError;
+      return { center: [4, 5] as [number, number], zoom: 6 };
+    },
+    flyTo(
+      options: Record<string, unknown>,
+      eventData?: Record<string, unknown>,
+    ) {
+      recordTransition('flyTo', options, eventData);
+      return fake;
+    },
+    easeTo(
+      options: Record<string, unknown>,
+      eventData?: Record<string, unknown>,
+    ) {
+      recordTransition('easeTo', options, eventData);
+      return fake;
+    },
+    fitBounds(
+      bounds: unknown,
+      options?: Record<string, unknown>,
+      eventData?: Record<string, unknown>,
+    ) {
+      calls.push({
+        name: 'fitBounds',
+        options: { bounds, ...options },
+        eventData,
+      });
+      return fake;
+    },
+    on(event: string, handler: (event: unknown) => void) {
+      const handlers = listeners.get(event) ?? new Set();
+      handlers.add(handler);
+      listeners.set(event, handlers);
+      return fake;
+    },
+    off(event: string, handler: (event: unknown) => void) {
+      listeners.get(event)?.delete(handler);
+      return fake;
+    },
+  };
+
+  return {
+    map: fake as unknown as MapLibreMap,
+    calls,
+    emit(event: string, data: Record<string, unknown> = {}) {
+      for (const handler of [...(listeners.get(event) ?? [])]) handler(data);
+    },
+    failCameraForBounds(error: Error) {
+      cameraForBoundsError = error;
+    },
+  };
+};
+
+const pointTarget = (
+  center: [number, number] = [10, 20],
+  zoom = 8,
+): CameraFocusTarget => ({ type: 'point', center, zoom });
+
+const reconcile = (
+  controller: ReturnType<typeof createMapCameraController>,
+  {
+    focusRequest = 1,
+    focusTarget,
+    selectionActive = focusTarget !== undefined,
+    viewPadding = padding(),
+    projection = 'mercator' as const,
+    overviewArcs = [arc],
+    automaticFitRequest = 0,
+  }: {
+    focusRequest?: number;
+    focusTarget?: CameraFocusTarget;
+    selectionActive?: boolean;
+    viewPadding?: CameraPadding;
+    projection?: 'globe' | 'mercator';
+    overviewArcs?: GlobeFitArc[];
+    automaticFitRequest?: number;
+  } = {},
+) =>
+  controller.reconcile({
+    selectionActive,
+    focusRequest,
+    focusTarget,
+    padding: viewPadding,
+    projection,
+    overviewArcs,
+    automaticFitRequest,
+  });
+
+describe('map camera controller', () => {
+  it('lets selection focus win over queued automatic fitting and padding', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: padding(40, 20, 440, 20),
+      automaticFitRequest: 1,
+    });
+    frames.flush();
+
+    expect(frames.request).toHaveBeenCalledTimes(1);
+    expect(fake.calls.map((call) => call.name)).toEqual(['flyTo']);
+  });
+
+  it('keeps focus queued until an active map touch finishes', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    fake.emit('touchstart');
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: padding(40, 20, 440, 20),
+    });
+
+    expect(fake.calls).toEqual([]);
+    expect(frames.request).not.toHaveBeenCalled();
+
+    fake.emit('touchend');
+    expect(frames.request).toHaveBeenCalledTimes(1);
+    frames.flush();
+    expect(fake.calls.map((call) => call.name)).toEqual(['flyTo']);
+  });
+
+  it('focuses details after the user has moved the camera', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    fake.emit('dragstart', { originalEvent: {} });
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: padding(40, 20, 440, 20),
+    });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual(['flyTo']);
+  });
+
+  it('gives geolocation ownership of the camera', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const previousStates: boolean[] = [];
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+      onPreviousViewChange: (available) => previousStates.push(available),
+    });
+    const detailPadding = padding(40, 20, 440, 20);
+
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: detailPadding,
+    });
+    frames.flush();
+    fake.calls.length = 0;
+
+    reconcile(controller, {
+      selectionActive: true,
+      focusTarget: pointTarget(),
+      viewPadding: detailPadding,
+      automaticFitRequest: 1,
+    });
+    fake.emit('movestart', { geolocateSource: true });
+    reconcile(controller, {
+      selectionActive: false,
+      viewPadding: padding(),
+      automaticFitRequest: 1,
+    });
+    frames.flush();
+
+    expect(previousStates).toEqual([true, false]);
+    expect(fake.calls.map((call) => call.name)).toEqual(['easeTo']);
+  });
+
+  it('manual fitting restores automatic fitting outside details', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    fake.emit('dragstart', { originalEvent: {} });
+    reconcile(controller, { automaticFitRequest: 1 });
+    expect(frames.request).not.toHaveBeenCalled();
+
+    controller.fit([arc], {
+      projection: 'mercator',
+      padding: padding(),
+    });
+    frames.flush();
+    fake.calls.length = 0;
+    frames.request.mockClear();
+
+    reconcile(controller, { automaticFitRequest: 2 });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual([
+      'setPadding',
+      'fitBounds',
+    ]);
+  });
+
+  it('keeps the initial automatic fit after non-user map startup events', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    fake.emit('zoomstart');
+    reconcile(controller, { automaticFitRequest: 1 });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual([
+      'setPadding',
+      'fitBounds',
+    ]);
+  });
+
+  it('lets a filtered-result fit replace details-close padding', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: padding(40, 20, 440, 20),
+    });
+    frames.flush();
+    fake.calls.length = 0;
+
+    reconcile(controller, {
+      selectionActive: false,
+      viewPadding: padding(),
+      automaticFitRequest: 1,
+    });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual([
+      'setPadding',
+      'fitBounds',
+    ]);
+  });
+
+  it('cancels a queued camera command during cleanup', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    reconcile(controller, { focusTarget: pointTarget() });
+    controller.destroy();
+
+    expect(frames.cancel).toHaveBeenCalledWith(1);
+    expect(fake.calls).toEqual([]);
+  });
+
+  it('pins mercator padding while calculating an arc focus target', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    reconcile(controller, {
+      focusTarget: { type: 'arcs', arcs: [arc], projection: 'mercator' },
+      viewPadding: padding(40, 20, 440, 20),
+    });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual([
+      'setPadding',
+      'cameraForBounds',
+      'setPadding',
+      'flyTo',
+    ]);
+    expect(fake.calls[0]?.options).toEqual(padding(40, 20, 440, 20));
+    expect(fake.calls[2]?.options).toEqual(padding());
+  });
+
+  it('restores persistent padding if target calculation fails', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+    fake.failCameraForBounds(new Error('cannot fit'));
+
+    reconcile(controller, {
+      focusTarget: { type: 'arcs', arcs: [arc], projection: 'mercator' },
+      viewPadding: padding(40, 20, 440, 20),
+    });
+
+    expect(() => frames.flush()).toThrow('cannot fit');
+    expect(fake.calls.at(-1)).toEqual({
+      name: 'setPadding',
+      options: padding(),
+    });
+  });
+
+  it('eases when focus only needs to interpolate padding', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    reconcile(controller, {
+      focusTarget: pointTarget([0, 0], 2),
+      viewPadding: padding(40, 20, 440, 20),
+    });
+    frames.flush();
+
+    expect(fake.calls[0]).toMatchObject({
+      name: 'easeTo',
+      options: { duration: 300, padding: padding(40, 20, 440, 20) },
+    });
+  });
+
+  it('keeps the previous view available after details padding is removed', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const previousStates: boolean[] = [];
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+      onPreviousViewChange: (available) => previousStates.push(available),
+    });
+
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: padding(40, 20, 440, 20),
+    });
+    frames.flush();
+    reconcile(controller, {
+      focusRequest: 1,
+      viewPadding: padding(),
+    });
+    frames.flush();
+
+    expect(previousStates).toEqual([true]);
+
+    controller.restore(true);
+    frames.flush();
+    expect(previousStates).toEqual([true, false]);
+  });
+
+  it('keeps a newer programmatic move active when an older move ends', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const previousStates: boolean[] = [];
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+      onPreviousViewChange: (available) => previousStates.push(available),
+    });
+
+    reconcile(controller, {
+      focusRequest: 1,
+      focusTarget: pointTarget([10, 20], 8),
+    });
+    frames.flush();
+    const firstMove = fake.calls.at(-1)?.eventData;
+    reconcile(controller, {
+      focusRequest: 2,
+      focusTarget: pointTarget([30, 40], 9),
+    });
+    frames.flush();
+    const secondMove = fake.calls.at(-1)?.eventData;
+
+    fake.emit('moveend', firstMove);
+    fake.emit('dragstart', secondMove);
+    controller.restore(true);
+    frames.flush();
+
+    expect(fake.calls.at(-1)).toMatchObject({
+      name: 'easeTo',
+      options: { center: [10, 20], zoom: 8, bearing: 15, duration: 650 },
+    });
+    expect(previousStates.at(-1)).toBe(false);
+  });
+
+  it('normalizes bearing and pitch when globe rotation is disabled', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    controller.normalizeOrientation(false);
+    frames.flush();
+
+    expect(fake.calls[0]).toMatchObject({
+      name: 'easeTo',
+      options: { bearing: 0, pitch: 0, duration: 0 },
+    });
+  });
+
+  it('defers automatic fitting until untouched details close', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+    const detailPadding = padding(40, 20, 440, 20);
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: detailPadding,
+    });
+    frames.flush();
+    fake.calls.length = 0;
+    frames.request.mockClear();
+
+    reconcile(controller, {
+      selectionActive: true,
+      focusTarget: pointTarget(),
+      viewPadding: detailPadding,
+      overviewArcs: [arc],
+      automaticFitRequest: 1,
+    });
+    expect(frames.request).not.toHaveBeenCalled();
+
+    reconcile(controller, {
+      selectionActive: false,
+      viewPadding: padding(),
+      overviewArcs: [updatedArc],
+      automaticFitRequest: 1,
+    });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual([
+      'setPadding',
+      'fitBounds',
+    ]);
+    expect(fake.calls[1]?.options?.bounds).toEqual([
+      [3, 1],
+      [4, 2],
+    ]);
+  });
+
+  it('cancels deferred and future automatic fitting after user movement', () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+    const detailPadding = padding(40, 20, 440, 20);
+    reconcile(controller, {
+      focusTarget: pointTarget(),
+      viewPadding: detailPadding,
+    });
+    frames.flush();
+    fake.emit('moveend', fake.calls.at(-1)?.eventData);
+    fake.calls.length = 0;
+    frames.request.mockClear();
+
+    reconcile(controller, {
+      selectionActive: true,
+      focusTarget: pointTarget(),
+      viewPadding: detailPadding,
+      automaticFitRequest: 1,
+    });
+    fake.emit('dragstart', { originalEvent: {} });
+    reconcile(controller, {
+      selectionActive: false,
+      viewPadding: padding(),
+      automaticFitRequest: 1,
+    });
+    frames.flush();
+
+    expect(fake.calls.map((call) => call.name)).toEqual(['easeTo']);
+
+    frames.request.mockClear();
+    reconcile(controller, {
+      selectionActive: false,
+      viewPadding: padding(),
+      automaticFitRequest: 2,
+    });
+    expect(frames.request).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/map/camera-controller.ts
+++ b/src/lib/map/camera-controller.ts
@@ -1,0 +1,495 @@
+import maplibregl, {
+  type EaseToOptions,
+  type FlyToOptions,
+  type Map as MapLibreMap,
+} from 'maplibre-gl';
+
+import { globeCameraForArcs, type GlobeFitArc } from './globe-fit';
+
+import { calculateBounds } from '$lib/utils/latlng';
+
+export type MapProjection = 'globe' | 'mercator';
+export type CameraPadding = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+export type CameraFocusTarget =
+  | { type: 'point'; center: [number, number]; zoom: number }
+  | { type: 'arcs'; arcs: GlobeFitArc[]; projection: MapProjection };
+
+type FitIntent = {
+  type: 'fit';
+  arcs: GlobeFitArc[];
+  projection: MapProjection;
+  padding: CameraPadding;
+  source: 'automatic' | 'manual';
+  resultMode: CameraMode;
+};
+
+type FocusIntent = {
+  type: 'focus';
+  target: CameraFocusTarget;
+  padding: CameraPadding;
+};
+
+type CameraIntent =
+  | FitIntent
+  | FocusIntent
+  | { type: 'padding'; padding: CameraPadding }
+  | { type: 'restore'; rotationEnabled: boolean }
+  | { type: 'orientation'; rotationEnabled: boolean };
+
+export type CameraViewState = {
+  selectionActive: boolean;
+  focusRequest: number;
+  focusTarget?: CameraFocusTarget;
+  padding: CameraPadding;
+  projection: MapProjection;
+  overviewArcs: GlobeFitArc[];
+  automaticFitRequest: number;
+};
+
+type CameraMode = 'overview' | 'details' | 'custom';
+
+type CameraSnapshot = {
+  center: [number, number];
+  zoom: number;
+  bearing: number;
+  pitch: number;
+  mode: CameraMode;
+};
+
+type FrameScheduler = {
+  request: (callback: FrameRequestCallback) => number;
+  cancel: (handle: number) => void;
+};
+
+type CameraControllerOptions = {
+  onPreviousViewChange?: (available: boolean) => void;
+  frameScheduler?: FrameScheduler;
+};
+
+const intentPriority = (intent: CameraIntent) => {
+  // One frame can contain several reactive state changes. Keep only the
+  // strongest resulting camera intent so their execution order is explicit:
+  // restoration > selection focus > overview fit > padding-only adjustment.
+  switch (intent.type) {
+    case 'padding':
+      return 10;
+    case 'fit':
+      return intent.source === 'manual' ? 25 : 20;
+    case 'focus':
+      return 30;
+    case 'restore':
+      return 40;
+    case 'orientation':
+      return 50;
+  }
+};
+
+const cameraEventGenerationKey = 'airtrailCameraGeneration';
+const defaultFrameScheduler: FrameScheduler = {
+  request: (callback) => requestAnimationFrame(callback),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+const addPadding = (padding: CameraPadding, amount: number) => ({
+  top: padding.top + amount,
+  right: padding.right + amount,
+  bottom: padding.bottom + amount,
+  left: padding.left + amount,
+});
+
+const paddingEquals = (left: CameraPadding, right: CameraPadding) =>
+  left.top === right.top &&
+  left.right === right.right &&
+  left.bottom === right.bottom &&
+  left.left === right.left;
+
+export const createMapCameraController = (
+  map: MapLibreMap,
+  options: CameraControllerOptions = {},
+) => {
+  const frameScheduler = options.frameScheduler ?? defaultFrameScheduler;
+  let previousCamera: CameraSnapshot | null = null;
+  let pendingIntent: CameraIntent | null = null;
+  let pendingOrientation: Extract<
+    CameraIntent,
+    { type: 'orientation' }
+  > | null = null;
+  let pendingFrame: number | null = null;
+  let pendingAutomaticFit = false;
+  let mapTouchActive = false;
+  let selectionActive = false;
+  let handledFocusRequest = -1;
+  let handledAutomaticFitRequest = 0;
+  let lastPadding: CameraPadding | null = null;
+  let cameraMode: CameraMode = 'overview';
+  let movementGeneration = 0;
+  const moveEndHandlers = new Set<(event: unknown) => void>();
+
+  const setPreviousCamera = (camera: CameraSnapshot | null) => {
+    previousCamera = camera;
+    options.onPreviousViewChange?.(camera !== null);
+  };
+
+  const snapshotCamera = (): CameraSnapshot => {
+    const center = map.getCenter();
+    return {
+      center: [center.lng, center.lat],
+      zoom: map.getZoom(),
+      bearing: map.getBearing(),
+      pitch: map.getPitch(),
+      mode: cameraMode,
+    };
+  };
+
+  const beginProgrammaticMove = () => {
+    const generation = ++movementGeneration;
+    const eventData = { [cameraEventGenerationKey]: generation };
+    const handleMoveEnd = (event: unknown) => {
+      const completedGeneration = (
+        event as Record<string, unknown> | undefined
+      )?.[cameraEventGenerationKey];
+      if (completedGeneration !== generation) return;
+
+      map.off('moveend', handleMoveEnd);
+      moveEndHandlers.delete(handleMoveEnd);
+    };
+    moveEndHandlers.add(handleMoveEnd);
+    map.on('moveend', handleMoveEnd);
+    return eventData;
+  };
+
+  const targetForArcs = (
+    arcs: GlobeFitArc[],
+    projection: MapProjection,
+    padding: CameraPadding,
+  ) => {
+    if (projection === 'globe') {
+      const canvas = map.getCanvas();
+      return globeCameraForArcs(arcs, {
+        width: canvas.clientWidth,
+        height: canvas.clientHeight,
+        padding,
+      });
+    }
+
+    const bounds = calculateBounds(arcs);
+    if (!bounds) return undefined;
+
+    const savedPadding = map.getPadding();
+    try {
+      // cameraForBounds uses persistent and option padding differently when
+      // calculating its center. Pin the calculation to the target persistent
+      // padding, then restore it before the next render.
+      map.setPadding(padding);
+      const target = map.cameraForBounds(bounds);
+      if (!target?.center || target.zoom === undefined) return undefined;
+      const center = maplibregl.LngLat.convert(target.center);
+      return {
+        center: [center.lng, center.lat] as [number, number],
+        zoom: target.zoom,
+      };
+    } finally {
+      map.setPadding(savedPadding);
+    }
+  };
+
+  const executeFit = (intent: FitIntent) => {
+    const padding = addPadding(intent.padding, 60);
+    if (intent.projection === 'globe') {
+      const target = targetForArcs(intent.arcs, intent.projection, padding);
+      if (!target) return;
+      map.setPadding(padding);
+      map.flyTo(
+        {
+          center: target.center,
+          zoom: target.zoom,
+          essential: true,
+        },
+        beginProgrammaticMove(),
+      );
+      cameraMode = intent.resultMode;
+      return;
+    }
+
+    const bounds = calculateBounds(intent.arcs);
+    if (!bounds) return;
+    map.setPadding(padding);
+    map.fitBounds(bounds, undefined, beginProgrammaticMove());
+    cameraMode = intent.resultMode;
+  };
+
+  const executeFocus = (intent: FocusIntent) => {
+    const target =
+      intent.target.type === 'point'
+        ? intent.target
+        : targetForArcs(
+            intent.target.arcs,
+            intent.target.projection,
+            intent.padding,
+          );
+    if (!target) return;
+
+    const currentCenter = map.getCenter();
+    const cameraMoved =
+      Math.abs(currentCenter.lng - target.center[0]) > 1e-4 ||
+      Math.abs(currentCenter.lat - target.center[1]) > 1e-4 ||
+      Math.abs(map.getZoom() - target.zoom) > 1e-2;
+
+    setPreviousCamera(snapshotCamera());
+    const transition: FlyToOptions | EaseToOptions = {
+      center: target.center,
+      zoom: target.zoom,
+      padding: intent.padding,
+      duration: cameraMoved ? 1200 : 300,
+      essential: true,
+    };
+    const eventData = beginProgrammaticMove();
+    if (cameraMoved) {
+      map.flyTo(transition, eventData);
+    } else {
+      map.easeTo(transition, eventData);
+    }
+    cameraMode = 'details';
+  };
+
+  const execute = (intent: CameraIntent) => {
+    switch (intent.type) {
+      case 'fit':
+        executeFit(intent);
+        break;
+      case 'focus':
+        executeFocus(intent);
+        break;
+      case 'padding':
+        map.easeTo(
+          {
+            padding: intent.padding,
+            duration: 300,
+            essential: true,
+          },
+          beginProgrammaticMove(),
+        );
+        break;
+      case 'restore':
+        if (!previousCamera) return;
+        cameraMode = previousCamera.mode;
+        map.easeTo(
+          {
+            center: previousCamera.center,
+            zoom: previousCamera.zoom,
+            bearing: intent.rotationEnabled ? previousCamera.bearing : 0,
+            pitch: 0,
+            duration: 650,
+            essential: true,
+          },
+          beginProgrammaticMove(),
+        );
+        setPreviousCamera(null);
+        break;
+      case 'orientation': {
+        const bearing = intent.rotationEnabled ? map.getBearing() : 0;
+        if (map.getPitch() === 0 && map.getBearing() === bearing) return;
+        map.easeTo(
+          {
+            pitch: 0,
+            bearing,
+            duration: 0,
+            essential: true,
+          },
+          beginProgrammaticMove(),
+        );
+        break;
+      }
+    }
+  };
+
+  const flush = () => {
+    pendingFrame = null;
+    const orientation = pendingOrientation;
+    pendingOrientation = null;
+    if (orientation) execute(orientation);
+
+    if (pendingIntent?.type === 'focus' && mapTouchActive) {
+      return;
+    }
+
+    const intent = pendingIntent;
+    pendingIntent = null;
+    if (intent) execute(intent);
+  };
+
+  const request = (intent: CameraIntent) => {
+    if (intent.type === 'orientation') {
+      pendingOrientation = intent;
+    } else if (
+      !pendingIntent ||
+      intentPriority(intent) >= intentPriority(pendingIntent)
+    ) {
+      pendingIntent = intent;
+    }
+    if (
+      pendingIntent?.type === 'focus' &&
+      mapTouchActive &&
+      pendingOrientation === null
+    )
+      return;
+    pendingFrame ??= frameScheduler.request(flush);
+  };
+
+  const requestOverviewFit = (view: CameraViewState) => {
+    request({
+      type: 'fit',
+      arcs: view.overviewArcs,
+      projection: view.projection,
+      padding: view.padding,
+      source: 'automatic',
+      resultMode: 'overview',
+    });
+  };
+
+  const markCustomCamera = (event: unknown) => {
+    const cameraEvent = event as Record<string, unknown> | undefined;
+    const generation = cameraEvent?.[cameraEventGenerationKey];
+    if (typeof generation === 'number') return;
+    if (!cameraEvent?.originalEvent && cameraEvent?.geolocateSource !== true)
+      return;
+
+    cameraMode = 'custom';
+    pendingAutomaticFit = false;
+    if (previousCamera) setPreviousCamera(null);
+  };
+
+  const markMapTouchStart = () => {
+    mapTouchActive = true;
+  };
+
+  const markMapTouchEnd = () => {
+    mapTouchActive = false;
+    if (pendingIntent && pendingFrame === null) {
+      pendingFrame = frameScheduler.request(flush);
+    }
+  };
+
+  map.on('movestart', markCustomCamera);
+  map.on('dragstart', markCustomCamera);
+  map.on('zoomstart', markCustomCamera);
+  map.on('rotatestart', markCustomCamera);
+  map.on('pitchstart', markCustomCamera);
+  map.on('touchstart', markMapTouchStart);
+  map.on('touchend', markMapTouchEnd);
+  map.on('touchcancel', markMapTouchEnd);
+
+  return {
+    fit(
+      arcs: GlobeFitArc[],
+      config: {
+        projection: MapProjection;
+        padding: CameraPadding;
+      },
+    ) {
+      const intent: FitIntent = {
+        type: 'fit',
+        arcs,
+        projection: config.projection,
+        padding: config.padding,
+        source: 'manual',
+        resultMode: selectionActive ? 'details' : 'overview',
+      };
+      request(intent);
+    },
+    reconcile(view: CameraViewState) {
+      const selectionClosed = selectionActive && !view.selectionActive;
+      const paddingChanged =
+        lastPadding !== null && !paddingEquals(lastPadding, view.padding);
+      const focusTarget = view.focusTarget;
+      const focusRequested =
+        focusTarget !== undefined && view.focusRequest !== handledFocusRequest;
+      const automaticFitRequested =
+        view.automaticFitRequest !== handledAutomaticFitRequest;
+
+      selectionActive = view.selectionActive;
+      lastPadding = view.padding;
+      handledAutomaticFitRequest = view.automaticFitRequest;
+
+      if (focusRequested) {
+        handledFocusRequest = view.focusRequest;
+        request({
+          type: 'focus',
+          target: focusTarget,
+          padding: view.padding,
+        });
+      }
+
+      if (view.selectionActive) {
+        if (
+          automaticFitRequested &&
+          (focusRequested ||
+            pendingIntent?.type === 'focus' ||
+            cameraMode === 'details')
+        ) {
+          pendingAutomaticFit = true;
+        }
+        if (!focusRequested && paddingChanged) {
+          request({ type: 'padding', padding: view.padding });
+        }
+        return;
+      }
+
+      if (selectionClosed && pendingIntent?.type === 'focus') {
+        pendingIntent = null;
+      }
+
+      const releaseAutomaticFit =
+        selectionClosed &&
+        cameraMode === 'details' &&
+        (pendingAutomaticFit || automaticFitRequested);
+      if (selectionClosed) pendingAutomaticFit = false;
+
+      if (releaseAutomaticFit) {
+        requestOverviewFit(view);
+      } else {
+        if (automaticFitRequested && cameraMode === 'overview') {
+          requestOverviewFit(view);
+        }
+        if (selectionClosed && cameraMode === 'details') {
+          cameraMode = 'custom';
+        }
+      }
+
+      if (paddingChanged && !releaseAutomaticFit) {
+        request({ type: 'padding', padding: view.padding });
+      }
+    },
+    restore(rotationEnabled: boolean) {
+      request({ type: 'restore', rotationEnabled });
+    },
+    normalizeOrientation(rotationEnabled: boolean) {
+      request({ type: 'orientation', rotationEnabled });
+    },
+    destroy() {
+      if (pendingFrame !== null) frameScheduler.cancel(pendingFrame);
+      pendingFrame = null;
+      pendingIntent = null;
+      pendingOrientation = null;
+      pendingAutomaticFit = false;
+      map.off('movestart', markCustomCamera);
+      map.off('dragstart', markCustomCamera);
+      map.off('zoomstart', markCustomCamera);
+      map.off('rotatestart', markCustomCamera);
+      map.off('pitchstart', markCustomCamera);
+      map.off('touchstart', markMapTouchStart);
+      map.off('touchend', markMapTouchEnd);
+      map.off('touchcancel', markMapTouchEnd);
+      for (const handler of moveEndHandlers) map.off('moveend', handler);
+      moveEndHandlers.clear();
+    },
+  };
+};
+
+export type MapCameraController = ReturnType<typeof createMapCameraController>;

--- a/src/lib/map/flight-layer-data.ts
+++ b/src/lib/map/flight-layer-data.ts
@@ -1,4 +1,7 @@
-import type { Route } from '$lib/components/flight-filters/types';
+import {
+  routeMatchesEndpoints,
+  type Route,
+} from '$lib/components/flight-filters/types';
 import {
   toFlightTrackSamples,
   type FlightTrackRow,
@@ -23,13 +26,7 @@ export const routeMatchesArc = (
   arc: FlightArc,
   route: Route | null | undefined,
 ) => {
-  if (!route) return false;
-  const fromId = arc.from.id.toString();
-  const toId = arc.to.id.toString();
-  return (
-    (fromId === route.a && toId === route.b) ||
-    (fromId === route.b && toId === route.a)
-  );
+  return routeMatchesEndpoints(arc.from.id, arc.to.id, route);
 };
 
 export const buildArcFrequencyPercentileByRoute = (flightArcs: FlightArc[]) => {

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -59,7 +59,8 @@ export const openModalsState = $state<OpenModalsState>({
 
 export type MapDetailsSelection =
   | { type: 'airport'; airportId: number }
-  | { type: 'route'; route: Route };
+  | { type: 'route'; route: Route }
+  | { type: 'flight'; flightId: number };
 
 export const mapDetailsState = $state<{
   selection: MapDetailsSelection | null;
@@ -81,6 +82,11 @@ export const openRouteDetails = (route: Route) => {
     type: 'route',
     route: normalizeRoute(route.a, route.b),
   };
+  mapDetailsState.focusRequest += 1;
+};
+
+export const openFlightDetails = (flightId: number) => {
+  mapDetailsState.selection = { type: 'flight', flightId };
   mapDetailsState.focusRequest += 1;
 };
 

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -133,6 +133,12 @@ export const openRouteInList = (
   openModalsState.listFlights = true;
 };
 
+/** Open the List Flights modal scrolled to and highlighting a single flight. */
+export const openFlightInList = (flightId: number) => {
+  focusFlightInList(flightId);
+  openModalsState.listFlights = true;
+};
+
 export const appConfig = $state<{
   config: ClientAppConfig | null;
   configured: DeepBoolean<FullAppConfig, boolean> | null;

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,8 +1,6 @@
 import {
   normalizeRoute,
-  setTempRoute,
   type Route,
-  type TempFilters,
 } from '$lib/components/flight-filters/types';
 import type { ClientAppConfig, FullAppConfig } from '$lib/server/utils/config';
 import type { DeepBoolean } from '$lib/utils';
@@ -99,21 +97,6 @@ export const focusMapDetails = () => {
 
 export const closeMapDetails = () => {
   mapDetailsState.selection = null;
-};
-
-/** Open the List Flights modal drilled down to all flights on a route. */
-export const openRouteInList = (
-  tempFilters: TempFilters | undefined,
-  route: Route,
-) => {
-  if (tempFilters) setTempRoute(tempFilters, route);
-  openModalsState.listFlights = true;
-};
-
-/** Open the List Flights modal scrolled to and highlighting a single flight. */
-export const openFlightInList = (flightId: number) => {
-  focusFlightInList(flightId);
-  openModalsState.listFlights = true;
 };
 
 export const appConfig = $state<{

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,8 +1,6 @@
 import {
-  clearTempFilters,
   normalizeRoute,
   setTempRoute,
-  type FlightFilters,
   type Route,
   type TempFilters,
 } from '$lib/components/flight-filters/types';
@@ -103,32 +101,11 @@ export const closeMapDetails = () => {
   mapDetailsState.selection = null;
 };
 
-const isolateFlightInFilters = (filters: FlightFilters, flightId: number) => {
-  filters.departureAirports = [];
-  filters.arrivalAirports = [];
-  filters.airportsEither = [];
-  filters.routes = [];
-  filters.flightIds = [flightId.toString()];
-};
-
-/** Isolate a single flight on the map and open its Flight Details pane. */
-export const openFlightOnMap = (
-  filters: FlightFilters | undefined,
-  tempFilters: TempFilters | undefined,
-  flightId: number,
-) => {
-  if (filters) isolateFlightInFilters(filters, flightId);
-  if (tempFilters) clearTempFilters(tempFilters);
-  openFlightDetails(flightId);
-};
-
 /** Open the List Flights modal drilled down to all flights on a route. */
 export const openRouteInList = (
-  filters: FlightFilters | undefined,
   tempFilters: TempFilters | undefined,
   route: Route,
 ) => {
-  if (filters) filters.flightIds = [];
   if (tempFilters) setTempRoute(tempFilters, route);
   openModalsState.listFlights = true;
 };

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,6 +1,10 @@
 import {
+  clearTempFilters,
   normalizeRoute,
+  setTempRoute,
+  type FlightFilters,
   type Route,
+  type TempFilters,
 } from '$lib/components/flight-filters/types';
 import type { ClientAppConfig, FullAppConfig } from '$lib/server/utils/config';
 import type { DeepBoolean } from '$lib/utils';
@@ -97,6 +101,36 @@ export const focusMapDetails = () => {
 
 export const closeMapDetails = () => {
   mapDetailsState.selection = null;
+};
+
+const isolateFlightInFilters = (filters: FlightFilters, flightId: number) => {
+  filters.departureAirports = [];
+  filters.arrivalAirports = [];
+  filters.airportsEither = [];
+  filters.routes = [];
+  filters.flightIds = [flightId.toString()];
+};
+
+/** Isolate a single flight on the map and open its Flight Details pane. */
+export const openFlightOnMap = (
+  filters: FlightFilters | undefined,
+  tempFilters: TempFilters | undefined,
+  flightId: number,
+) => {
+  if (filters) isolateFlightInFilters(filters, flightId);
+  if (tempFilters) clearTempFilters(tempFilters);
+  openFlightDetails(flightId);
+};
+
+/** Open the List Flights modal drilled down to all flights on a route. */
+export const openRouteInList = (
+  filters: FlightFilters | undefined,
+  tempFilters: TempFilters | undefined,
+  route: Route,
+) => {
+  if (filters) filters.flightIds = [];
+  if (tempFilters) setTempRoute(tempFilters, route);
+  openModalsState.listFlights = true;
 };
 
 export const appConfig = $state<{

--- a/src/lib/utils/highlight.ts
+++ b/src/lib/utils/highlight.ts
@@ -86,29 +86,38 @@ const findScrollContainer = (element: HTMLElement) => {
   return null;
 };
 
-const scrollElementIntoView = (
+/**
+ * Center `element` within its nearest scrollable ancestor. Scrolls that
+ * container directly rather than via `element.scrollIntoView()`, which does not
+ * reliably move custom scroll containers (e.g. a bits-ui ScrollArea viewport or
+ * a dialog's overflow pane). `scrollOffset` shifts the final position.
+ */
+export const scrollElementIntoView = (
   element: HTMLElement,
-  scrollOffset: number,
-  behavior: ScrollBehavior,
+  scrollOffset = 0,
+  behavior: ScrollBehavior = 'smooth',
 ) => {
   const scrollContainer = findScrollContainer(element);
 
-  element.scrollIntoView({
-    block: 'center',
-    inline: 'nearest',
-    behavior,
-  });
-
   if (!scrollContainer) {
+    element.scrollIntoView({ block: 'center', inline: 'nearest', behavior });
     if (scrollOffset !== 0) {
       window.scrollBy({ top: scrollOffset, behavior });
     }
     return;
   }
 
-  if (scrollOffset !== 0) {
-    scrollContainer.scrollBy({ top: scrollOffset, behavior });
-  }
+  const elementRect = element.getBoundingClientRect();
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const centerDelta =
+    elementRect.top -
+    containerRect.top -
+    (scrollContainer.clientHeight - elementRect.height) / 2;
+
+  scrollContainer.scrollTo({
+    top: scrollContainer.scrollTop + centerDelta + scrollOffset,
+    behavior,
+  });
 };
 
 export const highlightElement = (

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { page } from '$app/state';
+  import { tick } from 'svelte';
   import { writable } from 'svelte/store';
   import { toast } from 'svelte-sonner';
 
+  import { page } from '$app/state';
   import {
     createDefaultFilters,
     matchesFlight,
@@ -15,13 +16,19 @@
     type FlightFilters,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
-  import FlightsOnboarding from '$lib/components/onboarding/FlightsOnboarding.svelte';
-  import { MapDetailsPane } from '$lib/components/map-details';
   import { Map } from '$lib/components/map';
+  import { MapDetailsPane } from '$lib/components/map-details';
   import { ListFlightsModal, StatisticsModal } from '$lib/components/modals';
+  import FlightsOnboarding from '$lib/components/onboarding/FlightsOnboarding.svelte';
+  import { createFlightNavigator } from '$lib/flight-navigation';
+  import { includeFocusedFlightInList } from '$lib/flight-visibility';
+  import { waitForModalHistoryIdle } from '$lib/components/ui/modal/modal-history';
   import {
+    closeMapDetails,
     flightScopeState,
     focusFlightInList,
+    mapDetailsState,
+    openFlightDetails,
     openModalsState,
   } from '$lib/state.svelte';
   import { trpc } from '$lib/trpc';
@@ -55,6 +62,13 @@
     return prepareFlightData(data);
   });
 
+  $effect(() => {
+    const selection = mapDetailsState.selection;
+    if ($rawFlights.isLoading || selection?.type !== 'flight') return;
+    if (flights.some((flight) => flight.id === selection.flightId)) return;
+    closeMapDetails();
+  });
+
   const visitedCountriesData = $derived.by(() => {
     const data = $rawVisitedCountries.data;
     if (!data || !data.length) return [];
@@ -80,12 +94,12 @@
 
   const showPassengerDetails = $derived(flightScopeState.scope !== 'mine');
   const showCountryStats = $derived(flightScopeState.scope === 'mine');
-  let flightListOpenedFromStatistics = $state(false);
+  let focusedListFlightId = $state<number | null>(null);
 
   $effect(() => {
     if (!openModalsState.listFlights) {
       tempFilters = createDefaultTempFilters();
-      flightListOpenedFromStatistics = false;
+      focusedListFlightId = null;
     }
   });
 
@@ -93,7 +107,7 @@
     return flights.filter((flight) => matchesFlight(flight, filters));
   });
 
-  const drilldownFlights = $derived.by(() => {
+  const filteredDrilldownFlights = $derived.by(() => {
     const locationFilters = hasActiveTempFilters(tempFilters)
       ? tempFilters
       : filters;
@@ -104,6 +118,18 @@
         matchesNonLocationFilters(flight, filters),
     );
   });
+
+  const focusedListResult = $derived.by(() =>
+    includeFocusedFlightInList(
+      filteredDrilldownFlights,
+      flights,
+      focusedListFlightId,
+    ),
+  );
+  const drilldownFlights = $derived(focusedListResult.flights);
+  const focusedFlightOutsideFilters = $derived(
+    focusedListResult.focusedFlightOutsideFilters,
+  );
 
   const invalidator = {
     onSuccess: () => {
@@ -124,11 +150,34 @@
     }
   };
 
-  const openFlightInList = (flightId: number) => {
-    tempFilters = createDefaultTempFilters();
-    focusFlightInList(flightId);
-    flightListOpenedFromStatistics = true;
-    openModalsState.listFlights = true;
+  const navigateFlights = createFlightNavigator({
+    getState: () => ({
+      tempFilters,
+      focusedListFlightId,
+      listOpen: openModalsState.listFlights,
+      statisticsOpen: openModalsState.statistics,
+    }),
+    commitState: (next) => {
+      tempFilters = next.tempFilters;
+      focusedListFlightId = next.focusedListFlightId;
+      Object.assign(openModalsState, {
+        listFlights: next.listOpen,
+        statistics: next.statisticsOpen,
+      });
+    },
+    focusFlightInList,
+    waitForModalClose: async () => {
+      await tick();
+      await waitForModalHistoryIdle();
+    },
+    openFlightDetails,
+  });
+
+  const openStatisticsFlight = (flightId: number) => {
+    return navigateFlights({
+      destination: 'list',
+      focus: { type: 'flight', flightId },
+    });
   };
 </script>
 
@@ -141,9 +190,11 @@
   bind:tempFilters
   {flights}
   filteredFlights={drilldownFlights}
+  {focusedFlightOutsideFilters}
   {deleteFlight}
   seatUserId={effectiveSeatUserId}
   {showPassengerDetails}
+  onNavigate={navigateFlights}
 />
 <StatisticsModal
   bind:open={openModalsState.statistics}
@@ -153,15 +204,20 @@
   visitedCountries={showCountryStats ? visitedCountriesData : []}
   seatUserId={effectiveSeatUserId}
   {showCountryStats}
-  onOpenFlight={openFlightInList}
-  suppressEscapeNavigation={flightListOpenedFromStatistics &&
-    openModalsState.listFlights}
+  onOpenFlight={openStatisticsFlight}
 />
 
-<Map bind:filters bind:tempFilters {flights} {filteredFlights} {flightTracks} />
+<Map
+  bind:filters
+  bind:tempFilters
+  {flights}
+  {filteredFlights}
+  {flightTracks}
+  onNavigate={navigateFlights}
+/>
 <MapDetailsPane
   {flights}
   bind:filters
-  bind:tempFilters
   seatUserId={effectiveSeatUserId}
+  onNavigate={navigateFlights}
 />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -159,4 +159,9 @@
 />
 
 <Map bind:filters bind:tempFilters {flights} {filteredFlights} {flightTracks} />
-<MapDetailsPane {flights} bind:filters bind:tempFilters />
+<MapDetailsPane
+  {flights}
+  bind:filters
+  bind:tempFilters
+  seatUserId={effectiveSeatUserId}
+/>

--- a/src/routes/share/[slug]/+page.svelte
+++ b/src/routes/share/[slug]/+page.svelte
@@ -84,22 +84,14 @@
 
   let showFlightList = $state(false);
   let showStatistics = $state(false);
-  let flightListOpenedFromStatistics = $state(false);
   let filters: FlightFilters = $state(createDefaultFilters());
 
   const shareSettings = $derived($shareQuery.data?.settings);
 
   const openSharedFlightInList = (flightId: number) => {
     focusFlightInList(flightId);
-    flightListOpenedFromStatistics = true;
     showFlightList = true;
   };
-
-  $effect(() => {
-    if (!showFlightList) {
-      flightListOpenedFromStatistics = false;
-    }
-  });
 
   $effect(() => {
     return () => {
@@ -195,8 +187,6 @@
       onOpenFlight={shareSettings.showFlightList
         ? openSharedFlightInList
         : undefined}
-      suppressEscapeNavigation={flightListOpenedFromStatistics &&
-        showFlightList}
     />
   {/if}
 {:else if shareSettings}


### PR DESCRIPTION
# Description

#647. I added a flight details pane similar to the airport details and route details pane. This turned out to be a much larger change than I anticipated once I added the new details page so apologies in advance!

**The filter can be applied in four ways:**

1. On the filters tab on the right side of the map
1. Selecting an individual flight from the route details pane. Previously, this would open the "List Flights" modal and show all flights between the two airports. The "Open list" button still retains this behavior.
1. If a user has the route details pane opened and they click on a route instance on the map (i.e. an instance that has uploaded flight route) the map will filter to just that route and open the flight details pane
1. Flight filter in the "List flights" modal

The new flight details pane. Clicking on the route description at the top brings the user back to the route details pane.
<img width="2177" height="879" alt="Screenshot_20260704_234108" src="https://github.com/user-attachments/assets/0156d814-f4cf-425f-a481-a148b3af55fa" />

When a user hovers on an individual instance of a flight, that specific route is highlighted on the map and in the flight details pane on the left. Also, hovering over a flight in the flight details pane will highlight that same flight on the map.

<img width="1658" height="496" alt="Screenshot_20260713_224537" src="https://github.com/user-attachments/assets/bcf07f03-4e98-4279-91fb-c533582e6c1f" />

Added a "Show on map" button to the list flights page.

<img width="438" height="421" alt="Screenshot_20260704_222417" src="https://github.com/user-attachments/assets/a9a5c01c-ad76-4d69-bf72-7acb64f4db9c" />



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add flight details pane showing individual flight info and filtering the map to that flight
> - Adds a flight details pane ([FlightDetailsContent.svelte](https://github.com/johanohly/AirTrail/pull/649/files#diff-03ddab56fc4b2e4095615b278cef74048a7ef503a41551018bc54d0e3d0be07c), [FlightDetailsHeader.svelte](https://github.com/johanohly/AirTrail/pull/649/files#diff-2a796fc861607175ab4f14104d570a6c935050d1f66e6d428bc2a9d8540b3fe7), [FlightDetailsBody.svelte](https://github.com/johanohly/AirTrail/pull/649/files#diff-d7b97856c1e137f6b9895984bd1ca01c0fc2e79f33a1dbd5b22c0b0a37ce6c84)) that opens when a flight is selected, showing airline, aircraft, route, seat, gates, and notes.
> - Clicking a flight track on the map (or a row in the route details pane) opens the flight details pane; the map isolates that single flight's arc.
> - Introduces a `createMapCameraController` in [camera-controller.ts](https://github.com/johanohly/AirTrail/pull/649/files#diff-727c9e1ef1d0ccb9b924340cf2f32ba5cacd3cde4801028fe4c2b80dad1caafd) to orchestrate all camera moves: arc fitting, focus, padding interpolation, user-vs-programmatic move detection, and previous-view snapshots.
> - Adds a `createFlightNavigator` in [flight-navigation.ts](https://github.com/johanohly/AirTrail/pull/649/files#diff-de5c90b93d78eb96b078a7cf5c8904c5216b7e709556a09b0367ec553470dc9f) that coordinates transitions between map, list, and details — handling temp filters, flight focus, and modal history sequencing.
> - Centralises modal browser-history management in [modal-history.ts](https://github.com/johanohly/AirTrail/pull/649/files#diff-36015a94d261d51fd55c5cc983c2bfd2d2c1f9110ecd3381fa13c67110d87ed1) so nested modals and drilldowns use a shared controller instead of per-component `popstate` wiring.
> - Filter option lists (airports, airlines, aircraft, years) are now scoped to the active route/airport drilldown so only relevant values appear.
> - Risk: the camera controller replaces a large block of inline camera logic in [Map.svelte](https://github.com/johanohly/AirTrail/pull/649/files#diff-55c5f699f0451742fae7c9538b4aee9866837c6e20dea6d1b8f6a38cd1b89dc7); any subtle difference in prioritisation or event timing could affect existing focus/fit behaviour.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a66ae48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->