### PR TITLE
feat: add flight track preference option

### DIFF
--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -118,8 +118,13 @@
     return arcFrequencyPercentileByRoute[routeKey] ?? 0;
   };
 
+  const activeFlightTracks = $derived.by(() => {
+    if (mapPreferences.routeDisplay !== 'tracks') return [];
+    return flightTracks;
+  });
+
   const trackFlightIds = $derived.by(() => {
-    return new Set(flightTracks.map((track) => track.flightId));
+    return new Set(activeFlightTracks.map((track) => track.flightId));
   });
 
   const fullyTrackedRouteKeys = $derived.by(() => {
@@ -133,7 +138,7 @@
   });
 
   const flightTrackPaths = $derived.by(() => {
-    return buildFlightTrackPaths(flights, flightArcs, flightTracks);
+    return buildFlightTrackPaths(flights, flightArcs, activeFlightTracks);
   });
 
   // deck's picking coordinate is unprojected through deck's own globe

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -586,7 +586,10 @@
     <GeolocateControl position="top-right" />
     <Control position="top-right">
       <ControlGroup>
-        <MapAppearanceControl {openAipConfigured} />
+        <MapAppearanceControl
+          {openAipConfigured}
+          showTracksSection={flightTracks.length > 0}
+        />
       </ControlGroup>
     </Control>
     {#if flights.length}

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -34,7 +34,10 @@
   import { openModalsState } from '$lib/state.svelte';
   import { cn } from '$lib/utils';
 
-  let { openAipConfigured = false }: { openAipConfigured?: boolean } = $props();
+  let {
+    openAipConfigured = false,
+    showTracksSection = true,
+  }: { openAipConfigured?: boolean; showTracksSection?: boolean } = $props();
 
   let popoverOpen = $state(false);
   const isAdmin = $derived(page.data.user?.role !== 'user');
@@ -763,51 +766,53 @@
             </div>
           </div>
 
-          <div class="space-y-2">
-            <p class="text-xs font-medium">Tracks</p>
-            <div class="grid grid-cols-2 gap-2">
-              {#each ROUTE_DISPLAY_OPTIONS as option (option.value)}
-                <AppearanceTile
-                  selected={mapPreferences.routeDisplay === option.value}
-                  onclick={() => (mapPreferences.routeDisplay = option.value)}
-                  label={option.label}
-                >
-                  {#snippet illustration()}
-                    <svg
-                      viewBox="0 0 72 32"
-                      class="h-full w-full text-primary"
-                      aria-hidden="true"
-                    >
-                      {#if option.value === 'tracks'}
-                        <path
-                          d="M4 24 C12 16, 20 12, 28 14 S44 24, 52 18 S64 10, 68 8"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                        />
-                      {:else}
-                        <path
-                          d="M4 24 Q36 2 68 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                        />
-                        <path
-                          d="M4 28 Q36 8 68 28"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                        />
-                      {/if}
-                    </svg>
-                  {/snippet}
-                </AppearanceTile>
-              {/each}
+          {#if showTracksSection}
+            <div class="space-y-2">
+              <p class="text-xs font-medium">Tracks</p>
+              <div class="grid grid-cols-2 gap-2">
+                {#each ROUTE_DISPLAY_OPTIONS as option (option.value)}
+                  <AppearanceTile
+                    selected={mapPreferences.routeDisplay === option.value}
+                    onclick={() => (mapPreferences.routeDisplay = option.value)}
+                    label={option.label}
+                  >
+                    {#snippet illustration()}
+                      <svg
+                        viewBox="0 0 72 32"
+                        class="h-full w-full text-primary"
+                        aria-hidden="true"
+                      >
+                        {#if option.value === 'tracks'}
+                          <path
+                            d="M4 24 C12 16, 20 12, 28 14 S44 24, 52 18 S64 10, 68 8"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                          />
+                        {:else}
+                          <path
+                            d="M4 24 Q36 2 68 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                          />
+                          <path
+                            d="M4 28 Q36 8 68 28"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                          />
+                        {/if}
+                      </svg>
+                    {/snippet}
+                  </AppearanceTile>
+                {/each}
+              </div>
             </div>
-          </div>
+          {/if}
         </section>
 
         <section class="space-y-3 px-4 py-4">

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -17,6 +17,7 @@
     BASEMAP_OPTIONS,
     OPENAIP_GROUP_OPTIONS,
     PROJECTION_OPTIONS,
+    ROUTE_DISPLAY_OPTIONS,
   } from './map-appearance-options';
 
   import aptSymbol from '$lib/assets/openaip/symbols/apt-medium.svg';
@@ -753,6 +754,52 @@
                           stroke-width="2"
                           stroke-linecap="round"
                           class="text-red-500"
+                        />
+                      {/if}
+                    </svg>
+                  {/snippet}
+                </AppearanceTile>
+              {/each}
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <p class="text-xs font-medium">Tracks</p>
+            <div class="grid grid-cols-2 gap-2">
+              {#each ROUTE_DISPLAY_OPTIONS as option (option.value)}
+                <AppearanceTile
+                  selected={mapPreferences.routeDisplay === option.value}
+                  onclick={() => (mapPreferences.routeDisplay = option.value)}
+                  label={option.label}
+                >
+                  {#snippet illustration()}
+                    <svg
+                      viewBox="0 0 72 32"
+                      class="h-full w-full text-primary"
+                      aria-hidden="true"
+                    >
+                      {#if option.value === 'tracks'}
+                        <path
+                          d="M4 24 C12 16, 20 12, 28 14 S44 24, 52 18 S64 10, 68 8"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                        />
+                      {:else}
+                        <path
+                          d="M4 24 Q36 2 68 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                        />
+                        <path
+                          d="M4 28 Q36 8 68 28"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
                         />
                       {/if}
                     </svg>

--- a/src/lib/components/map/map-appearance-options.ts
+++ b/src/lib/components/map/map-appearance-options.ts
@@ -7,6 +7,7 @@ import {
   type ArcThicknessMode,
   type ArcThicknessScale,
   type MapProjection,
+  type RouteDisplayMode,
 } from '$lib/map/map-preferences.svelte';
 import {
   OPENAIP_OVERLAY_GROUPS,
@@ -50,6 +51,12 @@ export const ARC_SCALE_OPTIONS: Array<AppearanceOption<ArcThicknessScale>> = [
   { value: 'normal', label: 'Normal' },
   { value: 'thick', label: 'Thick' },
 ];
+
+export const ROUTE_DISPLAY_OPTIONS: Array<AppearanceOption<RouteDisplayMode>> =
+  [
+    { value: 'tracks', label: 'Flight tracks' },
+    { value: 'points', label: 'Point to point' },
+  ];
 
 export const AIRPORT_DETAIL_OPTIONS: Array<
   AppearanceOption<AirportOverlayDetail>

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -12,6 +12,7 @@ export type AirportCircleRadiusMode = 'byFrequency' | 'uniform';
 export type ArcColorMode = 'default' | 'byFrequency';
 export type ArcThicknessMode = 'uniform' | 'byFrequency';
 export type ArcThicknessScale = 'thin' | 'normal' | 'thick';
+export type RouteDisplayMode = 'points' | 'tracks';
 export type AirportOverlayDetail = 'standard' | 'detailed';
 export type MapProjection = 'mercator' | 'globe';
 
@@ -25,6 +26,7 @@ export type MapPreferences = {
   arcColor: ArcColorMode;
   arcThickness: ArcThicknessMode;
   arcThicknessScale: ArcThicknessScale;
+  routeDisplay: RouteDisplayMode;
   airportOverlayDetail: AirportOverlayDetail;
   openAipEnabled: boolean;
   openAipGroups: OpenAipOverlayGroup[];
@@ -53,6 +55,7 @@ const ARC_THICKNESS_SCALES: readonly ArcThicknessScale[] = [
   'normal',
   'thick',
 ];
+const ROUTE_DISPLAY_MODES: readonly RouteDisplayMode[] = ['points', 'tracks'];
 const AIRPORT_OVERLAY_DETAIL_MODES: readonly AirportOverlayDetail[] = [
   'standard',
   'detailed',
@@ -69,6 +72,7 @@ export const MAP_PREFERENCE_DEFAULTS: MapPreferences = {
   arcColor: 'default',
   arcThickness: 'uniform',
   arcThicknessScale: 'normal',
+  routeDisplay: 'tracks',
   airportOverlayDetail: 'detailed',
   openAipEnabled: false,
   openAipGroups: [...OPENAIP_DEFAULT_ENABLED_GROUPS],
@@ -140,6 +144,12 @@ const sanitize = (raw: unknown): MapPreferences => {
     result.arcThicknessScale = input.arcThicknessScale as ArcThicknessScale;
   }
   if (
+    typeof input.routeDisplay === 'string' &&
+    ROUTE_DISPLAY_MODES.includes(input.routeDisplay as RouteDisplayMode)
+  ) {
+    result.routeDisplay = input.routeDisplay as RouteDisplayMode;
+  }
+  if (
     typeof input.airportOverlayDetail === 'string' &&
     AIRPORT_OVERLAY_DETAIL_MODES.includes(
       input.airportOverlayDetail as AirportOverlayDetail,
@@ -199,6 +209,7 @@ export const initMapPreferences = () => {
   mapPreferences.arcColor = hydrated.arcColor;
   mapPreferences.arcThickness = hydrated.arcThickness;
   mapPreferences.arcThicknessScale = hydrated.arcThicknessScale;
+  mapPreferences.routeDisplay = hydrated.routeDisplay;
   mapPreferences.airportOverlayDetail = hydrated.airportOverlayDetail;
   mapPreferences.openAipEnabled = hydrated.openAipEnabled;
   mapPreferences.openAipGroups = hydrated.openAipGroups;
@@ -215,6 +226,7 @@ export const initMapPreferences = () => {
         arcColor: mapPreferences.arcColor,
         arcThickness: mapPreferences.arcThickness,
         arcThicknessScale: mapPreferences.arcThicknessScale,
+        routeDisplay: mapPreferences.routeDisplay,
         airportOverlayDetail: mapPreferences.airportOverlayDetail,
         openAipEnabled: mapPreferences.openAipEnabled,
         openAipGroups: [...mapPreferences.openAipGroups],
@@ -239,6 +251,7 @@ export const resetMapPreferences = () => {
   mapPreferences.arcColor = MAP_PREFERENCE_DEFAULTS.arcColor;
   mapPreferences.arcThickness = MAP_PREFERENCE_DEFAULTS.arcThickness;
   mapPreferences.arcThicknessScale = MAP_PREFERENCE_DEFAULTS.arcThicknessScale;
+  mapPreferences.routeDisplay = MAP_PREFERENCE_DEFAULTS.routeDisplay;
   mapPreferences.airportOverlayDetail =
     MAP_PREFERENCE_DEFAULTS.airportOverlayDetail;
   mapPreferences.openAipEnabled = MAP_PREFERENCE_DEFAULTS.openAipEnabled;


### PR DESCRIPTION
Closes #645.
Adds a map preferences option to display all flights in point-to-point mode rather than flight tracks. Default is to display flight tracks. If there are no flight tracks (either none in the database or flight tracks were not included in the share) then the option is hidden.

<img width="324" height="496" alt="image" src="https://github.com/user-attachments/assets/5d5d4fad-f775-4f5f-a0ba-884f8b7623be" />

I'm really not familiar with svelte, so I definitely appreciate any feedback!

Testing:
- While there are no flights with a flight track, confirm the option doesn't appear
- Add a flight with a track, confirm the option now appears
- Confirm toggling the option appropriately draws the flight tracks vs point to point
- Confirm that the option appears appropriately in shares, based on whether tracks were included

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add flight track route display preference to map appearance controls
> - Adds a `RouteDisplayMode` type (`'tracks'` | `'points'`) to `mapPreferences`, defaulting to `'tracks'`, with persistence to and restoration from localStorage.
> - Adds a Tracks section to [`MapAppearanceControl.svelte`](https://github.com/johanohly/AirTrail/pull/655/files#diff-cc78f2f9305525c510df3c0b9e1c77aa12b84e70843390543e84b495d0e2290b) letting users toggle between 'Flight tracks' and 'Point to point' route rendering; the section is only shown when flight tracks are present.
> - When `routeDisplay` is not `'tracks'`, [`AirportsArcsLayer.svelte`](https://github.com/johanohly/AirTrail/pull/655/files#diff-4afe79e0339cf3be73d747515004ab3b4e390bdf9b120d52b3d59249167946b4) receives an empty track list, disabling track path rendering.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 455383a. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->