### PR TITLE
fix: improve antimeridian flight track rendering and map interactions

### DIFF
--- a/src/lib/components/airport-details/AirportFlightsCard.svelte
+++ b/src/lib/components/airport-details/AirportFlightsCard.svelte
@@ -3,6 +3,7 @@
 
   import { AirlineIcon } from '$lib/components/display';
   import { Button } from '$lib/components/ui/button';
+  import { mapDetailsState } from '$lib/state.svelte';
   import type { FlightData } from '$lib/utils';
   import { formatAsFlightDate } from '$lib/utils/datetime';
 
@@ -99,6 +100,13 @@
               {flightNumber}
             </span>
           {/if}
+          <span
+            class="size-2 shrink-0 rounded-full bg-emerald-500 transition-opacity"
+            class:opacity-100={mapDetailsState.hoveredFlightTrackId ===
+              flight.id}
+            class:opacity-0={mapDetailsState.hoveredFlightTrackId !== flight.id}
+            aria-hidden="true"
+          ></span>
         </div>
         {#if subtitle}
           <p class="mt-0.5 truncate text-xs text-muted-foreground">

--- a/src/lib/components/map-details/RouteDetailsBody.svelte
+++ b/src/lib/components/map-details/RouteDetailsBody.svelte
@@ -4,6 +4,7 @@
 
   import { AirlineIcon, RouteArrow } from '$lib/components/display';
   import { Button } from '$lib/components/ui/button';
+  import { mapDetailsState } from '$lib/state.svelte';
   import type { FlightData } from '$lib/utils';
   import { formatAsFlightDate } from '$lib/utils/datetime';
   import { distanceUnitLabel } from '$lib/utils/preferences';
@@ -74,6 +75,13 @@
               {flightNumber}
             </span>
           {/if}
+          <span
+            class="size-2 shrink-0 rounded-full bg-emerald-500 transition-opacity"
+            class:opacity-100={mapDetailsState.hoveredFlightTrackId ===
+              flight.id}
+            class:opacity-0={mapDetailsState.hoveredFlightTrackId !== flight.id}
+            aria-hidden="true"
+          ></span>
         </div>
         {#if subtitle}
           <p class="mt-0.5 truncate text-xs text-muted-foreground">

--- a/src/lib/components/map/AirportPopup.svelte
+++ b/src/lib/components/map/AirportPopup.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
   import NumberFlow from '@number-flow/svelte';
 
-  import { AirlineIcon, RouteArrow } from '$lib/components/display';
-  import { pluralize } from '$lib/utils';
-  import { formatAsFlightDate } from '$lib/utils/datetime';
+  import { pluralize, type prepareVisitedAirports } from '$lib/utils';
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let { data, clickable }: { data: any; clickable: boolean } = $props();
+  import PopupFlightList from './PopupFlightList.svelte';
 
-  const recentFlights = $derived(
-    [...data.flights]
-      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
-      .slice(0, 5),
-  );
+  type VisitedAirport = ReturnType<typeof prepareVisitedAirports>[number];
+
+  let { data, clickable }: { data: VisitedAirport; clickable: boolean } =
+    $props();
 </script>
 
 <div class="w-80 max-w-[calc(100vw-2rem)]">
@@ -58,64 +54,7 @@
     </div>
   </div>
 
-  <div class="border-t border-border/50 px-4 pt-2.5 pb-3">
-    <div class="mb-1 flex items-center gap-2">
-      <h3 class="text-xs font-medium text-muted-foreground">Flights</h3>
-      <span class="text-xs text-muted-foreground tabular-nums">
-        {data.flights.length}
-      </span>
-    </div>
-    <div class="divide-y divide-border/50">
-      {#each recentFlights as flight}
-        {@const [fromCode, toCode] = flight.route.split(' - ')}
-        <div
-          class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 py-2"
-        >
-          <div class="flex w-7 shrink-0 justify-center">
-            <AirlineIcon
-              airline={flight.airline || null}
-              size={22}
-              fallback="plane"
-            />
-          </div>
-          <div class="min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm leading-4 font-semibold tracking-tight">
-                {fromCode}
-              </span>
-              <RouteArrow class="size-3.5 fill-muted-foreground/70" />
-              <span class="text-sm leading-4 font-semibold tracking-tight">
-                {toCode}
-              </span>
-            </div>
-            {#if flight.airline}
-              <p class="mt-0.5 truncate text-xs text-muted-foreground">
-                {flight.airline.name}
-              </p>
-            {/if}
-          </div>
-          <div
-            class="shrink-0 text-right text-xs font-medium text-muted-foreground tabular-nums"
-          >
-            {flight.date
-              ? formatAsFlightDate(
-                  flight.date,
-                  flight.datePrecision ?? 'day',
-                  true,
-                  true,
-                )
-              : 'Unknown date'}
-          </div>
-        </div>
-      {/each}
-    </div>
-
-    {#if data.flights.length > 5}
-      <p class="mt-1.5 text-xs text-muted-foreground">
-        +{data.flights.length - 5} more
-      </p>
-    {/if}
-  </div>
+  <PopupFlightList flights={data.flights} />
 
   {#if clickable}
     <div class="border-t border-border/50 px-4 py-2">

--- a/src/lib/components/map/AirportPopup.svelte
+++ b/src/lib/components/map/AirportPopup.svelte
@@ -1,81 +1,127 @@
 <script lang="ts">
   import NumberFlow from '@number-flow/svelte';
 
+  import { AirlineIcon, RouteArrow } from '$lib/components/display';
   import { pluralize } from '$lib/utils';
   import { formatAsFlightDate } from '$lib/utils/datetime';
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let { data, clickable }: { data: any; clickable: boolean } = $props();
+
+  const recentFlights = $derived(
+    [...data.flights]
+      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
+      .slice(0, 5),
+  );
 </script>
 
-<div class="min-w-[18rem]">
-  <div class="flex flex-col px-3 pt-3">
-    <h3 class="font-thin text-muted-foreground">Airport</h3>
-    <h4 class="flex items-center text-lg">
-      <img
-        src="https://flagcdn.com/{data.country.toLowerCase()}.svg"
-        alt={data.country}
-        class="w-8 h-5 mr-2"
-      />
-      {data.iata ?? data.icao} - {data.name}
-    </h4>
-  </div>
-  <div class="h-px bg-muted my-3" />
-  <div class="grid grid-cols-[repeat(3,1fr)] px-3">
-    <h4 class="font-semibold">
-      <NumberFlow value={data.departures} />
-      <span class="font-thin text-muted-foreground"
-        >{pluralize(data.departures, 'departure')}</span
-      >
-    </h4>
-    <h4 class="font-semibold">
-      <NumberFlow value={data.arrivals} />
-      <span class="font-thin text-muted-foreground"
-        >{pluralize(data.arrivals, 'arrival')}</span
-      >
-    </h4>
-    <h4 class="font-semibold">
-      <NumberFlow value={data.airlines.length} />
-      <span class="font-thin text-muted-foreground"
-        >{pluralize(data.airlines.length, 'airline')}</span
-      >
-    </h4>
-  </div>
-  <div class="h-px bg-muted my-3" />
-  <div class="px-3 pb-3">
-    <div class="grid grid-cols-[repeat(3,1fr)]">
-      <h3 class="font-semibold">Route</h3>
-      <h3 class="font-semibold">Date</h3>
-      <h3 class="font-semibold">Airline</h3>
-    </div>
-    {#each data.flights
-      .slice(0, 5)
-      .sort( (a, b) => (a.date && b.date ? b.date.getTime() - a.date.getTime() : 0), ) as flight}
-      <div class="grid grid-cols-[repeat(3,1fr)]">
-        <h4 class="font-thin">{flight.route}</h4>
-        <h4 class="font-thin">
-          {flight.date
-            ? formatAsFlightDate(
-                flight.date,
-                flight.datePrecision ?? 'day',
-                true,
-                true,
-              )
-            : ''}
-        </h4>
-        <h4 class="font-thin">{flight.airline.name}</h4>
+<div class="w-80 max-w-[calc(100vw-2rem)]">
+  <div class="px-4 pt-3 pb-2.5">
+    <h3 class="text-xs font-medium text-muted-foreground">Airport</h3>
+    <div class="mt-2">
+      <div class="flex items-center gap-2 py-1">
+        <img
+          src="https://flagcdn.com/{data.country.toLowerCase()}.svg"
+          alt={data.country}
+          class="h-4 w-6 shrink-0 rounded-sm object-cover ring-1 ring-black/10 dark:ring-white/15"
+        />
+        <span class="text-xl leading-none font-semibold tracking-tight">
+          {data.iata ?? data.icao}
+        </span>
+        <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+          {data.name}
+        </span>
       </div>
-    {/each}
+
+      <div
+        class="grid grid-cols-[1fr_auto_1fr] items-center gap-3 py-1.5 text-[11px] text-muted-foreground tabular-nums"
+      >
+        <div class="h-px bg-border/60"></div>
+        <div class="flex items-center gap-1.5 whitespace-nowrap">
+          <span>
+            <NumberFlow value={data.departures} />
+            {pluralize(data.departures, 'departure')}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
+            <NumberFlow value={data.arrivals} />
+            {pluralize(data.arrivals, 'arrival')}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
+            <NumberFlow value={data.airlines.length} />
+            {pluralize(data.airlines.length, 'airline')}
+          </span>
+        </div>
+        <div class="h-px bg-border/60"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="border-t border-border/50 px-4 pt-2.5 pb-3">
+    <div class="mb-1 flex items-center gap-2">
+      <h3 class="text-xs font-medium text-muted-foreground">Flights</h3>
+      <span class="text-xs text-muted-foreground tabular-nums">
+        {data.flights.length}
+      </span>
+    </div>
+    <div class="divide-y divide-border/50">
+      {#each recentFlights as flight}
+        {@const [fromCode, toCode] = flight.route.split(' - ')}
+        <div
+          class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 py-2"
+        >
+          <div class="flex w-7 shrink-0 justify-center">
+            <AirlineIcon
+              airline={flight.airline || null}
+              size={22}
+              fallback="plane"
+            />
+          </div>
+          <div class="min-w-0">
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm leading-4 font-semibold tracking-tight">
+                {fromCode}
+              </span>
+              <RouteArrow class="size-3.5 fill-muted-foreground/70" />
+              <span class="text-sm leading-4 font-semibold tracking-tight">
+                {toCode}
+              </span>
+            </div>
+            {#if flight.airline}
+              <p class="mt-0.5 truncate text-xs text-muted-foreground">
+                {flight.airline.name}
+              </p>
+            {/if}
+          </div>
+          <div
+            class="shrink-0 text-right text-xs font-medium text-muted-foreground tabular-nums"
+          >
+            {flight.date
+              ? formatAsFlightDate(
+                  flight.date,
+                  flight.datePrecision ?? 'day',
+                  true,
+                  true,
+                )
+              : 'Unknown date'}
+          </div>
+        </div>
+      {/each}
+    </div>
+
     {#if data.flights.length > 5}
-      <h4 class="font-thin text-muted-foreground">
+      <p class="mt-1.5 text-xs text-muted-foreground">
         +{data.flights.length - 5} more
-      </h4>
+      </p>
     {/if}
   </div>
+
   {#if clickable}
-    <div class="h-px bg-muted my-2" />
-    <div class="px-3 pb-2">
-      <p class="text-xs text-muted-foreground text-center">Click for details</p>
+    <div class="border-t border-border/50 px-4 py-2">
+      <p class="text-center text-xs text-muted-foreground">
+        Click for airport details
+      </p>
     </div>
   {/if}
 </div>

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -55,6 +55,7 @@
   const TO_COLOR = [139, 92, 246] as const; // TW violet-500
   const HIGH_FREQUENCY_COLOR = [239, 68, 68] as const; // TW red-500
   const HOVER_COLOR = [16, 185, 129];
+  const SECONDARY_TRACK_HOVER_COLOR = [14, 165, 233]; // TW sky-500
   const FUTURE_COLOR = [102, 217, 239, 100];
 
   const MERCATOR_ROUTE_PARAMETERS = {
@@ -213,7 +214,8 @@
 
   let id = getId('deckgl-layer');
   let hoveredAirport: VisitedAirport | undefined = $state.raw(undefined);
-  let hoveredArc: FlightArc | undefined = $state.raw(undefined);
+  let hoveredArc: FlightArc | FlightTrackPath | undefined =
+    $state.raw(undefined);
   const clickable = $derived(tempFilters !== undefined);
 
   const context = getMapContext();
@@ -235,6 +237,7 @@
     event?: DeckPointerEvent,
   ) => {
     if (!isTouchDevice()) {
+      mapDetailsState.hoveredFlightTrackId = null;
       hoveredAirport = e.object ?? undefined;
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
@@ -251,6 +254,7 @@
     event?: DeckPointerEvent,
   ) => {
     if (!isTouchDevice()) {
+      mapDetailsState.hoveredFlightTrackId = null;
       hoveredArc = e.object ?? undefined;
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
@@ -267,6 +271,7 @@
     event?: DeckPointerEvent,
   ) => {
     if (!isTouchDevice()) {
+      mapDetailsState.hoveredFlightTrackId = e.object?.flightId ?? null;
       hoveredArc = e.object ?? undefined;
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
@@ -316,6 +321,7 @@
   const isGlobe = $derived(mapPreferences.projection === 'globe');
 
   onDestroy(() => {
+    mapDetailsState.hoveredFlightTrackId = null;
     if (loaded && layer) {
       map.removeControl(layer);
     }
@@ -612,11 +618,34 @@
     greatCircle: true,
   });
 
-  type TrackInteractionState = 'active' | 'highlighted' | 170 | 200;
+  type TrackInteractionState =
+    | 'active'
+    | 'highlighted'
+    | 'secondary'
+    | 170
+    | 200;
+
+  const getHoveredTrackFlightId = () =>
+    hoveredArc && 'flightId' in hoveredArc ? hoveredArc.flightId : undefined;
+
+  const arcsShareRoute = (left: FlightArc, right: FlightArc) =>
+    getRouteKey(left.from.id, left.to.id) ===
+    getRouteKey(right.from.id, right.to.id);
 
   const getTrackInteractionState = <T extends FlightArc>(
     d: T,
   ): TrackInteractionState => {
+    const hoveredTrackFlightId = getHoveredTrackFlightId();
+    if (hoveredTrackFlightId !== undefined) {
+      if (
+        'flightId' in d &&
+        (d as FlightTrackPath).flightId === hoveredTrackFlightId
+      ) {
+        return 'highlighted';
+      }
+      return hoveredArc && arcsShareRoute(d, hoveredArc) ? 'secondary' : 200;
+    }
+
     if (
       (hoveredArc?.from === d.from && hoveredArc?.to === d.to) ||
       routeMatchesArc(d, selectedRoute)
@@ -645,6 +674,7 @@
     return (d: T): Color => {
       const state = getTrackInteractionState(d);
       if (state === 'highlighted') return HOVER_COLOR;
+      if (state === 'secondary') return SECONDARY_TRACK_HOVER_COLOR;
       if (typeof state === 'number') return INACTIVE_COLOR(state);
       return getBaseColor?.(d) ?? baseArcColor(d);
     };

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -665,10 +665,10 @@
     (run: FlightTrackRun): Color => {
       const state = getTrackInteractionState(run);
       return [
-        24,
-        24,
-        27,
-        typeof state === 'number' ? Math.round(state * 0.3) : 190,
+        0,
+        0,
+        0,
+        typeof state === 'number' ? Math.round(state * 0.3) : 176,
       ];
     };
 
@@ -680,7 +680,7 @@
       return isDarkMode ? [9, 9, 11, alpha] : [250, 250, 250, alpha];
     };
 
-  const pathWidthUpdateTriggers = $derived([
+  const flightTrackWidthUpdateTriggers = $derived([
     mapPreferences.arcThickness,
     mapPreferences.arcThicknessScale,
     selectedRoute,
@@ -702,7 +702,7 @@
         getAltitudeColor: getAltitudeTrackColor(),
         getGroundCasingColor: getGroundCasingColor(),
         getEstimatedUnderlayColor: getEstimatedUnderlayColor(),
-        widthUpdateTriggers: pathWidthUpdateTriggers,
+        widthUpdateTriggers: flightTrackWidthUpdateTriggers,
         standardColorUpdateTriggers: [
           hoveredArc,
           hoveredAirport,

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -672,6 +672,14 @@
       ];
     };
 
+  const getGroundCasingColor =
+    () =>
+    (run: FlightTrackRun): Color => {
+      const state = getTrackInteractionState(run);
+      const alpha = typeof state === 'number' ? Math.round(state * 0.75) : 220;
+      return isDarkMode ? [9, 9, 11, alpha] : [250, 250, 250, alpha];
+    };
+
   const pathWidthUpdateTriggers = $derived([
     mapPreferences.arcThickness,
     mapPreferences.arcThicknessScale,
@@ -692,6 +700,7 @@
         getWidth: getVisibleArcWidth,
         getStandardColor: getTrackColor(),
         getAltitudeColor: getAltitudeTrackColor(),
+        getGroundCasingColor: getGroundCasingColor(),
         getEstimatedUnderlayColor: getEstimatedUnderlayColor(),
         widthUpdateTriggers: pathWidthUpdateTriggers,
         standardColorUpdateTriggers: [

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -3,6 +3,7 @@
   import { ArcLayer, ScatterplotLayer } from '@deck.gl/layers';
   import { MapboxOverlay } from '@deck.gl/mapbox';
   import { isTouchDevice } from '@melt-ui/svelte/internal/helpers';
+  import { mode } from 'mode-watcher';
   import { onDestroy } from 'svelte';
   import {
     Box,
@@ -84,6 +85,7 @@
     depthWriteEnabled: false,
   } as const;
   const globeOcclusion = new GlobeOcclusionExtension();
+  const isDarkMode = $derived(mode.current === 'dark');
 
   const interpolateColor = (
     from: readonly [number, number, number],
@@ -654,6 +656,7 @@
         altitudeFeet: run.altitudeFeet,
         ground: run.ground,
         estimated: run.estimated,
+        darkMode: isDarkMode,
       }),
     );
 
@@ -704,6 +707,7 @@
           hoveredAirport,
           selectedAirportId,
           selectedRoute,
+          isDarkMode,
         ],
         onHover: handleTrackHover,
         onClick: handleTrackClick,

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -3,7 +3,6 @@
   import { ArcLayer, ScatterplotLayer } from '@deck.gl/layers';
   import { MapboxOverlay } from '@deck.gl/mapbox';
   import { isTouchDevice } from '@melt-ui/svelte/internal/helpers';
-  import type { Popup as MaplibrePopup } from 'maplibre-gl';
   import { mode } from 'mode-watcher';
   import { onDestroy } from 'svelte';
   import {
@@ -31,6 +30,12 @@
     type FlightTrackPath,
   } from '$lib/map/flight-layer-data';
   import {
+    applyFlightTrackInteractionColor,
+    getEstimatedTrackUnderlayColor,
+    getGroundTrackCasingColor,
+    resolveRouteInteraction,
+  } from '$lib/map/flight-track-interaction';
+  import {
     buildFlightTrackLayers,
     prepareFlightTrackLayerData,
   } from '$lib/map/flight-track-layers';
@@ -39,6 +44,12 @@
     type FlightTrackRun,
   } from '$lib/map/flight-track-style';
   import { GlobeOcclusionExtension } from '$lib/map/globe-occlusion';
+  import {
+    createPopupPositionController,
+    getDeckPointerLngLat,
+    getDeckPointerPixel,
+    type DeckPointerEvent,
+  } from '$lib/map/map-popup-position';
   import { mapPreferences } from '$lib/map/map-preferences.svelte';
   import {
     closeMapDetails,
@@ -55,9 +66,7 @@
   const FROM_COLOR = [59, 130, 246] as const; // Also the primary color
   const TO_COLOR = [139, 92, 246] as const; // TW violet-500
   const HIGH_FREQUENCY_COLOR = [239, 68, 68] as const; // TW red-500
-  const HOVER_COLOR = [16, 185, 129];
-  const SECONDARY_TRACK_HOVER_COLOR = [14, 165, 233]; // TW sky-500
-  const FUTURE_COLOR = [102, 217, 239, 100];
+  const FUTURE_COLOR: Color = [102, 217, 239, 100];
 
   const MERCATOR_ROUTE_PARAMETERS = {
     cullMode: 'none',
@@ -160,85 +169,6 @@
     ),
   );
 
-  const getPointerPixel = (
-    e: PickingInfo,
-    event?: DeckPointerEvent,
-  ): { x: number; y: number } | undefined =>
-    event?.srcEvent?.point ??
-    event?.offsetCenter ??
-    (e.pixel ? { x: e.pixel[0], y: e.pixel[1] } : undefined) ??
-    (Number.isFinite(e.x) && Number.isFinite(e.y)
-      ? { x: e.x, y: e.y }
-      : undefined);
-
-  // deck's picking coordinate is unprojected through deck's own globe
-  // viewport, which drifts from MapLibre during the globe<->mercator
-  // transition zooms — anchor popups via the raw pointer position instead.
-  const getPointerLngLat = (
-    e: PickingInfo,
-    event?: DeckPointerEvent,
-  ): [number, number] | undefined => {
-    const point = getPointerPixel(e, event);
-
-    if (event?.srcEvent?.lngLat) {
-      return [event.srcEvent.lngLat.lng, event.srcEvent.lngLat.lat];
-    }
-
-    if (map && point) {
-      const lngLat = map.unproject([point.x, point.y]);
-      return [lngLat.lng, lngLat.lat];
-    }
-
-    const srcEvent = event?.srcEvent;
-    if (
-      map &&
-      typeof srcEvent?.clientX === 'number' &&
-      typeof srcEvent.clientY === 'number'
-    ) {
-      const rect = map.getContainer().getBoundingClientRect();
-      const lngLat = map.unproject([
-        srcEvent.clientX - rect.left,
-        srcEvent.clientY - rect.top,
-      ]);
-      return [lngLat.lng, lngLat.lat];
-    }
-
-    return e.coordinate?.length
-      ? ([e.coordinate[0], e.coordinate[1]] as [number, number])
-      : undefined;
-  };
-
-  type DeckPointerEvent = {
-    offsetCenter?: { x: number; y: number };
-    srcEvent?: Event & {
-      point?: { x: number; y: number };
-      lngLat?: { lng: number; lat: number };
-      clientX?: number;
-      clientY?: number;
-    };
-  };
-
-  const POPUP_OFFSET = 20;
-  const POPUP_FALLBACK_SIZE = { width: 320, height: 280 };
-  let popupInstance: MaplibrePopup | undefined;
-
-  // MapLibre re-reads options.anchor on every popup position update, so
-  // mutating it flips the popup at screen edges without recreating it.
-  const updatePopupAnchor = (point: { x: number; y: number } | undefined) => {
-    if (!popupInstance || !map || !point) return;
-    const container = map.getContainer();
-    const el = popupInstance.getElement();
-    const width = el?.offsetWidth || POPUP_FALLBACK_SIZE.width;
-    const height = el?.offsetHeight || POPUP_FALLBACK_SIZE.height;
-    const vertical =
-      point.y + POPUP_OFFSET + height > container.clientHeight
-        ? 'bottom'
-        : 'top';
-    const horizontal =
-      point.x + POPUP_OFFSET + width > container.clientWidth ? 'right' : 'left';
-    popupInstance.options.anchor = `${vertical}-${horizontal}`;
-  };
-
   let id = getId('deckgl-layer');
   let hoveredAirport: VisitedAirport | undefined = $state.raw(undefined);
   let hoveredArc: FlightArc | FlightTrackPath | undefined =
@@ -247,6 +177,7 @@
 
   const context = getMapContext();
   const { map, loaded } = $derived(context);
+  const popupPosition = createPopupPositionController(() => map);
 
   const { layer: layerId, layerEvent } = updatedDeckGlContext();
   layerId.value = id;
@@ -266,11 +197,11 @@
     if (!isTouchDevice()) {
       mapDetailsState.hoveredFlightTrackId = null;
       hoveredAirport = e.object ?? undefined;
-      updatePopupAnchor(getPointerPixel(e, event));
+      popupPosition.update(getDeckPointerPixel(e, event));
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
         ...e,
-        coordinate: getPointerLngLat(e, event),
+        coordinate: getDeckPointerLngLat(e, event, map),
         layerType: 'deckgl',
         type,
       };
@@ -284,11 +215,11 @@
     if (!isTouchDevice()) {
       mapDetailsState.hoveredFlightTrackId = null;
       hoveredArc = e.object ?? undefined;
-      updatePopupAnchor(getPointerPixel(e, event));
+      popupPosition.update(getDeckPointerPixel(e, event));
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
         ...e,
-        coordinate: getPointerLngLat(e, event),
+        coordinate: getDeckPointerLngLat(e, event, map),
         layerType: 'deckgl',
         type,
       };
@@ -302,11 +233,11 @@
     if (!isTouchDevice()) {
       mapDetailsState.hoveredFlightTrackId = e.object?.flightId ?? null;
       hoveredArc = e.object ?? undefined;
-      updatePopupAnchor(getPointerPixel(e, event));
+      popupPosition.update(getDeckPointerPixel(e, event));
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
         ...e,
-        coordinate: getPointerLngLat(e, event),
+        coordinate: getDeckPointerLngLat(e, event, map),
         layerType: 'deckgl',
         type,
       };
@@ -476,33 +407,11 @@
   const getArcColor = (point: 'source' | 'target') => {
     const baseArcColor = getBaseArcColor(point);
 
-    return (d: (typeof flightArcs)[number]) => {
-      if (hoveredArc?.from === d.from && hoveredArc?.to === d.to) {
-        return HOVER_COLOR;
-      } else if (routeMatchesArc(d, selectedRoute)) {
-        return HOVER_COLOR;
-      } else if (hoveredArc) {
-        return INACTIVE_COLOR(200);
-      } else if (
-        hoveredAirport?.id === d.from.id ||
-        hoveredAirport?.id === d.to.id
-      ) {
-        return baseArcColor(d);
-      } else if (hoveredAirport) {
-        return INACTIVE_COLOR(200);
-      } else if (
-        selectedAirportId &&
-        (d.from.id === selectedAirportId || d.to.id === selectedAirportId)
-      ) {
-        return baseArcColor(d);
-      } else if (selectedAirportId) {
-        return INACTIVE_COLOR(170);
-      } else if (selectedRoute) {
-        return INACTIVE_COLOR(170);
-      } else {
-        return baseArcColor(d);
-      }
-    };
+    return (arc: (typeof flightArcs)[number]) =>
+      applyFlightTrackInteractionColor(
+        getRouteInteraction(arc),
+        baseArcColor(arc),
+      );
   };
 
   const AIRPORT_CIRCLE_SIZE = {
@@ -648,53 +557,13 @@
     greatCircle: true,
   });
 
-  type TrackInteractionState =
-    | 'active'
-    | 'highlighted'
-    | 'secondary'
-    | 170
-    | 200;
-
-  const getHoveredTrackFlightId = () =>
-    hoveredArc && 'flightId' in hoveredArc ? hoveredArc.flightId : undefined;
-
-  const arcsShareRoute = (left: FlightArc, right: FlightArc) =>
-    getRouteKey(left.from.id, left.to.id) ===
-    getRouteKey(right.from.id, right.to.id);
-
-  const getTrackInteractionState = <T extends FlightArc>(
-    d: T,
-  ): TrackInteractionState => {
-    const hoveredTrackFlightId = getHoveredTrackFlightId();
-    if (hoveredTrackFlightId !== undefined) {
-      if (
-        'flightId' in d &&
-        (d as FlightTrackPath).flightId === hoveredTrackFlightId
-      ) {
-        return 'highlighted';
-      }
-      return hoveredArc && arcsShareRoute(d, hoveredArc) ? 'secondary' : 200;
-    }
-
-    if (
-      (hoveredArc?.from === d.from && hoveredArc?.to === d.to) ||
-      routeMatchesArc(d, selectedRoute)
-    ) {
-      return 'highlighted';
-    }
-    if (hoveredArc) return 200;
-    if (hoveredAirport) {
-      return hoveredAirport.id === d.from.id || hoveredAirport.id === d.to.id
-        ? 'active'
-        : 200;
-    }
-    if (selectedAirportId) {
-      return selectedAirportId === d.from.id || selectedAirportId === d.to.id
-        ? 'active'
-        : 170;
-    }
-    return selectedRoute ? 170 : 'active';
-  };
+  const getRouteInteraction = (arc: FlightArc) =>
+    resolveRouteInteraction(arc, {
+      hoveredArc,
+      hoveredAirportId: hoveredAirport?.id,
+      selectedAirportId,
+      selectedRoute,
+    });
 
   const getTrackColor = <T extends FlightArc>(
     getBaseColor?: (data: T) => Color,
@@ -702,11 +571,10 @@
     const baseArcColor = getBaseArcColor('source');
 
     return (d: T): Color => {
-      const state = getTrackInteractionState(d);
-      if (state === 'highlighted') return HOVER_COLOR;
-      if (state === 'secondary') return SECONDARY_TRACK_HOVER_COLOR;
-      if (typeof state === 'number') return INACTIVE_COLOR(state);
-      return getBaseColor?.(d) ?? baseArcColor(d);
+      return applyFlightTrackInteractionColor(
+        getRouteInteraction(d),
+        getBaseColor?.(d) ?? baseArcColor(d),
+      );
     };
   };
 
@@ -723,21 +591,13 @@
   const getEstimatedUnderlayColor =
     () =>
     (run: FlightTrackRun): Color => {
-      const state = getTrackInteractionState(run);
-      return [
-        0,
-        0,
-        0,
-        typeof state === 'number' ? Math.round(state * 0.3) : 176,
-      ];
+      return getEstimatedTrackUnderlayColor(getRouteInteraction(run));
     };
 
   const getGroundCasingColor =
     () =>
     (run: FlightTrackRun): Color => {
-      const state = getTrackInteractionState(run);
-      const alpha = typeof state === 'number' ? Math.round(state * 0.75) : 220;
-      return isDarkMode ? [9, 9, 11, alpha] : [250, 250, 250, alpha];
+      return getGroundTrackCasingColor(getRouteInteraction(run), isDarkMode);
     };
 
   const flightTrackWidthUpdateTriggers = $derived([
@@ -755,31 +615,43 @@
       ...buildFlightTrackLayers({
         data: flightTrackLayerData,
         style: mapPreferences.flightTrackStyle,
-        parameters: isGlobe ? GLOBE_ARC_PARAMETERS : MERCATOR_ROUTE_PARAMETERS,
-        extensions: [globeOcclusion],
-        getWidth: getVisibleArcWidth,
-        getStandardColor: getTrackColor(),
-        getAltitudeColor: getAltitudeTrackColor(),
-        getGroundCasingColor: getGroundCasingColor(),
-        getEstimatedUnderlayColor: getEstimatedUnderlayColor(),
-        widthUpdateTriggers: flightTrackWidthUpdateTriggers,
-        standardColorUpdateTriggers: [
-          hoveredArc,
-          hoveredAirport,
-          selectedAirportId,
-          selectedRoute,
-          mapPreferences.arcColor,
-          arcFrequencyPercentileByRoute,
-        ],
-        altitudeColorUpdateTriggers: [
-          hoveredArc,
-          hoveredAirport,
-          selectedAirportId,
-          selectedRoute,
-          isDarkMode,
-        ],
-        onHover: handleTrackHover,
-        onClick: handleTrackClick,
+        context: {
+          geometry: {
+            parameters: isGlobe
+              ? GLOBE_ARC_PARAMETERS
+              : MERCATOR_ROUTE_PARAMETERS,
+            extensions: [globeOcclusion],
+          },
+          appearance: {
+            getWidth: getVisibleArcWidth,
+            getStandardColor: getTrackColor(),
+            getAltitudeColor: getAltitudeTrackColor(),
+            getGroundCasingColor: getGroundCasingColor(),
+            getEstimatedUnderlayColor: getEstimatedUnderlayColor(),
+            updateTriggers: {
+              width: flightTrackWidthUpdateTriggers,
+              standardColor: [
+                hoveredArc,
+                hoveredAirport,
+                selectedAirportId,
+                selectedRoute,
+                mapPreferences.arcColor,
+                arcFrequencyPercentileByRoute,
+              ],
+              altitudeColor: [
+                hoveredArc,
+                hoveredAirport,
+                selectedAirportId,
+                selectedRoute,
+                isDarkMode,
+              ],
+            },
+          },
+          interaction: {
+            onHover: handleTrackHover,
+            onClick: handleTrackClick,
+          },
+        },
       }),
     );
     if (mapPreferences.airportCircles !== 'off') {
@@ -828,8 +700,8 @@
   <Popup
     openOn="hover"
     anchor="top-left"
-    offset={POPUP_OFFSET}
-    onopen={(popup) => (popupInstance = popup)}
+    offset={20}
+    onopen={popupPosition.setPopup}
   >
     {#snippet children({ data })}
       {#if data?.country}

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -3,6 +3,7 @@
   import { ArcLayer, ScatterplotLayer } from '@deck.gl/layers';
   import { MapboxOverlay } from '@deck.gl/mapbox';
   import { isTouchDevice } from '@melt-ui/svelte/internal/helpers';
+  import type { Popup as MaplibrePopup } from 'maplibre-gl';
   import { mode } from 'mode-watcher';
   import { onDestroy } from 'svelte';
   import {
@@ -159,6 +160,17 @@
     ),
   );
 
+  const getPointerPixel = (
+    e: PickingInfo,
+    event?: DeckPointerEvent,
+  ): { x: number; y: number } | undefined =>
+    event?.srcEvent?.point ??
+    event?.offsetCenter ??
+    (e.pixel ? { x: e.pixel[0], y: e.pixel[1] } : undefined) ??
+    (Number.isFinite(e.x) && Number.isFinite(e.y)
+      ? { x: e.x, y: e.y }
+      : undefined);
+
   // deck's picking coordinate is unprojected through deck's own globe
   // viewport, which drifts from MapLibre during the globe<->mercator
   // transition zooms — anchor popups via the raw pointer position instead.
@@ -166,13 +178,7 @@
     e: PickingInfo,
     event?: DeckPointerEvent,
   ): [number, number] | undefined => {
-    const point =
-      event?.srcEvent?.point ??
-      event?.offsetCenter ??
-      (e.pixel ? { x: e.pixel[0], y: e.pixel[1] } : undefined) ??
-      (Number.isFinite(e.x) && Number.isFinite(e.y)
-        ? { x: e.x, y: e.y }
-        : undefined);
+    const point = getPointerPixel(e, event);
 
     if (event?.srcEvent?.lngLat) {
       return [event.srcEvent.lngLat.lng, event.srcEvent.lngLat.lat];
@@ -212,6 +218,27 @@
     };
   };
 
+  const POPUP_OFFSET = 20;
+  const POPUP_FALLBACK_SIZE = { width: 320, height: 280 };
+  let popupInstance: MaplibrePopup | undefined;
+
+  // MapLibre re-reads options.anchor on every popup position update, so
+  // mutating it flips the popup at screen edges without recreating it.
+  const updatePopupAnchor = (point: { x: number; y: number } | undefined) => {
+    if (!popupInstance || !map || !point) return;
+    const container = map.getContainer();
+    const el = popupInstance.getElement();
+    const width = el?.offsetWidth || POPUP_FALLBACK_SIZE.width;
+    const height = el?.offsetHeight || POPUP_FALLBACK_SIZE.height;
+    const vertical =
+      point.y + POPUP_OFFSET + height > container.clientHeight
+        ? 'bottom'
+        : 'top';
+    const horizontal =
+      point.x + POPUP_OFFSET + width > container.clientWidth ? 'right' : 'left';
+    popupInstance.options.anchor = `${vertical}-${horizontal}`;
+  };
+
   let id = getId('deckgl-layer');
   let hoveredAirport: VisitedAirport | undefined = $state.raw(undefined);
   let hoveredArc: FlightArc | FlightTrackPath | undefined =
@@ -239,6 +266,7 @@
     if (!isTouchDevice()) {
       mapDetailsState.hoveredFlightTrackId = null;
       hoveredAirport = e.object ?? undefined;
+      updatePopupAnchor(getPointerPixel(e, event));
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
         ...e,
@@ -256,6 +284,7 @@
     if (!isTouchDevice()) {
       mapDetailsState.hoveredFlightTrackId = null;
       hoveredArc = e.object ?? undefined;
+      updatePopupAnchor(getPointerPixel(e, event));
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
         ...e,
@@ -273,6 +302,7 @@
     if (!isTouchDevice()) {
       mapDetailsState.hoveredFlightTrackId = e.object?.flightId ?? null;
       hoveredArc = e.object ?? undefined;
+      updatePopupAnchor(getPointerPixel(e, event));
       const type = e.index !== -1 ? 'mousemove' : 'mouseleave';
       layerEvent.value = {
         ...e,
@@ -795,7 +825,12 @@
 </script>
 
 {#if layer}
-  <Popup openOn="hover" anchor="top-left" offset={20}>
+  <Popup
+    openOn="hover"
+    anchor="top-left"
+    offset={POPUP_OFFSET}
+    onopen={(popup) => (popupInstance = popup)}
+  >
     {#snippet children({ data })}
       {#if data?.country}
         <AirportPopup {data} {clickable} />

--- a/src/lib/components/map/ArcPopup.svelte
+++ b/src/lib/components/map/ArcPopup.svelte
@@ -2,6 +2,7 @@
   import NumberFlow from '@number-flow/svelte';
 
   import { page } from '$app/state';
+  import { AirlineIcon, RouteArrow } from '$lib/components/display';
   import { pluralize } from '$lib/utils';
   import { formatAsFlightDate } from '$lib/utils/datetime';
   import {
@@ -14,82 +15,132 @@
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let { data, clickable }: { data: any; clickable: boolean } = $props();
+
+  const airportCode = (airport: typeof data.from) =>
+    airport.iata ?? airport.icao;
+
+  const recentFlights = $derived(
+    [...data.flights]
+      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
+      .slice(0, 5),
+  );
 </script>
 
-<div class="flex flex-col px-3 pt-3">
-  <h3 class="font-thin text-muted-foreground">Route</h3>
-  <h4 class="flex items-center text-lg">
+{#snippet routeStop(airport: typeof data.from)}
+  <div class="flex items-center gap-2 py-1">
     <img
-      src="https://flagcdn.com/{data.from.country.toLowerCase()}.svg"
-      alt={data.from.country}
-      class="w-8 h-5 mr-2"
+      src="https://flagcdn.com/{airport.country.toLowerCase()}.svg"
+      alt={airport.country}
+      class="h-4 w-6 shrink-0 rounded-sm object-cover ring-1 ring-black/10 dark:ring-white/15"
     />
-    {data.from.iata ?? data.from.icao} - {data.from.name}
-  </h4>
-  <h4 class="flex items-center text-lg">
-    <img
-      src="https://flagcdn.com/{data.to.country.toLowerCase()}.svg"
-      alt={data.to.country}
-      class="w-8 h-5 mr-2"
-    />
-    {data.to.iata ?? data.to.icao} - {data.to.name}
-  </h4>
-</div>
-<div class="h-px bg-muted my-3" />
-<div class="grid grid-cols-[repeat(3,1fr)] px-3">
-  <h4 class="font-semibold">
-    <NumberFlow value={Math.round(convertDistance(data.distance, prefs))} />
-    <span class="font-thin text-muted-foreground">
-      {distanceUnitLabel(prefs)}
+    <span class="text-xl leading-none font-semibold tracking-tight">
+      {airportCode(airport)}
     </span>
-  </h4>
-  <h4 class="font-semibold">
-    <NumberFlow value={data.flights.length} />
-    <span class="font-thin text-muted-foreground"
-      >{pluralize(data.flights.length, 'trip')}</span
-    >
-  </h4>
-  <h4 class="font-semibold">
-    <NumberFlow value={data.airlines.length} />
-    <span class="font-thin text-muted-foreground"
-      >{pluralize(data.airlines.length, 'airline')}</span
-    >
-  </h4>
-</div>
-<div class="h-px bg-muted my-3" />
-<div class="px-3 pb-3">
-  <div class="grid grid-cols-[repeat(3,1fr)]">
-    <h3 class="font-semibold">Route</h3>
-    <h3 class="font-semibold">Date</h3>
-    <h3 class="font-semibold">Airline</h3>
+    <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+      {airport.name}
+    </span>
   </div>
-  {#each data.flights
-    .slice(0, 5)
-    .sort( (a, b) => (a.date && b.date ? b.date.getTime() - a.date.getTime() : 0), ) as flight}
-    <div class="grid grid-cols-[repeat(3,1fr)]">
-      <h4 class="font-thin">{flight.route}</h4>
-      <h4 class="font-thin">
-        {flight.date
-          ? formatAsFlightDate(
-              flight.date,
-              flight.datePrecision ?? 'day',
-              true,
-              true,
-            )
-          : ''}
-      </h4>
-      <h4 class="font-thin">{flight.airline.name}</h4>
+{/snippet}
+
+<div class="w-80 max-w-[calc(100vw-2rem)]">
+  <div class="px-4 pt-3 pb-2.5">
+    <h3 class="text-xs font-medium text-muted-foreground">Route</h3>
+    <div class="mt-2">
+      {@render routeStop(data.from)}
+
+      <div
+        class="grid grid-cols-[1fr_auto_1fr] items-center gap-3 py-1.5 text-[11px] text-muted-foreground tabular-nums"
+      >
+        <div class="h-px bg-border/60"></div>
+        <div class="flex items-center gap-1.5 whitespace-nowrap">
+          <span>
+            <NumberFlow
+              value={Math.round(convertDistance(data.distance, prefs))}
+            />
+            {distanceUnitLabel(prefs)}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
+            <NumberFlow value={data.flights.length} />
+            {pluralize(data.flights.length, 'trip')}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
+            <NumberFlow value={data.airlines.length} />
+            {pluralize(data.airlines.length, 'airline')}
+          </span>
+        </div>
+        <div class="h-px bg-border/60"></div>
+      </div>
+
+      {@render routeStop(data.to)}
     </div>
-  {/each}
-  {#if data.flights.length > 5}
-    <h4 class="font-thin text-muted-foreground">
-      +{data.flights.length - 5} more
-    </h4>
+  </div>
+
+  <div class="border-t border-border/50 px-4 pt-2.5 pb-3">
+    <div class="mb-1 flex items-center gap-2">
+      <h3 class="text-xs font-medium text-muted-foreground">Flights</h3>
+      <span class="text-xs text-muted-foreground tabular-nums">
+        {data.flights.length}
+      </span>
+    </div>
+    <div class="divide-y divide-border/50">
+      {#each recentFlights as flight}
+        {@const [fromCode, toCode] = flight.route.split(' - ')}
+        <div
+          class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 py-2"
+        >
+          <div class="flex w-7 shrink-0 justify-center">
+            <AirlineIcon
+              airline={flight.airline || null}
+              size={22}
+              fallback="plane"
+            />
+          </div>
+          <div class="min-w-0">
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm leading-4 font-semibold tracking-tight">
+                {fromCode}
+              </span>
+              <RouteArrow class="size-3.5 fill-muted-foreground/70" />
+              <span class="text-sm leading-4 font-semibold tracking-tight">
+                {toCode}
+              </span>
+            </div>
+            {#if flight.airline}
+              <p class="mt-0.5 truncate text-xs text-muted-foreground">
+                {flight.airline.name}
+              </p>
+            {/if}
+          </div>
+          <div
+            class="shrink-0 text-right text-xs font-medium text-muted-foreground tabular-nums"
+          >
+            {flight.date
+              ? formatAsFlightDate(
+                  flight.date,
+                  flight.datePrecision ?? 'day',
+                  true,
+                  true,
+                )
+              : 'Unknown date'}
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    {#if data.flights.length > 5}
+      <p class="mt-1.5 text-xs text-muted-foreground">
+        +{data.flights.length - 5} more
+      </p>
+    {/if}
+  </div>
+
+  {#if clickable}
+    <div class="border-t border-border/50 px-4 py-2">
+      <p class="text-center text-xs text-muted-foreground">
+        Click for route details
+      </p>
+    </div>
   {/if}
 </div>
-{#if clickable}
-  <div class="h-px bg-muted my-2" />
-  <div class="px-3 pb-2">
-    <p class="text-xs text-muted-foreground text-center">Click for details</p>
-  </div>
-{/if}

--- a/src/lib/components/map/ArcPopup.svelte
+++ b/src/lib/components/map/ArcPopup.svelte
@@ -2,28 +2,22 @@
   import NumberFlow from '@number-flow/svelte';
 
   import { page } from '$app/state';
-  import { AirlineIcon, RouteArrow } from '$lib/components/display';
+  import type { FlightArc } from '$lib/map/flight-layer-data';
   import { pluralize } from '$lib/utils';
-  import { formatAsFlightDate } from '$lib/utils/datetime';
   import {
     convertDistance,
     distanceUnitLabel,
     getPreferences,
   } from '$lib/utils/preferences';
 
+  import PopupFlightList from './PopupFlightList.svelte';
+
   const prefs = $derived(getPreferences(page.data.user));
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let { data, clickable }: { data: any; clickable: boolean } = $props();
+  let { data, clickable }: { data: FlightArc; clickable: boolean } = $props();
 
   const airportCode = (airport: typeof data.from) =>
     airport.iata ?? airport.icao;
-
-  const recentFlights = $derived(
-    [...data.flights]
-      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
-      .slice(0, 5),
-  );
 </script>
 
 {#snippet routeStop(airport: typeof data.from)}
@@ -77,64 +71,7 @@
     </div>
   </div>
 
-  <div class="border-t border-border/50 px-4 pt-2.5 pb-3">
-    <div class="mb-1 flex items-center gap-2">
-      <h3 class="text-xs font-medium text-muted-foreground">Flights</h3>
-      <span class="text-xs text-muted-foreground tabular-nums">
-        {data.flights.length}
-      </span>
-    </div>
-    <div class="divide-y divide-border/50">
-      {#each recentFlights as flight}
-        {@const [fromCode, toCode] = flight.route.split(' - ')}
-        <div
-          class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 py-2"
-        >
-          <div class="flex w-7 shrink-0 justify-center">
-            <AirlineIcon
-              airline={flight.airline || null}
-              size={22}
-              fallback="plane"
-            />
-          </div>
-          <div class="min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm leading-4 font-semibold tracking-tight">
-                {fromCode}
-              </span>
-              <RouteArrow class="size-3.5 fill-muted-foreground/70" />
-              <span class="text-sm leading-4 font-semibold tracking-tight">
-                {toCode}
-              </span>
-            </div>
-            {#if flight.airline}
-              <p class="mt-0.5 truncate text-xs text-muted-foreground">
-                {flight.airline.name}
-              </p>
-            {/if}
-          </div>
-          <div
-            class="shrink-0 text-right text-xs font-medium text-muted-foreground tabular-nums"
-          >
-            {flight.date
-              ? formatAsFlightDate(
-                  flight.date,
-                  flight.datePrecision ?? 'day',
-                  true,
-                  true,
-                )
-              : 'Unknown date'}
-          </div>
-        </div>
-      {/each}
-    </div>
-
-    {#if data.flights.length > 5}
-      <p class="mt-1.5 text-xs text-muted-foreground">
-        +{data.flights.length - 5} more
-      </p>
-    {/if}
-  </div>
+  <PopupFlightList flights={data.flights} />
 
   {#if clickable}
     <div class="border-t border-border/50 px-4 py-2">

--- a/src/lib/components/map/FlightTrackLegend.svelte
+++ b/src/lib/components/map/FlightTrackLegend.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ChevronDown } from '@o7/icon/lucide';
+  import { mode } from 'mode-watcher';
   import { MediaQuery } from 'svelte/reactivity';
   import { Control } from 'svelte-maplibre';
 
@@ -19,18 +20,22 @@
   const labelAltitudes = [0, 10_000, 20_000, 30_000, 40_000, 51_000];
   const cssColor = (color: readonly number[]) =>
     `rgb(${color[0]} ${color[1]} ${color[2]})`;
+  const darkMode = $derived(mode.current === 'dark');
   const colorAt = (altitudeFeet: number | null, ground = false) =>
-    cssColor(getFlightTrackColor({ altitudeFeet, ground }));
+    cssColor(getFlightTrackColor({ altitudeFeet, ground, darkMode }));
   const gradient = `linear-gradient(90deg in oklab, ${FLIGHT_TRACK_ALTITUDE_COLOR_STOPS.map(
     ({ at, color }) =>
       `${cssColor(color)} ${(at / FLIGHT_TRACK_MAX_ALTITUDE_FEET) * 100}%`,
   ).join(', ')})`;
-  const estimatedColor = cssColor(
-    getFlightTrackColor({
-      altitudeFeet: 20_000,
-      ground: false,
-      estimated: true,
-    }),
+  const estimatedColor = $derived(
+    cssColor(
+      getFlightTrackColor({
+        altitudeFeet: 20_000,
+        ground: false,
+        estimated: true,
+        darkMode,
+      }),
+    ),
   );
   const prefs = $derived(getPreferences(page.data.user));
   const unit = $derived(altitudeUnitLabel(prefs));

--- a/src/lib/components/map/MapAppearanceControl.svelte
+++ b/src/lib/components/map/MapAppearanceControl.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { ControlButton } from 'svelte-maplibre';
-  import { page } from '$app/state';
 
   import FlightsAppearanceTab from './map-appearance/FlightsAppearanceTab.svelte';
   import LayersAppearanceTab from './map-appearance/LayersAppearanceTab.svelte';
   import MapAppearanceTab from './map-appearance/MapAppearanceTab.svelte';
 
+  import { page } from '$app/state';
+  import AnimatedSizeContainer from '$lib/components/ui/animated-size-container.svelte';
   import * as Popover from '$lib/components/ui/popover';
   import * as Tabs from '$lib/components/ui/tabs';
   import { resetMapPreferences } from '$lib/map/map-preferences.svelte';
@@ -65,46 +66,48 @@
     sideOffset={8}
     class="w-[min(calc(100vw-2rem),340px)] overflow-hidden p-0"
   >
-    <div class="flex max-h-[calc(100vh-6rem)] flex-col">
-      <div
-        class="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-3"
-      >
-        <h2 class="text-sm font-semibold leading-none">Map appearance</h2>
-        <button
-          type="button"
-          class="text-muted-foreground hover:text-foreground rounded-sm px-1.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-          onclick={resetMapPreferences}
+    <AnimatedSizeContainer height class="max-h-[calc(100vh-6rem)]">
+      <div class="flex max-h-[calc(100vh-6rem)] flex-col">
+        <div
+          class="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-3"
         >
-          Reset
-        </button>
-      </div>
-
-      <Tabs.Root
-        bind:value={activeTab}
-        class="min-h-0 flex-1 gap-0 overflow-hidden"
-      >
-        <div class="shrink-0 border-b px-3 py-2">
-          <Tabs.List class="grid w-full grid-cols-3">
-            <Tabs.Trigger value="map">Map</Tabs.Trigger>
-            <Tabs.Trigger value="flights">Flights</Tabs.Trigger>
-            <Tabs.Trigger value="layers">Layers</Tabs.Trigger>
-          </Tabs.List>
+          <h2 class="text-sm font-semibold leading-none">Map appearance</h2>
+          <button
+            type="button"
+            class="text-muted-foreground hover:text-foreground rounded-sm px-1.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            onclick={resetMapPreferences}
+          >
+            Reset
+          </button>
         </div>
 
-        <Tabs.Content value="map" class="min-h-0 overflow-y-auto">
-          <MapAppearanceTab />
-        </Tabs.Content>
-        <Tabs.Content value="flights" class="min-h-0 overflow-y-auto">
-          <FlightsAppearanceTab {showTracksSection} {hasFallbackArcs} />
-        </Tabs.Content>
-        <Tabs.Content value="layers" class="min-h-0 overflow-y-auto">
-          <LayersAppearanceTab
-            {openAipConfigured}
-            {isAdmin}
-            onOpenIntegrationSettings={openIntegrationSettings}
-          />
-        </Tabs.Content>
-      </Tabs.Root>
-    </div>
+        <Tabs.Root
+          bind:value={activeTab}
+          class="min-h-0 flex-1 gap-0 overflow-hidden"
+        >
+          <div class="shrink-0 border-b px-3 py-2">
+            <Tabs.List class="grid w-full grid-cols-3">
+              <Tabs.Trigger value="map">Map</Tabs.Trigger>
+              <Tabs.Trigger value="flights">Flights</Tabs.Trigger>
+              <Tabs.Trigger value="layers">Layers</Tabs.Trigger>
+            </Tabs.List>
+          </div>
+
+          <Tabs.Content value="map" class="min-h-0 overflow-y-auto">
+            <MapAppearanceTab />
+          </Tabs.Content>
+          <Tabs.Content value="flights" class="min-h-0 overflow-y-auto">
+            <FlightsAppearanceTab {showTracksSection} {hasFallbackArcs} />
+          </Tabs.Content>
+          <Tabs.Content value="layers" class="min-h-0 overflow-y-auto">
+            <LayersAppearanceTab
+              {openAipConfigured}
+              {isAdmin}
+              onOpenIntegrationSettings={openIntegrationSettings}
+            />
+          </Tabs.Content>
+        </Tabs.Root>
+      </div>
+    </AnimatedSizeContainer>
   </Popover.Content>
 </Popover.Root>

--- a/src/lib/components/map/PopupFlightList.svelte
+++ b/src/lib/components/map/PopupFlightList.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { AirlineIcon, RouteArrow } from '$lib/components/display';
+  import type { SimpleFlight } from '$lib/utils';
+  import { formatAsFlightDate } from '$lib/utils/datetime';
+
+  let { flights }: { flights: SimpleFlight[] } = $props();
+
+  const recentFlights = $derived(
+    [...flights]
+      .sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0))
+      .slice(0, 5),
+  );
+</script>
+
+<div class="border-t border-border/50 px-4 pt-2.5 pb-3">
+  <div class="mb-1 flex items-center gap-2">
+    <h3 class="text-xs font-medium text-muted-foreground">Flights</h3>
+    <span class="text-xs text-muted-foreground tabular-nums">
+      {flights.length}
+    </span>
+  </div>
+  <div class="divide-y divide-border/50">
+    {#each recentFlights as flight}
+      <div
+        class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 py-2"
+      >
+        <div class="flex w-7 shrink-0 justify-center">
+          <AirlineIcon
+            airline={flight.airline || null}
+            size={22}
+            fallback="plane"
+          />
+        </div>
+        <div class="min-w-0">
+          <div class="flex items-center gap-1.5">
+            <span class="text-sm leading-4 font-semibold tracking-tight">
+              {flight.fromCode}
+            </span>
+            <RouteArrow class="size-3.5 fill-muted-foreground/70" />
+            <span class="text-sm leading-4 font-semibold tracking-tight">
+              {flight.toCode}
+            </span>
+          </div>
+          {#if flight.airline}
+            <p class="mt-0.5 truncate text-xs text-muted-foreground">
+              {flight.airline.name}
+            </p>
+          {/if}
+        </div>
+        <div
+          class="shrink-0 text-right text-xs font-medium text-muted-foreground tabular-nums"
+        >
+          {flight.date
+            ? formatAsFlightDate(
+                flight.date,
+                flight.datePrecision ?? 'day',
+                true,
+                true,
+              )
+            : 'Unknown date'}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  {#if flights.length > 5}
+    <p class="mt-1.5 text-xs text-muted-foreground">
+      +{flights.length - 5} more
+    </p>
+  {/if}
+</div>

--- a/src/lib/components/map/map-appearance-options.ts
+++ b/src/lib/components/map/map-appearance-options.ts
@@ -1,96 +1,21 @@
-import type { MapBasemap } from '$lib/map/basemap';
-import {
-  type AirportCircleRadiusMode,
-  type AirportCirclesMode,
-  type AirportOverlayDetail,
-  type ArcColorMode,
-  type ArcThicknessMode,
-  type ArcThicknessScale,
-  type FlightTrackStyle,
-  type MapProjection,
-  type RouteDisplayMode,
-} from '$lib/map/map-preferences.svelte';
-import {
-  OPENAIP_OVERLAY_GROUPS,
-  type OpenAipOverlayGroup,
-} from '$lib/map/openaip';
+import { MAP_PREFERENCE_DEFINITIONS } from '$lib/map/map-preferences.svelte';
 
-type AppearanceOption<T extends string> = {
-  value: T;
-  label: string;
-};
-
-export const AIRPORT_CIRCLE_OPTIONS: Array<
-  AppearanceOption<AirportCirclesMode>
-> = [
-  { value: 'off', label: 'Off' },
-  { value: 'small', label: 'Small' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'large', label: 'Large' },
-];
-
-export const AIRPORT_CIRCLE_RADIUS_OPTIONS: Array<
-  AppearanceOption<AirportCircleRadiusMode>
-> = [
-  { value: 'byFrequency', label: 'By frequency' },
-  { value: 'uniform', label: 'Uniform' },
-];
-
-export const ARC_COLOR_OPTIONS: Array<AppearanceOption<ArcColorMode>> = [
-  { value: 'default', label: 'Default' },
-  { value: 'byFrequency', label: 'By frequency' },
-];
-
-export const ARC_THICKNESS_OPTIONS: Array<AppearanceOption<ArcThicknessMode>> =
-  [
-    { value: 'uniform', label: 'Uniform' },
-    { value: 'byFrequency', label: 'By frequency' },
-  ];
-
-export const ARC_SCALE_OPTIONS: Array<AppearanceOption<ArcThicknessScale>> = [
-  { value: 'thin', label: 'Thin' },
-  { value: 'normal', label: 'Normal' },
-  { value: 'thick', label: 'Thick' },
-];
-
-export const ROUTE_DISPLAY_OPTIONS: Array<AppearanceOption<RouteDisplayMode>> =
-  [
-    { value: 'tracks', label: 'Flight tracks' },
-    { value: 'points', label: 'Point to point' },
-  ];
-
-export const FLIGHT_TRACK_STYLE_OPTIONS: Array<
-  AppearanceOption<FlightTrackStyle>
-> = [
-  { value: 'standard', label: 'Standard' },
-  { value: 'altitude', label: 'Altitude' },
-];
-
-export const AIRPORT_DETAIL_OPTIONS: Array<
-  AppearanceOption<AirportOverlayDetail>
-> = [
-  { value: 'standard', label: 'Standard' },
-  { value: 'detailed', label: 'Detailed' },
-];
-
-export const OPENAIP_GROUP_OPTIONS: Array<
-  AppearanceOption<OpenAipOverlayGroup>
-> = [
-  { value: 'airspaces', label: 'Airspaces' },
-  { value: 'airspaceLabels', label: 'Airspace labels' },
-  { value: 'airports', label: 'Airports' },
-  { value: 'navaids', label: 'Navaids' },
-  { value: 'reportingPoints', label: 'Reporting points' },
-];
-
-export const BASEMAP_OPTIONS: Array<AppearanceOption<MapBasemap>> = [
-  { value: 'default', label: 'Default' },
-  { value: 'satellite', label: 'Satellite' },
-];
-
-export const PROJECTION_OPTIONS: Array<AppearanceOption<MapProjection>> = [
-  { value: 'mercator', label: 'Flat' },
-  { value: 'globe', label: 'Globe' },
-];
-
-OPENAIP_OVERLAY_GROUPS satisfies readonly OpenAipOverlayGroup[];
+export const AIRPORT_CIRCLE_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.airportCircles.options;
+export const AIRPORT_CIRCLE_RADIUS_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.airportCircleRadius.options;
+export const ARC_COLOR_OPTIONS = MAP_PREFERENCE_DEFINITIONS.arcColor.options;
+export const ARC_THICKNESS_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.arcThickness.options;
+export const ARC_SCALE_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.arcThicknessScale.options;
+export const ROUTE_DISPLAY_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.routeDisplay.options;
+export const FLIGHT_TRACK_STYLE_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.flightTrackStyle.options;
+export const AIRPORT_DETAIL_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.airportOverlayDetail.options;
+export const OPENAIP_GROUP_OPTIONS =
+  MAP_PREFERENCE_DEFINITIONS.openAipGroups.options;
+export const BASEMAP_OPTIONS = MAP_PREFERENCE_DEFINITIONS.basemap.options;
+export const PROJECTION_OPTIONS = MAP_PREFERENCE_DEFINITIONS.projection.options;

--- a/src/lib/map/flight-layer-data.test.ts
+++ b/src/lib/map/flight-layer-data.test.ts
@@ -42,7 +42,9 @@ describe('flight track layer data', () => {
       },
     ] as FlightTrackRow[];
 
-    expect(buildFlightTrackPaths(flights, arcs, tracks)).toMatchObject([
+    const paths = buildFlightTrackPaths(flights, arcs, tracks);
+
+    expect(paths).toMatchObject([
       {
         flightId: 7,
         path: [
@@ -53,6 +55,7 @@ describe('flight track layer data', () => {
         estimated: [false, true],
       },
     ]);
+    expect(paths[0]!.path).toHaveLength(paths[0]!.estimated!.length);
   });
 
   it('detects whether route arcs remain after tracked flights are replaced', () => {

--- a/src/lib/map/flight-layer-data.test.ts
+++ b/src/lib/map/flight-layer-data.test.ts
@@ -4,25 +4,27 @@ import {
   buildFlightTrackPaths,
   hasFallbackFlightArcs,
   type FlightArc,
-  unwrapTrackPath,
 } from './flight-layer-data';
 
 import type { FlightTrackRow } from '$lib/track/schema';
 import type { FlightData } from '$lib/utils';
 
 describe('flight track layer data', () => {
-  it('unwraps dateline crossings without dropping altitude', () => {
-    expect(
-      unwrapTrackPath([
-        [179, 55, 1_000],
-        [-179, 56, 2_000],
-        [-178, 57],
-      ]),
-    ).toEqual([
+  it('preserves canonical source coordinates in render paths', () => {
+    const flights = [{ id: 7, from: { id: 1 }, to: { id: 2 } }] as FlightData[];
+    const arcs = [{ from: { id: 1 }, to: { id: 2 } }] as FlightArc[];
+    const coordinates = [
       [179, 55, 1_000],
-      [181, 56, 2_000],
-      [182, 57],
-    ]);
+      [-179, 56, 2_000],
+      [-178, 57],
+    ] as FlightTrackRow['coordinates'];
+    const tracks = [{ flightId: 7, coordinates }] as FlightTrackRow[];
+
+    const paths = buildFlightTrackPaths(flights, arcs, tracks);
+
+    expect(paths[0]!.samples.map((sample) => sample.coordinate)).toEqual(
+      coordinates,
+    );
   });
 
   it('carries aligned flags into render paths', () => {

--- a/src/lib/map/flight-layer-data.test.ts
+++ b/src/lib/map/flight-layer-data.test.ts
@@ -47,15 +47,21 @@ describe('flight track layer data', () => {
     expect(paths).toMatchObject([
       {
         flightId: 7,
-        path: [
-          [10, 55, 0],
-          [11, 56, 304.8],
+        samples: [
+          {
+            coordinate: [10, 55, 0],
+            point: { ground: true },
+            incomingEdge: { estimated: false },
+          },
+          {
+            coordinate: [11, 56, 304.8],
+            point: { ground: false },
+            incomingEdge: { estimated: true },
+          },
         ],
-        ground: [true, false],
-        estimated: [false, true],
       },
     ]);
-    expect(paths[0]!.path).toHaveLength(paths[0]!.estimated!.length);
+    expect(paths[0]!.samples).toHaveLength(2);
   });
 
   it('detects whether route arcs remain after tracked flights are replaced', () => {

--- a/src/lib/map/flight-layer-data.ts
+++ b/src/lib/map/flight-layer-data.ts
@@ -1,7 +1,6 @@
 import type { Route } from '$lib/components/flight-filters/types';
 import {
   toFlightTrackSamples,
-  type FlightTrackCoordinate,
   type FlightTrackRow,
   type FlightTrackSample,
 } from '$lib/track/schema';
@@ -31,26 +30,6 @@ export const routeMatchesArc = (
     (fromId === route.a && toId === route.b) ||
     (fromId === route.b && toId === route.a)
   );
-};
-
-export const unwrapTrackPath = (path: FlightTrackCoordinate[]) => {
-  if (!path.length) return path;
-  const unwrapped: FlightTrackCoordinate[] = [path[0]!];
-
-  for (let index = 1; index < path.length; index++) {
-    const previous = unwrapped[index - 1]!;
-    const current = path[index]!;
-    let lon = current[0];
-    while (lon - previous[0] > 180) lon -= 360;
-    while (lon - previous[0] < -180) lon += 360;
-    unwrapped.push(
-      current[2] === undefined
-        ? [lon, current[1]]
-        : [lon, current[1], current[2]],
-    );
-  }
-
-  return unwrapped;
 };
 
 export const buildArcFrequencyPercentileByRoute = (flightArcs: FlightArc[]) => {
@@ -129,18 +108,10 @@ export const buildFlightTrackPaths = (
     const arc = arcByRoute.get(getRouteKey(flight.from.id, flight.to.id));
     if (!arc) continue;
 
-    const samples = toFlightTrackSamples(track);
-    const unwrappedCoordinates = unwrapTrackPath(
-      samples.map((sample) => sample.coordinate),
-    );
-
     paths.push({
       ...arc,
       flightId: track.flightId,
-      samples: samples.map((sample, index) => ({
-        ...sample,
-        coordinate: unwrappedCoordinates[index]!,
-      })),
+      samples: toFlightTrackSamples(track),
     });
   }
 

--- a/src/lib/map/flight-layer-data.ts
+++ b/src/lib/map/flight-layer-data.ts
@@ -1,6 +1,8 @@
 import type { Route } from '$lib/components/flight-filters/types';
 import type { FlightTrackCoordinate, FlightTrackRow } from '$lib/track/schema';
 import type { prepareFlightArcData, FlightData } from '$lib/utils';
+import greatCircle from '@turf/great-circle';
+import { point } from '@turf/helpers';
 
 export type FlightArc = ReturnType<typeof prepareFlightArcData>[number];
 

--- a/src/lib/map/flight-layer-data.ts
+++ b/src/lib/map/flight-layer-data.ts
@@ -29,11 +29,48 @@ export const routeMatchesArc = (
 
 export const unwrapTrackPath = (path: FlightTrackCoordinate[]) => {
   if (!path.length) return path;
-  const unwrapped: FlightTrackCoordinate[] = [path[0]!];
 
-  for (let index = 1; index < path.length; index++) {
+  const interpolatedPath: FlightTrackCoordinate[] = [path[0]!];
+  const maxDegrees = 3;
+
+  for (let i = 1; i < path.length; i++) {
+    const prev = interpolatedPath[interpolatedPath.length - 1]!;
+    const curr = path[i]!;
+
+    const dLon = Math.abs(curr[0] - prev[0]);
+    const dLat = Math.abs(curr[1] - prev[1]);
+
+    if (dLon > maxDegrees || dLat > maxDegrees) {
+      try {
+        const startPoint = point([prev[0], prev[1]]);
+        const endPoint = point([curr[0], curr[1]]);
+
+        const arc = greatCircle(startPoint, endPoint, { npoints: 20 });
+        let arcCoords: [number, number][] = [];
+
+        if (arc.geometry.type === 'MultiLineString') {
+          arcCoords = arc.geometry.coordinates.flat() as [number, number][];
+        } else {
+          arcCoords = arc.geometry.coordinates as [number, number][];
+        }
+        const interpolatedArcCoords = arcCoords.slice(1).map((coord) => {
+          return prev[2] !== undefined ? [coord[0], coord[1], prev[2]] : coord;
+        }) as FlightTrackCoordinate[];
+
+        interpolatedPath.push(...interpolatedArcCoords);
+      } catch (error) {
+        interpolatedPath.push(curr);
+      }
+    } else {
+      interpolatedPath.push(curr);
+    }
+  }
+
+  const unwrapped: FlightTrackCoordinate[] = [interpolatedPath[0]!];
+
+  for (let index = 1; index < interpolatedPath.length; index++) {
     const previous = unwrapped[index - 1]!;
-    const current = path[index]!;
+    const current = interpolatedPath[index]!;
     let lon = current[0];
     while (lon - previous[0] > 180) lon -= 360;
     while (lon - previous[0] < -180) lon += 360;

--- a/src/lib/map/flight-layer-data.ts
+++ b/src/lib/map/flight-layer-data.ts
@@ -1,8 +1,6 @@
 import type { Route } from '$lib/components/flight-filters/types';
 import type { FlightTrackCoordinate, FlightTrackRow } from '$lib/track/schema';
 import type { prepareFlightArcData, FlightData } from '$lib/utils';
-import greatCircle from '@turf/great-circle';
-import { point } from '@turf/helpers';
 
 export type FlightArc = ReturnType<typeof prepareFlightArcData>[number];
 
@@ -31,48 +29,11 @@ export const routeMatchesArc = (
 
 export const unwrapTrackPath = (path: FlightTrackCoordinate[]) => {
   if (!path.length) return path;
+  const unwrapped: FlightTrackCoordinate[] = [path[0]!];
 
-  const interpolatedPath: FlightTrackCoordinate[] = [path[0]!];
-  const maxDegrees = 3;
-
-  for (let i = 1; i < path.length; i++) {
-    const prev = interpolatedPath[interpolatedPath.length - 1]!;
-    const curr = path[i]!;
-
-    const dLon = Math.abs(curr[0] - prev[0]);
-    const dLat = Math.abs(curr[1] - prev[1]);
-
-    if (dLon > maxDegrees || dLat > maxDegrees) {
-      try {
-        const startPoint = point([prev[0], prev[1]]);
-        const endPoint = point([curr[0], curr[1]]);
-
-        const arc = greatCircle(startPoint, endPoint, { npoints: 20 });
-        let arcCoords: [number, number][] = [];
-
-        if (arc.geometry.type === 'MultiLineString') {
-          arcCoords = arc.geometry.coordinates.flat() as [number, number][];
-        } else {
-          arcCoords = arc.geometry.coordinates as [number, number][];
-        }
-        const interpolatedArcCoords = arcCoords.slice(1).map((coord) => {
-          return prev[2] !== undefined ? [coord[0], coord[1], prev[2]] : coord;
-        }) as FlightTrackCoordinate[];
-
-        interpolatedPath.push(...interpolatedArcCoords);
-      } catch (error) {
-        interpolatedPath.push(curr);
-      }
-    } else {
-      interpolatedPath.push(curr);
-    }
-  }
-
-  const unwrapped: FlightTrackCoordinate[] = [interpolatedPath[0]!];
-
-  for (let index = 1; index < interpolatedPath.length; index++) {
+  for (let index = 1; index < path.length; index++) {
     const previous = unwrapped[index - 1]!;
-    const current = interpolatedPath[index]!;
+    const current = path[index]!;
     let lon = current[0];
     while (lon - previous[0] > 180) lon -= 360;
     while (lon - previous[0] < -180) lon += 360;

--- a/src/lib/map/flight-layer-data.ts
+++ b/src/lib/map/flight-layer-data.ts
@@ -1,14 +1,20 @@
 import type { Route } from '$lib/components/flight-filters/types';
-import type { FlightTrackCoordinate, FlightTrackRow } from '$lib/track/schema';
+import {
+  toFlightTrackSamples,
+  type FlightTrackCoordinate,
+  type FlightTrackRow,
+  type FlightTrackSample,
+} from '$lib/track/schema';
 import type { prepareFlightArcData, FlightData } from '$lib/utils';
 
 export type FlightArc = ReturnType<typeof prepareFlightArcData>[number];
 
-export type FlightTrackPath = FlightArc & {
+export type FlightTrackIdentity = FlightArc & {
   flightId: number;
-  path: FlightTrackCoordinate[];
-  ground?: boolean[];
-  estimated?: boolean[];
+};
+
+export type FlightTrackPath = FlightTrackIdentity & {
+  samples: FlightTrackSample[];
 };
 
 export const getRouteKey = (fromId: number, toId: number) =>
@@ -123,12 +129,18 @@ export const buildFlightTrackPaths = (
     const arc = arcByRoute.get(getRouteKey(flight.from.id, flight.to.id));
     if (!arc) continue;
 
+    const samples = toFlightTrackSamples(track);
+    const unwrappedCoordinates = unwrapTrackPath(
+      samples.map((sample) => sample.coordinate),
+    );
+
     paths.push({
       ...arc,
       flightId: track.flightId,
-      path: unwrapTrackPath(track.coordinates),
-      ground: track.ground,
-      estimated: track.estimated,
+      samples: samples.map((sample, index) => ({
+        ...sample,
+        coordinate: unwrappedCoordinates[index]!,
+      })),
     });
   }
 

--- a/src/lib/map/flight-track-display-geometry.ts
+++ b/src/lib/map/flight-track-display-geometry.ts
@@ -23,14 +23,18 @@ const unwrapLongitude = (longitude: number, previous: number) => {
 
 const interpolateLinearSegment = (
   path: [number, number][],
-  start: FlightTrackCoordinate,
-  end: FlightTrackCoordinate,
+  start: [number, number],
+  end: [number, number],
   segmentCount: number,
 ) => {
   for (let index = 1; index < segmentCount; index++) {
     const progress = index / segmentCount;
+    const previousLongitude = path.at(-1)![0];
     path.push([
-      start[0] + (end[0] - start[0]) * progress,
+      unwrapLongitude(
+        start[0] + (end[0] - start[0]) * progress,
+        previousLongitude,
+      ),
       start[1] + (end[1] - start[1]) * progress,
     ]);
   }
@@ -110,8 +114,6 @@ const prepareDisplaySegments = (path: FlightTrackCoordinate[]) =>
         : 0;
 
     return {
-      start,
-      end,
       normalizedStart,
       normalizedEnd,
       subdivisionDepth,
@@ -200,8 +202,8 @@ const buildDisplayPath = (
         // surface interpolation still avoids drawing a chord through the globe.
         interpolateLinearSegment(
           displayPath,
-          segment.start,
-          segment.end,
+          segment.normalizedStart,
+          segment.normalizedEnd,
           2 ** subdivisionDepth,
         );
       }
@@ -210,7 +212,7 @@ const buildDisplayPath = (
     const previousLongitude = displayPath.at(-1)![0];
     displayPath.push([
       unwrapLongitude(segment.normalizedEnd[0], previousLongitude),
-      segment.end[1],
+      segment.normalizedEnd[1],
     ]);
   }
 

--- a/src/lib/map/flight-track-display-geometry.ts
+++ b/src/lib/map/flight-track-display-geometry.ts
@@ -207,7 +207,11 @@ const buildDisplayPath = (
       }
     }
 
-    displayPath.push([segment.end[0], segment.end[1]]);
+    const previousLongitude = displayPath.at(-1)![0];
+    displayPath.push([
+      unwrapLongitude(segment.normalizedEnd[0], previousLongitude),
+      segment.end[1],
+    ]);
   }
 
   return displayPath;

--- a/src/lib/map/flight-track-display-geometry.ts
+++ b/src/lib/map/flight-track-display-geometry.ts
@@ -1,0 +1,233 @@
+import { distance, point } from '@turf/turf';
+
+import type { FlightTrackCoordinate } from '$lib/track/schema';
+
+const GREAT_CIRCLE_MIN_DISTANCE_METERS = 30_000;
+const GREAT_CIRCLE_TARGET_SEGMENT_METERS = 19_000;
+export const MAX_FLIGHT_TRACK_DISPLAY_POINTS = 50_000;
+
+export type FlightTrackDisplaySource = {
+  path: FlightTrackCoordinate[];
+  layerCount: number;
+};
+
+const normalizeLongitude = (longitude: number) =>
+  ((((longitude + 180) % 360) + 360) % 360) - 180;
+
+const unwrapLongitude = (longitude: number, previous: number) => {
+  let unwrapped = longitude;
+  while (unwrapped - previous > 180) unwrapped -= 360;
+  while (unwrapped - previous < -180) unwrapped += 360;
+  return unwrapped;
+};
+
+const interpolateLinearSegment = (
+  path: [number, number][],
+  start: FlightTrackCoordinate,
+  end: FlightTrackCoordinate,
+  segmentCount: number,
+) => {
+  for (let index = 1; index < segmentCount; index++) {
+    const progress = index / segmentCount;
+    path.push([
+      start[0] + (end[0] - start[0]) * progress,
+      start[1] + (end[1] - start[1]) * progress,
+    ]);
+  }
+};
+
+const greatCircleMidpoint = (
+  from: [number, number],
+  to: [number, number],
+): [number, number] | null => {
+  const longitude1 = (from[0] * Math.PI) / 180;
+  const latitude1 = (from[1] * Math.PI) / 180;
+  const longitude2 = (to[0] * Math.PI) / 180;
+  const latitude2 = (to[1] * Math.PI) / 180;
+  const longitudeDifference = longitude2 - longitude1;
+  const bx = Math.cos(latitude2) * Math.cos(longitudeDifference);
+  const by = Math.cos(latitude2) * Math.sin(longitudeDifference);
+  const x = Math.cos(latitude1) + bx;
+  const y = by;
+
+  if (Math.hypot(x, y) < Number.EPSILON) return null;
+
+  const latitude = Math.atan2(
+    Math.sin(latitude1) + Math.sin(latitude2),
+    Math.hypot(x, y),
+  );
+  const longitude = longitude1 + Math.atan2(by, x);
+  return [
+    normalizeLongitude((longitude * 180) / Math.PI),
+    (latitude * 180) / Math.PI,
+  ];
+};
+
+const subdivideGreatCircle = (
+  start: [number, number],
+  end: [number, number],
+  depth: number,
+) => {
+  let coordinates = [start, end];
+
+  for (let level = 0; level < depth; level++) {
+    const subdivided: [number, number][] = [coordinates[0]!];
+    for (let index = 1; index < coordinates.length; index++) {
+      const midpoint = greatCircleMidpoint(
+        coordinates[index - 1]!,
+        coordinates[index]!,
+      );
+      if (!midpoint) return null;
+      subdivided.push(midpoint, coordinates[index]!);
+    }
+    coordinates = subdivided;
+  }
+
+  return coordinates;
+};
+
+const prepareDisplaySegments = (path: FlightTrackCoordinate[]) =>
+  path.slice(1).map((end, offset) => {
+    const start = path[offset]!;
+    const normalizedStart: [number, number] = [
+      normalizeLongitude(start[0]),
+      start[1],
+    ];
+    const normalizedEnd: [number, number] = [
+      normalizeLongitude(end[0]),
+      end[1],
+    ];
+    const segmentDistance = distance(
+      point(normalizedStart),
+      point(normalizedEnd),
+      { units: 'meters' },
+    );
+    const subdivisionDepth =
+      segmentDistance > GREAT_CIRCLE_MIN_DISTANCE_METERS
+        ? Math.ceil(
+            Math.log2(segmentDistance / GREAT_CIRCLE_TARGET_SEGMENT_METERS),
+          )
+        : 0;
+
+    return {
+      start,
+      end,
+      normalizedStart,
+      normalizedEnd,
+      subdivisionDepth,
+    };
+  });
+
+type PreparedDisplaySegments = ReturnType<typeof prepareDisplaySegments>;
+
+const countDisplayPoints = (
+  segments: PreparedDisplaySegments,
+  depthCeiling: number,
+) =>
+  segments.length === 0
+    ? 0
+    : 1 +
+      segments.reduce(
+        (total, segment) =>
+          total + 2 ** Math.min(segment.subdivisionDepth, depthCeiling),
+        0,
+      );
+
+const findSharedDepthCeiling = (
+  prepared: Array<{
+    segments: PreparedDisplaySegments;
+    layerCount: number;
+  }>,
+) => {
+  let depthCeiling = prepared.reduce(
+    (maximum, item) =>
+      item.segments.reduce(
+        (pathMaximum, segment) =>
+          Math.max(pathMaximum, segment.subdivisionDepth),
+        maximum,
+      ),
+    0,
+  );
+  const totalPointCount = (maximumDepth: number) =>
+    prepared.reduce(
+      (total, item) =>
+        total +
+        item.layerCount * countDisplayPoints(item.segments, maximumDepth),
+      0,
+    );
+
+  while (
+    depthCeiling > 0 &&
+    totalPointCount(depthCeiling) > MAX_FLIGHT_TRACK_DISPLAY_POINTS
+  ) {
+    depthCeiling--;
+  }
+
+  return depthCeiling;
+};
+
+const buildDisplayPath = (
+  sourcePath: FlightTrackCoordinate[],
+  segments: PreparedDisplaySegments,
+  depthCeiling: number,
+) => {
+  if (!sourcePath.length) return [];
+
+  const displayPath: [number, number][] = [
+    [sourcePath[0]![0], sourcePath[0]![1]],
+  ];
+
+  for (const segment of segments) {
+    const subdivisionDepth = Math.min(segment.subdivisionDepth, depthCeiling);
+
+    if (subdivisionDepth > 0) {
+      const arc = subdivideGreatCircle(
+        segment.normalizedStart,
+        segment.normalizedEnd,
+        subdivisionDepth,
+      );
+
+      if (arc) {
+        for (const coordinate of arc.slice(1, -1)) {
+          const previousLongitude = displayPath.at(-1)![0];
+          displayPath.push([
+            unwrapLongitude(coordinate[0], previousLongitude),
+            coordinate[1],
+          ]);
+        }
+      } else {
+        // Antipodal points have no unique great-circle route. A deterministic
+        // surface interpolation still avoids drawing a chord through the globe.
+        interpolateLinearSegment(
+          displayPath,
+          segment.start,
+          segment.end,
+          2 ** subdivisionDepth,
+        );
+      }
+    }
+
+    displayPath.push([segment.end[0], segment.end[1]]);
+  }
+
+  return displayPath;
+};
+
+export const buildFlightTrackDisplayPaths = (
+  sources: FlightTrackDisplaySource[],
+) => {
+  const prepared = sources.map(({ path, layerCount }) => ({
+    path,
+    layerCount,
+    segments: prepareDisplaySegments(path),
+  }));
+  const depthCeiling = findSharedDepthCeiling(prepared);
+
+  return prepared.map(({ path, segments }) =>
+    buildDisplayPath(path, segments, depthCeiling),
+  );
+};
+
+export const buildFlightTrackDisplayPath = (
+  sourcePath: FlightTrackCoordinate[],
+) => buildFlightTrackDisplayPaths([{ path: sourcePath, layerCount: 1 }])[0]!;

--- a/src/lib/map/flight-track-interaction.test.ts
+++ b/src/lib/map/flight-track-interaction.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FlightArc, FlightTrackPath } from './flight-layer-data';
+import {
+  applyFlightTrackInteractionColor,
+  getEstimatedTrackUnderlayColor,
+  resolveRouteInteraction,
+  type RouteInteractionContext,
+} from './flight-track-interaction';
+
+const airport = (id: number) => ({ id });
+const arc = (fromId: number, toId: number) =>
+  ({ from: airport(fromId), to: airport(toId) }) as FlightArc;
+const track = (flightId: number, fromId: number, toId: number) =>
+  ({ ...arc(fromId, toId), flightId, samples: [] }) as FlightTrackPath;
+const context = (
+  overrides: Partial<RouteInteractionContext> = {},
+): RouteInteractionContext => ({
+  selectedAirportId: null,
+  selectedRoute: null,
+  ...overrides,
+});
+
+describe('flight track interaction', () => {
+  it('distinguishes the hovered track from other tracks on its route', () => {
+    const hoveredArc = track(10, 1, 2);
+
+    expect(
+      resolveRouteInteraction(hoveredArc, context({ hoveredArc })),
+    ).toEqual({ emphasis: 'primary', opacity: 255 });
+    expect(
+      resolveRouteInteraction(track(11, 2, 1), context({ hoveredArc })),
+    ).toEqual({ emphasis: 'secondary', opacity: 255 });
+    expect(
+      resolveRouteInteraction(track(12, 3, 4), context({ hoveredArc })),
+    ).toEqual({ emphasis: 'dimmed', opacity: 200 });
+    expect(resolveRouteInteraction(arc(1, 2), context({ hoveredArc }))).toEqual(
+      { emphasis: 'primary', opacity: 255 },
+    );
+  });
+
+  it('uses explicit opacity for selected-route dimming', () => {
+    const state = resolveRouteInteraction(
+      arc(3, 4),
+      context({ selectedRoute: { a: '1', b: '2' } }),
+    );
+
+    expect(state).toEqual({ emphasis: 'dimmed', opacity: 170 });
+    expect(applyFlightTrackInteractionColor(state, [1, 2, 3])).toEqual([
+      113, 113, 122, 170,
+    ]);
+    expect(getEstimatedTrackUnderlayColor(state)).toEqual([0, 0, 0, 51]);
+  });
+});

--- a/src/lib/map/flight-track-interaction.ts
+++ b/src/lib/map/flight-track-interaction.ts
@@ -1,0 +1,104 @@
+import type { Color } from '@deck.gl/core';
+
+import type { Route } from '$lib/components/flight-filters/types';
+
+import {
+  getRouteKey,
+  routeMatchesArc,
+  type FlightArc,
+  type FlightTrackPath,
+} from './flight-layer-data';
+
+export type RouteInteraction = {
+  emphasis: 'normal' | 'primary' | 'secondary' | 'dimmed';
+  opacity: number;
+};
+
+export type RouteInteractionContext = {
+  hoveredArc?: FlightArc | FlightTrackPath;
+  hoveredAirportId?: number;
+  selectedAirportId: number | null;
+  selectedRoute: Route | null;
+};
+
+const interaction = (
+  emphasis: RouteInteraction['emphasis'],
+  opacity = 255,
+): RouteInteraction => ({ emphasis, opacity });
+
+const arcsShareRoute = (left: FlightArc, right: FlightArc) =>
+  getRouteKey(left.from.id, left.to.id) ===
+  getRouteKey(right.from.id, right.to.id);
+
+export const resolveRouteInteraction = (
+  arc: FlightArc,
+  context: RouteInteractionContext,
+): RouteInteraction => {
+  const { hoveredArc, hoveredAirportId, selectedAirportId, selectedRoute } =
+    context;
+  const hoveredTrackFlightId =
+    hoveredArc && 'flightId' in hoveredArc ? hoveredArc.flightId : undefined;
+
+  if (hoveredTrackFlightId !== undefined) {
+    if ('flightId' in arc && arc.flightId === hoveredTrackFlightId) {
+      return interaction('primary');
+    }
+    if (!('flightId' in arc) && hoveredArc && arcsShareRoute(arc, hoveredArc)) {
+      return interaction('primary');
+    }
+    return hoveredArc && arcsShareRoute(arc, hoveredArc)
+      ? interaction('secondary')
+      : interaction('dimmed', 200);
+  }
+
+  if (
+    (hoveredArc?.from === arc.from && hoveredArc?.to === arc.to) ||
+    routeMatchesArc(arc, selectedRoute)
+  ) {
+    return interaction('primary');
+  }
+  if (hoveredArc) return interaction('dimmed', 200);
+  if (hoveredAirportId !== undefined) {
+    return hoveredAirportId === arc.from.id || hoveredAirportId === arc.to.id
+      ? interaction('normal')
+      : interaction('dimmed', 200);
+  }
+  if (selectedAirportId) {
+    return selectedAirportId === arc.from.id || selectedAirportId === arc.to.id
+      ? interaction('normal')
+      : interaction('dimmed', 170);
+  }
+  return selectedRoute ? interaction('dimmed', 170) : interaction('normal');
+};
+
+const PRIMARY_COLOR: Color = [16, 185, 129];
+const SECONDARY_COLOR: Color = [14, 165, 233];
+const INACTIVE_COLOR = (alpha: number): Color => [113, 113, 122, alpha];
+
+export const applyFlightTrackInteractionColor = (
+  state: RouteInteraction,
+  baseColor: Color,
+): Color => {
+  if (state.emphasis === 'primary') return PRIMARY_COLOR;
+  if (state.emphasis === 'secondary') return SECONDARY_COLOR;
+  if (state.emphasis === 'dimmed') return INACTIVE_COLOR(state.opacity);
+  return baseColor;
+};
+
+export const getEstimatedTrackUnderlayColor = (
+  state: RouteInteraction,
+): Color => [
+  0,
+  0,
+  0,
+  state.emphasis === 'dimmed' ? Math.round(state.opacity * 0.3) : 176,
+];
+
+export const getGroundTrackCasingColor = (
+  state: RouteInteraction,
+  darkMode: boolean,
+): Color => {
+  const alpha =
+    state.emphasis === 'dimmed' ? Math.round(state.opacity * 0.75) : 220;
+  return darkMode ? [9, 9, 11, alpha] : [250, 250, 250, alpha];
+};

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -16,6 +16,7 @@ const paths = [
       [12, 57, 609.6],
     ],
     estimated: [false, false, true],
+    ground: [true, false, false],
   },
 ] as FlightTrackPath[];
 
@@ -61,6 +62,7 @@ describe('flight track layers', () => {
     const standardData = prepareFlightTrackLayerData(paths, 'standard');
     expect(standardData.solidRuns).toHaveLength(1);
     expect(standardData.estimatedRuns).toHaveLength(1);
+    expect(standardData.groundRuns).toHaveLength(0);
     expect(standardData.solidRuns[0]).toMatchObject({
       altitudeFeet: null,
       estimated: false,
@@ -69,6 +71,7 @@ describe('flight track layers', () => {
     const altitudeData = prepareFlightTrackLayerData(paths, 'altitude');
     expect(altitudeData.solidRuns).toHaveLength(1);
     expect(altitudeData.estimatedRuns).toHaveLength(1);
+    expect(altitudeData.groundRuns).toHaveLength(1);
   });
 
   it('renders estimated standard segments through the dotted layers', () => {
@@ -81,6 +84,7 @@ describe('flight track layers', () => {
       getWidth: () => 2,
       getStandardColor: () => [1, 2, 3],
       getAltitudeColor: () => [4, 5, 6],
+      getGroundCasingColor: () => [9, 9, 11, 220],
       getEstimatedUnderlayColor: () => [24, 24, 27, 190],
       widthUpdateTriggers: [],
       standardColorUpdateTriggers: [],
@@ -91,10 +95,11 @@ describe('flight track layers', () => {
 
     expect(layers[0]!.props.data).toBe(data.solidRuns);
     expect(layers[1]!.props.data).toEqual([]);
-    expect(layers[2]!.props.data).toBe(data.estimatedRuns);
+    expect(layers[2]!.props.data).toEqual([]);
     expect(layers[3]!.props.data).toBe(data.estimatedRuns);
+    expect(layers[4]!.props.data).toBe(data.estimatedRuns);
     expect(
-      layers[3]!.props.getColor(data.estimatedRuns[0], {
+      layers[4]!.props.getColor(data.estimatedRuns[0], {
         index: 0,
         data: data.estimatedRuns,
         target: [],
@@ -112,6 +117,7 @@ describe('flight track layers', () => {
       getWidth: () => 2,
       getStandardColor: () => [0, 0, 0],
       getAltitudeColor: () => [0, 0, 0],
+      getGroundCasingColor: () => [9, 9, 11, 220],
       getEstimatedUnderlayColor: () => [24, 24, 27, 190],
       widthUpdateTriggers: [],
       standardColorUpdateTriggers: [],
@@ -122,15 +128,18 @@ describe('flight track layers', () => {
 
     expect(layers.map((layer) => layer.id)).toEqual([
       'track-path-layer',
+      'ground-track-casing-layer',
       'altitude-track-path-layer',
       'estimated-track-underlay-layer',
       'estimated-track-path-layer',
       'ghost-track-path',
     ]);
     expect(layers[0]!.props.data).toEqual([]);
-    expect(layers[1]!.props.data).toBe(data.solidRuns);
-    expect(layers[2]!.props.data).toBe(data.estimatedRuns);
-    expect(layers[4]!.props.data).toBe(paths);
+    expect(layers[1]!.props.data).toBe(data.groundRuns);
+    expect(layers[1]!.props.getWidth(data.groundRuns[0])).toBe(4.5);
+    expect(layers[2]!.props.data).toBe(data.solidRuns);
+    expect(layers[3]!.props.data).toBe(data.estimatedRuns);
+    expect(layers[5]!.props.data).toBe(paths);
   });
 
   it('renders tracks on the map surface while retaining stored altitude', () => {
@@ -143,6 +152,7 @@ describe('flight track layers', () => {
       getWidth: () => 2,
       getStandardColor: () => [0, 0, 0],
       getAltitudeColor: () => [0, 0, 0],
+      getGroundCasingColor: () => [9, 9, 11, 220],
       getEstimatedUnderlayColor: () => [24, 24, 27, 60],
       widthUpdateTriggers: [],
       standardColorUpdateTriggers: [],
@@ -151,12 +161,12 @@ describe('flight track layers', () => {
       onClick: undefined,
     });
 
-    const visiblePath = layers[1]!.props.getPath(data.solidRuns[0], {
+    const visiblePath = layers[2]!.props.getPath(data.solidRuns[0], {
       index: 0,
       data: data.solidRuns,
       target: [],
     });
-    const pickingPath = layers[4]!.props.getPath(paths[0], {
+    const pickingPath = layers[5]!.props.getPath(paths[0], {
       index: 0,
       data: paths,
       target: [],
@@ -173,7 +183,7 @@ describe('flight track layers', () => {
     ]);
     expect(paths[0]!.path[1]).toEqual([11, 56, 304.8]);
     expect(
-      layers[2]!.props.getColor(data.estimatedRuns[0], {
+      layers[3]!.props.getColor(data.estimatedRuns[0], {
         index: 0,
         data: data.estimatedRuns,
         target: [],

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -57,16 +57,49 @@ describe('flight track layers', () => {
     }
   });
 
-  it('only prepares altitude runs when the altitude style is active', () => {
-    expect(prepareFlightTrackLayerData(paths, 'standard')).toEqual({
-      paths,
-      solidRuns: [],
-      estimatedRuns: [],
+  it('prepares estimated runs for every track style', () => {
+    const standardData = prepareFlightTrackLayerData(paths, 'standard');
+    expect(standardData.solidRuns).toHaveLength(1);
+    expect(standardData.estimatedRuns).toHaveLength(1);
+    expect(standardData.solidRuns[0]).toMatchObject({
+      altitudeFeet: null,
+      estimated: false,
     });
 
     const altitudeData = prepareFlightTrackLayerData(paths, 'altitude');
     expect(altitudeData.solidRuns).toHaveLength(1);
     expect(altitudeData.estimatedRuns).toHaveLength(1);
+  });
+
+  it('renders estimated standard segments through the dotted layers', () => {
+    const data = prepareFlightTrackLayerData(paths, 'standard');
+    const layers = buildFlightTrackLayers({
+      data,
+      style: 'standard',
+      parameters: {},
+      extensions: [],
+      getWidth: () => 2,
+      getStandardColor: () => [1, 2, 3],
+      getAltitudeColor: () => [4, 5, 6],
+      getEstimatedUnderlayColor: () => [24, 24, 27, 190],
+      widthUpdateTriggers: [],
+      standardColorUpdateTriggers: [],
+      altitudeColorUpdateTriggers: [],
+      onHover: undefined,
+      onClick: undefined,
+    });
+
+    expect(layers[0]!.props.data).toBe(data.solidRuns);
+    expect(layers[1]!.props.data).toEqual([]);
+    expect(layers[2]!.props.data).toBe(data.estimatedRuns);
+    expect(layers[3]!.props.data).toBe(data.estimatedRuns);
+    expect(
+      layers[3]!.props.getColor(data.estimatedRuns[0], {
+        index: 0,
+        data: data.estimatedRuns,
+        target: [],
+      }),
+    ).toEqual([1, 2, 3]);
   });
 
   it('owns the complete ordered flight-track layer stack', () => {

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -1,32 +1,78 @@
-import { describe, expect, it } from 'vitest';
+import type { Color } from '@deck.gl/core';
 import { distance, point } from '@turf/turf';
+import { describe, expect, it } from 'vitest';
 
 import type { FlightTrackPath } from './flight-layer-data';
 import {
   buildFlightTrackDisplayPath,
+  MAX_FLIGHT_TRACK_DISPLAY_POINTS,
+} from './flight-track-display-geometry';
+import {
   buildFlightTrackLayers,
+  type FlightTrackRenderContext,
   prepareFlightTrackLayerData,
+  type RenderableFlightTrackPath,
+  type RenderableFlightTrackRun,
 } from './flight-track-layers';
+
+import {
+  toFlightTrackSamples,
+  type FlightTrackCoordinate,
+} from '$lib/track/schema';
 
 const paths = [
   {
     flightId: 1,
-    path: [
-      [10, 55, 0],
-      [11, 56, 304.8],
-      [12, 57, 609.6],
-    ],
-    estimated: [false, false, true],
-    ground: [true, false, false],
+    samples: toFlightTrackSamples({
+      coordinates: [
+        [10, 55, 0],
+        [11, 56, 304.8],
+        [12, 57, 609.6],
+      ],
+      estimated: [false, false, true],
+      ground: [true, false, false],
+    }),
   },
 ] as FlightTrackPath[];
+
+const renderContext = ({
+  standardColor = [0, 0, 0],
+  estimatedUnderlayColor = [24, 24, 27, 190],
+}: {
+  standardColor?: Color;
+  estimatedUnderlayColor?: Color;
+} = {}): FlightTrackRenderContext => ({
+  geometry: { parameters: {}, extensions: [] },
+  appearance: {
+    getWidth: () => 2,
+    getStandardColor: () => standardColor,
+    getAltitudeColor: () => [4, 5, 6],
+    getGroundCasingColor: () => [9, 9, 11, 220],
+    getEstimatedUnderlayColor: () => estimatedUnderlayColor,
+    updateTriggers: { width: [], standardColor: [], altitudeColor: [] },
+  },
+  interaction: { onHover: undefined, onClick: undefined },
+});
+
+type RuntimePathLayerProps<T> = {
+  data: T[];
+  getWidth: (value: T) => number;
+  getColor: (value: T, info?: unknown) => Color;
+  getPath: (value: T, info?: unknown) => [number, number][];
+  getDashArray: (value: T) => [number, number];
+  widthMinPixels: number;
+  capRounded: boolean;
+};
+
+const runtimeProps = <T>(layer: { props: unknown }) =>
+  layer.props as RuntimePathLayerProps<T>;
 
 describe('flight track layers', () => {
   it('adaptively follows the globe without changing source coordinates', () => {
     const source = [
       [0, 0, 100],
       [179, 0, 1_000],
-    ] as FlightTrackPath['path'];
+    ] as FlightTrackCoordinate[];
 
     const display = buildFlightTrackDisplayPath(source);
 
@@ -78,6 +124,49 @@ describe('flight track layers', () => {
     ).toHaveLength(5);
   });
 
+  it('bounds tessellation for pathological maximum-size tracks', () => {
+    const source: FlightTrackCoordinate[] = Array.from(
+      { length: 5_000 },
+      (_, index): FlightTrackCoordinate =>
+        index % 2 === 0 ? [0, 0] : [179, 0],
+    );
+
+    const display = buildFlightTrackDisplayPath(source);
+
+    expect(display.length).toBeLessThanOrEqual(MAX_FLIGHT_TRACK_DISPLAY_POINTS);
+    expect(display[0]).toEqual(source[0]);
+    expect(display.at(-1)).toEqual(source.at(-1));
+  });
+
+  it('shares the display budget across every layer generated for a track', () => {
+    const coordinates: FlightTrackCoordinate[] = Array.from(
+      { length: 100 },
+      (_, index) => [index % 2 === 0 ? 0 : 179, 0, index * 100],
+    );
+    const data = prepareFlightTrackLayerData(
+      [
+        {
+          flightId: 2,
+          samples: toFlightTrackSamples({ coordinates }),
+        } as FlightTrackPath,
+      ],
+      'altitude',
+    );
+    const renderedPointCount =
+      data.paths.reduce((total, path) => total + path.displayPath.length, 0) +
+      data.solidRuns.reduce((total, run) => total + run.displayPath.length, 0) +
+      2 *
+        data.estimatedRuns.reduce(
+          (total, run) => total + run.displayPath.length,
+          0,
+        ) +
+      data.groundRuns.reduce((total, run) => total + run.displayPath.length, 0);
+
+    expect(renderedPointCount).toBeLessThanOrEqual(
+      MAX_FLIGHT_TRACK_DISPLAY_POINTS,
+    );
+  });
+
   it('prepares estimated runs for every track style', () => {
     const standardData = prepareFlightTrackLayerData(paths, 'standard');
     expect(standardData.solidRuns).toHaveLength(1);
@@ -99,18 +188,7 @@ describe('flight track layers', () => {
     const layers = buildFlightTrackLayers({
       data,
       style: 'standard',
-      parameters: {},
-      extensions: [],
-      getWidth: () => 2,
-      getStandardColor: () => [1, 2, 3],
-      getAltitudeColor: () => [4, 5, 6],
-      getGroundCasingColor: () => [9, 9, 11, 220],
-      getEstimatedUnderlayColor: () => [24, 24, 27, 190],
-      widthUpdateTriggers: [],
-      standardColorUpdateTriggers: [],
-      altitudeColorUpdateTriggers: [],
-      onHover: undefined,
-      onClick: undefined,
+      context: renderContext({ standardColor: [1, 2, 3] }),
     });
 
     expect(layers[0]!.props.data).toBe(data.solidRuns);
@@ -118,15 +196,17 @@ describe('flight track layers', () => {
     expect(layers[2]!.props.data).toEqual([]);
     expect(layers[3]!.props.data).toBe(data.estimatedRuns);
     expect(layers[4]!.props.data).toBe(data.estimatedRuns);
-    expect(layers[3]!.props.getWidth(data.estimatedRuns[0])).toBeCloseTo(1.12);
-    expect(layers[3]!.props.widthMinPixels).toBe(1);
-    expect(layers[3]!.props.capRounded).toBe(true);
-    expect(layers[4]!.props.capRounded).toBe(true);
-    expect(layers[4]!.props.getWidth(data.estimatedRuns[0])).toBe(2);
-    const dashArray = layers[4]!.props.getDashArray(data.estimatedRuns[0]);
+    const underlayProps = runtimeProps<RenderableFlightTrackRun>(layers[3]!);
+    const estimatedProps = runtimeProps<RenderableFlightTrackRun>(layers[4]!);
+    expect(underlayProps.getWidth(data.estimatedRuns[0]!)).toBeCloseTo(1.12);
+    expect(underlayProps.widthMinPixels).toBe(1);
+    expect(underlayProps.capRounded).toBe(true);
+    expect(estimatedProps.capRounded).toBe(true);
+    expect(estimatedProps.getWidth(data.estimatedRuns[0]!)).toBe(2);
+    const dashArray = estimatedProps.getDashArray(data.estimatedRuns[0]!);
     expect(dashArray).toEqual([10, 23]);
     expect(
-      layers[4]!.props.getColor(data.estimatedRuns[0], {
+      estimatedProps.getColor(data.estimatedRuns[0]!, {
         index: 0,
         data: data.estimatedRuns,
         target: [],
@@ -139,18 +219,7 @@ describe('flight track layers', () => {
     const layers = buildFlightTrackLayers({
       data,
       style: 'altitude',
-      parameters: {},
-      extensions: [],
-      getWidth: () => 2,
-      getStandardColor: () => [0, 0, 0],
-      getAltitudeColor: () => [0, 0, 0],
-      getGroundCasingColor: () => [9, 9, 11, 220],
-      getEstimatedUnderlayColor: () => [24, 24, 27, 190],
-      widthUpdateTriggers: [],
-      standardColorUpdateTriggers: [],
-      altitudeColorUpdateTriggers: [],
-      onHover: undefined,
-      onClick: undefined,
+      context: renderContext(),
     });
 
     expect(layers.map((layer) => layer.id)).toEqual([
@@ -163,10 +232,14 @@ describe('flight track layers', () => {
     ]);
     expect(layers[0]!.props.data).toEqual([]);
     expect(layers[1]!.props.data).toBe(data.groundRuns);
-    expect(layers[1]!.props.getWidth(data.groundRuns[0])).toBe(4.5);
+    expect(
+      runtimeProps<RenderableFlightTrackRun>(layers[1]!).getWidth(
+        data.groundRuns[0]!,
+      ),
+    ).toBe(4.5);
     expect(layers[2]!.props.data).toBe(data.solidRuns);
     expect(layers[3]!.props.data).toBe(data.estimatedRuns);
-    expect(layers[5]!.props.data).toBe(paths);
+    expect(layers[5]!.props.data).toBe(data.paths);
   });
 
   it('renders tracks on the map surface while retaining stored altitude', () => {
@@ -174,28 +247,21 @@ describe('flight track layers', () => {
     const layers = buildFlightTrackLayers({
       data,
       style: 'altitude',
-      parameters: {},
-      extensions: [],
-      getWidth: () => 2,
-      getStandardColor: () => [0, 0, 0],
-      getAltitudeColor: () => [0, 0, 0],
-      getGroundCasingColor: () => [9, 9, 11, 220],
-      getEstimatedUnderlayColor: () => [24, 24, 27, 60],
-      widthUpdateTriggers: [],
-      standardColorUpdateTriggers: [],
-      altitudeColorUpdateTriggers: [],
-      onHover: undefined,
-      onClick: undefined,
+      context: renderContext({ estimatedUnderlayColor: [24, 24, 27, 60] }),
     });
 
-    const visiblePath = layers[2]!.props.getPath(data.solidRuns[0], {
+    const visiblePath = runtimeProps<RenderableFlightTrackRun>(
+      layers[2]!,
+    ).getPath(data.solidRuns[0]!, {
       index: 0,
       data: data.solidRuns,
       target: [],
     });
-    const pickingPath = layers[5]!.props.getPath(paths[0], {
+    const pickingPath = runtimeProps<RenderableFlightTrackPath>(
+      layers[5]!,
+    ).getPath(data.paths[0]!, {
       index: 0,
-      data: paths,
+      data: data.paths,
       target: [],
     });
 
@@ -207,13 +273,16 @@ describe('flight track layers', () => {
     expect(pickingPath.every((coordinate) => coordinate.length === 2)).toBe(
       true,
     );
-    expect(paths[0]!.path[1]).toEqual([11, 56, 304.8]);
+    expect(paths[0]!.samples[1]!.coordinate).toEqual([11, 56, 304.8]);
     expect(
-      layers[3]!.props.getColor(data.estimatedRuns[0], {
-        index: 0,
-        data: data.estimatedRuns,
-        target: [],
-      }),
+      runtimeProps<RenderableFlightTrackRun>(layers[3]!).getColor(
+        data.estimatedRuns[0]!,
+        {
+          index: 0,
+          data: data.estimatedRuns,
+          target: [],
+        },
+      ),
     ).toEqual([24, 24, 27, 60]);
   });
 });

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -2,7 +2,11 @@ import type { Color } from '@deck.gl/core';
 import { distance, point } from '@turf/turf';
 import { describe, expect, it } from 'vitest';
 
-import type { FlightTrackPath } from './flight-layer-data';
+import {
+  buildFlightTrackPaths,
+  type FlightArc,
+  type FlightTrackPath,
+} from './flight-layer-data';
 import {
   buildFlightTrackDisplayPath,
   MAX_FLIGHT_TRACK_DISPLAY_POINTS,
@@ -18,7 +22,9 @@ import {
 import {
   toFlightTrackSamples,
   type FlightTrackCoordinate,
+  type FlightTrackRow,
 } from '$lib/track/schema';
+import type { FlightData } from '$lib/utils';
 
 const paths = [
   {
@@ -93,19 +99,73 @@ describe('flight track layers', () => {
   });
 
   it('keeps generated antimeridian geometry continuous', () => {
-    const display = buildFlightTrackDisplayPath([
+    const source = [
       [170, 10],
-      [190, 10],
-    ]);
+      [-170, 10],
+    ] as FlightTrackCoordinate[];
+    const display = buildFlightTrackDisplayPath(source);
 
     expect(display[0]).toEqual([170, 10]);
     expect(display.at(-1)).toEqual([190, 10]);
+    expect(source).toEqual([
+      [170, 10],
+      [-170, 10],
+    ]);
     for (let index = 1; index < display.length; index++) {
+      expect(
+        Math.abs(display[index]![0] - display[index - 1]![0]),
+      ).toBeLessThan(180);
       expect(
         distance(point(display[index - 1]!), point(display[index]!), {
           units: 'meters',
         }),
       ).toBeLessThanOrEqual(19_000.001);
+    }
+  });
+
+  it('unwraps short antimeridian crossings without tessellation', () => {
+    const source = [
+      [179.9, 10],
+      [-179.9, 10],
+    ] as FlightTrackCoordinate[];
+
+    const display = buildFlightTrackDisplayPath(source);
+
+    expect(display).toHaveLength(2);
+    expect(display[0]).toEqual([179.9, 10]);
+    expect(display[1]![0]).toBeCloseTo(180.1);
+    expect(display[1]![1]).toBe(10);
+    expect(source).toEqual([
+      [179.9, 10],
+      [-179.9, 10],
+    ]);
+  });
+
+  it('unwraps canonical crossings only in full-pipeline display geometry', () => {
+    const coordinates = [
+      [170, 10, 1_000],
+      [-170, 10, 2_000],
+    ] as FlightTrackRow['coordinates'];
+    const trackPaths = buildFlightTrackPaths(
+      [{ id: 7, from: { id: 1 }, to: { id: 2 } }] as FlightData[],
+      [{ from: { id: 1 }, to: { id: 2 } }] as FlightArc[],
+      [{ flightId: 7, coordinates }] as FlightTrackRow[],
+    );
+
+    const data = prepareFlightTrackLayerData(trackPaths, 'standard');
+
+    expect(trackPaths[0]!.samples.map((sample) => sample.coordinate)).toEqual(
+      coordinates,
+    );
+    expect(data.paths[0]!.displayPath[0]).toEqual([170, 10]);
+    expect(data.paths[0]!.displayPath.at(-1)).toEqual([190, 10]);
+    for (let index = 1; index < data.paths[0]!.displayPath.length; index++) {
+      expect(
+        Math.abs(
+          data.paths[0]!.displayPath[index]![0] -
+            data.paths[0]!.displayPath[index - 1]![0],
+        ),
+      ).toBeLessThan(180);
     }
   });
 

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { distance, point } from '@turf/turf';
 
 import type { FlightTrackPath } from './flight-layer-data';
 import {
@@ -29,7 +30,7 @@ describe('flight track layers', () => {
 
     const display = buildFlightTrackDisplayPath(source);
 
-    expect(display).toHaveLength(61);
+    expect(display).toHaveLength(2_049);
     expect(display[0]).toEqual([0, 0]);
     expect(display.at(-1)).toEqual([179, 0]);
     expect(source).toEqual([
@@ -38,8 +39,10 @@ describe('flight track layers', () => {
     ]);
     for (let index = 1; index < display.length; index++) {
       expect(
-        Math.abs(display[index]![0] - display[index - 1]![0]),
-      ).toBeLessThanOrEqual(3);
+        distance(point(display[index - 1]!), point(display[index]!), {
+          units: 'meters',
+        }),
+      ).toBeLessThanOrEqual(19_000.001);
     }
   });
 
@@ -53,9 +56,26 @@ describe('flight track layers', () => {
     expect(display.at(-1)).toEqual([190, 10]);
     for (let index = 1; index < display.length; index++) {
       expect(
-        Math.abs(display[index]![0] - display[index - 1]![0]),
-      ).toBeLessThanOrEqual(3);
+        distance(point(display[index - 1]!), point(display[index]!), {
+          units: 'meters',
+        }),
+      ).toBeLessThanOrEqual(19_000.001);
     }
+  });
+
+  it('uses tar1090 distance thresholds and power-of-two subdivision', () => {
+    expect(
+      buildFlightTrackDisplayPath([
+        [0, 0],
+        [0.2, 0],
+      ]),
+    ).toHaveLength(2);
+    expect(
+      buildFlightTrackDisplayPath([
+        [0, 0],
+        [0.4, 0],
+      ]),
+    ).toHaveLength(5);
   });
 
   it('prepares estimated runs for every track style', () => {
@@ -98,6 +118,13 @@ describe('flight track layers', () => {
     expect(layers[2]!.props.data).toEqual([]);
     expect(layers[3]!.props.data).toBe(data.estimatedRuns);
     expect(layers[4]!.props.data).toBe(data.estimatedRuns);
+    expect(layers[3]!.props.getWidth(data.estimatedRuns[0])).toBeCloseTo(1.12);
+    expect(layers[3]!.props.widthMinPixels).toBe(1);
+    expect(layers[3]!.props.capRounded).toBe(true);
+    expect(layers[4]!.props.capRounded).toBe(true);
+    expect(layers[4]!.props.getWidth(data.estimatedRuns[0])).toBe(2);
+    const dashArray = layers[4]!.props.getDashArray(data.estimatedRuns[0]);
+    expect(dashArray).toEqual([10, 23]);
     expect(
       layers[4]!.props.getColor(data.estimatedRuns[0], {
         index: 0,
@@ -172,15 +199,14 @@ describe('flight track layers', () => {
       target: [],
     });
 
-    expect(visiblePath).toEqual([
-      [10, 55],
-      [11, 56],
-    ]);
-    expect(pickingPath).toEqual([
-      [10, 55],
-      [11, 56],
-      [12, 57],
-    ]);
+    expect(visiblePath[0]).toEqual([10, 55]);
+    expect(visiblePath.at(-1)).toEqual([11, 56]);
+    expect(visiblePath).toHaveLength(9);
+    expect(pickingPath[0]).toEqual([10, 55]);
+    expect(pickingPath.at(-1)).toEqual([12, 57]);
+    expect(pickingPath.every((coordinate) => coordinate.length === 2)).toBe(
+      true,
+    );
     expect(paths[0]!.path[1]).toEqual([11, 56, 304.8]);
     expect(
       layers[3]!.props.getColor(data.estimatedRuns[0], {

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -141,6 +141,29 @@ describe('flight track layers', () => {
     ]);
   });
 
+  it('keeps antipodal fallback geometry continuous after a crossing', () => {
+    const source = [
+      [170, 10],
+      [-170, 10],
+      [10, -10],
+    ] as FlightTrackCoordinate[];
+
+    const display = buildFlightTrackDisplayPath(source);
+
+    expect(display[0]).toEqual([170, 10]);
+    expect(display.at(-1)).toEqual([370, -10]);
+    expect(source).toEqual([
+      [170, 10],
+      [-170, 10],
+      [10, -10],
+    ]);
+    for (let index = 1; index < display.length; index++) {
+      expect(
+        Math.abs(display[index]![0] - display[index - 1]![0]),
+      ).toBeLessThan(180);
+    }
+  });
+
   it('unwraps canonical crossings only in full-pipeline display geometry', () => {
     const coordinates = [
       [170, 10, 1_000],

--- a/src/lib/map/flight-track-layers.test.ts
+++ b/src/lib/map/flight-track-layers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { FlightTrackPath } from './flight-layer-data';
 import {
+  buildFlightTrackDisplayPath,
   buildFlightTrackLayers,
   prepareFlightTrackLayerData,
 } from './flight-track-layers';
@@ -19,6 +20,43 @@ const paths = [
 ] as FlightTrackPath[];
 
 describe('flight track layers', () => {
+  it('adaptively follows the globe without changing source coordinates', () => {
+    const source = [
+      [0, 0, 100],
+      [179, 0, 1_000],
+    ] as FlightTrackPath['path'];
+
+    const display = buildFlightTrackDisplayPath(source);
+
+    expect(display).toHaveLength(61);
+    expect(display[0]).toEqual([0, 0]);
+    expect(display.at(-1)).toEqual([179, 0]);
+    expect(source).toEqual([
+      [0, 0, 100],
+      [179, 0, 1_000],
+    ]);
+    for (let index = 1; index < display.length; index++) {
+      expect(
+        Math.abs(display[index]![0] - display[index - 1]![0]),
+      ).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('keeps generated antimeridian geometry continuous', () => {
+    const display = buildFlightTrackDisplayPath([
+      [170, 10],
+      [190, 10],
+    ]);
+
+    expect(display[0]).toEqual([170, 10]);
+    expect(display.at(-1)).toEqual([190, 10]);
+    for (let index = 1; index < display.length; index++) {
+      expect(
+        Math.abs(display[index]![0] - display[index - 1]![0]),
+      ).toBeLessThanOrEqual(3);
+    }
+  });
+
   it('only prepares altitude runs when the altitude style is active', () => {
     expect(prepareFlightTrackLayerData(paths, 'standard')).toEqual({
       paths,

--- a/src/lib/map/flight-track-layers.ts
+++ b/src/lib/map/flight-track-layers.ts
@@ -1,9 +1,13 @@
-import type { Color, Layer, LayerExtension } from '@deck.gl/core';
+import type { Color, LayerExtension } from '@deck.gl/core';
 import { PathStyleExtension } from '@deck.gl/extensions';
 import { PathLayer, type PathLayerProps } from '@deck.gl/layers';
-import { distance, point } from '@turf/turf';
 
-import type { FlightArc, FlightTrackPath } from './flight-layer-data';
+import type {
+  FlightArc,
+  FlightTrackIdentity,
+  FlightTrackPath,
+} from './flight-layer-data';
+import { buildFlightTrackDisplayPaths } from './flight-track-display-geometry';
 import {
   buildFlightTrackRuns,
   type FlightTrackRun,
@@ -14,227 +18,120 @@ type PathParameters = PathLayerProps<FlightTrackPath>['parameters'];
 type PathHoverHandler = PathLayerProps<FlightTrackPath>['onHover'];
 type PathClickHandler = PathLayerProps<FlightTrackPath>['onClick'];
 
+export type RenderableFlightTrackPath = FlightTrackPath & {
+  displayPath: [number, number][];
+};
+
+export type RenderableFlightTrackRun = FlightTrackRun & {
+  displayPath: [number, number][];
+};
+
 export type FlightTrackLayerData = {
-  paths: FlightTrackPath[];
-  solidRuns: FlightTrackRun[];
-  estimatedRuns: FlightTrackRun[];
-  groundRuns: FlightTrackRun[];
+  paths: RenderableFlightTrackPath[];
+  solidRuns: RenderableFlightTrackRun[];
+  estimatedRuns: RenderableFlightTrackRun[];
+  groundRuns: RenderableFlightTrackRun[];
 };
 
 type FlightTrackLayerOptions = {
   data: FlightTrackLayerData;
   style: FlightTrackStyle;
-  parameters: PathParameters;
-  extensions: LayerExtension[];
-  getWidth: (track: FlightArc) => number;
-  getStandardColor: (track: FlightTrackPath) => Color;
-  getAltitudeColor: (run: FlightTrackRun) => Color;
-  getGroundCasingColor: (run: FlightTrackRun) => Color;
-  getEstimatedUnderlayColor: (run: FlightTrackRun) => Color;
-  widthUpdateTriggers: unknown[];
-  standardColorUpdateTriggers: unknown[];
-  altitudeColorUpdateTriggers: unknown[];
-  onHover: PathHoverHandler;
-  onClick: PathClickHandler;
+  context: FlightTrackRenderContext;
+};
+
+export type FlightTrackRenderContext = {
+  geometry: {
+    parameters: PathParameters;
+    extensions: LayerExtension[];
+  };
+  appearance: {
+    getWidth: (track: FlightArc) => number;
+    getStandardColor: (track: FlightTrackIdentity) => Color;
+    getAltitudeColor: (run: FlightTrackRun) => Color;
+    getGroundCasingColor: (run: FlightTrackRun) => Color;
+    getEstimatedUnderlayColor: (run: FlightTrackRun) => Color;
+    updateTriggers: {
+      width: readonly unknown[];
+      standardColor: readonly unknown[];
+      altitudeColor: readonly unknown[];
+    };
+  };
+  interaction: {
+    onHover: PathHoverHandler;
+    onClick: PathClickHandler;
+  };
 };
 
 const estimatedPathStyle = new PathStyleExtension({
   dash: true,
   highPrecisionDash: true,
 });
-
-const surfacePathCache = new WeakMap<
-  FlightTrackPath['path'],
-  [number, number][]
->();
-
-const GREAT_CIRCLE_MIN_DISTANCE_METERS = 30_000;
-const GREAT_CIRCLE_TARGET_SEGMENT_METERS = 19_000;
 const ESTIMATED_UNDERLAY_WIDTH_SCALE = 0.56;
-
-const normalizeLongitude = (longitude: number) =>
-  ((((longitude + 180) % 360) + 360) % 360) - 180;
-
-const unwrapLongitude = (longitude: number, previous: number) => {
-  let unwrapped = longitude;
-  while (unwrapped - previous > 180) unwrapped -= 360;
-  while (unwrapped - previous < -180) unwrapped += 360;
-  return unwrapped;
-};
-
-const interpolateLinearSegment = (
-  path: [number, number][],
-  start: FlightTrackPath['path'][number],
-  end: FlightTrackPath['path'][number],
-  segmentCount: number,
-) => {
-  for (let index = 1; index < segmentCount; index++) {
-    const progress = index / segmentCount;
-    path.push([
-      start[0] + (end[0] - start[0]) * progress,
-      start[1] + (end[1] - start[1]) * progress,
-    ]);
-  }
-};
-
-const greatCircleMidpoint = (
-  from: [number, number],
-  to: [number, number],
-): [number, number] | null => {
-  const longitude1 = (from[0] * Math.PI) / 180;
-  const latitude1 = (from[1] * Math.PI) / 180;
-  const longitude2 = (to[0] * Math.PI) / 180;
-  const latitude2 = (to[1] * Math.PI) / 180;
-  const longitudeDifference = longitude2 - longitude1;
-  const bx = Math.cos(latitude2) * Math.cos(longitudeDifference);
-  const by = Math.cos(latitude2) * Math.sin(longitudeDifference);
-  const x = Math.cos(latitude1) + bx;
-  const y = by;
-
-  if (Math.hypot(x, y) < Number.EPSILON) return null;
-
-  const latitude = Math.atan2(
-    Math.sin(latitude1) + Math.sin(latitude2),
-    Math.hypot(x, y),
-  );
-  const longitude = longitude1 + Math.atan2(by, x);
-  return [
-    normalizeLongitude((longitude * 180) / Math.PI),
-    (latitude * 180) / Math.PI,
-  ];
-};
-
-const subdivideGreatCircle = (
-  start: [number, number],
-  end: [number, number],
-  depth: number,
-) => {
-  let coordinates = [start, end];
-
-  for (let level = 0; level < depth; level++) {
-    const subdivided: [number, number][] = [coordinates[0]!];
-    for (let index = 1; index < coordinates.length; index++) {
-      const midpoint = greatCircleMidpoint(
-        coordinates[index - 1]!,
-        coordinates[index]!,
-      );
-      if (!midpoint) return null;
-      subdivided.push(midpoint, coordinates[index]!);
-    }
-    coordinates = subdivided;
-  }
-
-  return coordinates;
-};
-
-export const buildFlightTrackDisplayPath = (
-  sourcePath: FlightTrackPath['path'],
-) => {
-  if (!sourcePath.length) return [];
-
-  const displayPath: [number, number][] = [
-    [sourcePath[0]![0], sourcePath[0]![1]],
-  ];
-
-  for (let index = 1; index < sourcePath.length; index++) {
-    const start = sourcePath[index - 1]!;
-    const end = sourcePath[index]!;
-    const normalizedStart: [number, number] = [
-      normalizeLongitude(start[0]),
-      start[1],
-    ];
-    const normalizedEnd: [number, number] = [
-      normalizeLongitude(end[0]),
-      end[1],
-    ];
-    const segmentDistance = distance(
-      point(normalizedStart),
-      point(normalizedEnd),
-      {
-        units: 'meters',
-      },
-    );
-    const subdivisionDepth =
-      segmentDistance > GREAT_CIRCLE_MIN_DISTANCE_METERS
-        ? Math.ceil(
-            Math.log2(segmentDistance / GREAT_CIRCLE_TARGET_SEGMENT_METERS),
-          )
-        : 0;
-
-    if (subdivisionDepth > 0) {
-      const arc = subdivideGreatCircle(
-        normalizedStart,
-        normalizedEnd,
-        subdivisionDepth,
-      );
-
-      if (arc) {
-        for (const coordinate of arc.slice(1, -1)) {
-          const previousLongitude = displayPath.at(-1)![0];
-          displayPath.push([
-            unwrapLongitude(coordinate[0], previousLongitude),
-            coordinate[1],
-          ]);
-        }
-      } else {
-        // Antipodal points have no unique great-circle route. A deterministic
-        // surface interpolation still avoids drawing a chord through the globe.
-        interpolateLinearSegment(
-          displayPath,
-          start,
-          end,
-          2 ** subdivisionDepth,
-        );
-      }
-    }
-
-    displayPath.push([end[0], end[1]]);
-  }
-
-  return displayPath;
-};
-
-const getSurfacePath = (track: Pick<FlightTrackPath, 'path'>) => {
-  const cached = surfacePathCache.get(track.path);
-  if (cached) return cached;
-
-  const path = buildFlightTrackDisplayPath(track.path);
-  surfacePathCache.set(track.path, path);
-  return path;
-};
 
 export const prepareFlightTrackLayerData = (
   paths: FlightTrackPath[],
   style: FlightTrackStyle,
 ): FlightTrackLayerData => {
-  const runs = buildFlightTrackRuns(paths, {
-    splitByAltitude: style === 'altitude',
-  });
+  const preparedPaths: RenderableFlightTrackPath[] = [];
+  const preparedRuns: RenderableFlightTrackRun[] = [];
+
+  for (const path of paths) {
+    const sourcePath = path.samples.map((sample) => sample.coordinate);
+    const runs = buildFlightTrackRuns([path], {
+      splitByAltitude: style === 'altitude',
+    });
+    const [trackDisplayPath, ...runDisplayPaths] = buildFlightTrackDisplayPaths(
+      [
+        { path: sourcePath, layerCount: 1 },
+        ...runs.map((run) => ({
+          path: run.path,
+          layerCount:
+            (run.estimated ? 2 : 1) +
+            (style === 'altitude' && run.ground ? 1 : 0),
+        })),
+      ],
+    );
+
+    preparedPaths.push({
+      ...path,
+      displayPath: trackDisplayPath!,
+    });
+    preparedRuns.push(
+      ...runs.map((run, index) => ({
+        ...run,
+        displayPath: runDisplayPaths[index]!,
+      })),
+    );
+  }
 
   return {
-    paths,
-    solidRuns: runs.filter((run) => !run.estimated),
-    estimatedRuns: runs.filter((run) => run.estimated),
-    groundRuns: runs.filter((run) => run.ground),
+    paths: preparedPaths,
+    solidRuns: preparedRuns.filter((run) => !run.estimated),
+    estimatedRuns: preparedRuns.filter((run) => run.estimated),
+    groundRuns: preparedRuns.filter((run) => run.ground),
   };
 };
 
 export const buildFlightTrackLayers = ({
   data,
   style,
-  parameters,
-  extensions,
-  getWidth,
-  getStandardColor,
-  getAltitudeColor,
-  getGroundCasingColor,
-  getEstimatedUnderlayColor,
-  widthUpdateTriggers,
-  standardColorUpdateTriggers,
-  altitudeColorUpdateTriggers,
-  onHover,
-  onClick,
-}: FlightTrackLayerOptions): Layer[] => {
+  context: {
+    geometry: { parameters, extensions },
+    appearance: {
+      getWidth,
+      getStandardColor,
+      getAltitudeColor,
+      getGroundCasingColor,
+      getEstimatedUnderlayColor,
+      updateTriggers: {
+        width: widthUpdateTriggers,
+        standardColor: standardColorUpdateTriggers,
+        altitudeColor: altitudeColorUpdateTriggers,
+      },
+    },
+    interaction: { onHover, onClick },
+  },
+}: FlightTrackLayerOptions) => {
   const sharedPathOptions = {
     parameters,
     getWidth,
@@ -246,12 +143,12 @@ export const buildFlightTrackLayers = ({
   };
 
   return [
-    new PathLayer<FlightTrackPath>({
+    new PathLayer<RenderableFlightTrackRun>({
       ...sharedPathOptions,
       id: 'track-path-layer',
       extensions,
       data: style === 'standard' ? data.solidRuns : [],
-      getPath: getSurfacePath,
+      getPath: (track) => track.displayPath,
       getColor: getStandardColor,
       capRounded: true,
       updateTriggers: {
@@ -259,12 +156,12 @@ export const buildFlightTrackLayers = ({
         getColor: standardColorUpdateTriggers,
       },
     }),
-    new PathLayer<FlightTrackRun>({
+    new PathLayer<RenderableFlightTrackRun>({
       ...sharedPathOptions,
       id: 'ground-track-casing-layer',
       extensions,
       data: style === 'altitude' ? data.groundRuns : [],
-      getPath: getSurfacePath,
+      getPath: (run) => run.displayPath,
       getColor: getGroundCasingColor,
       getWidth: (run) => getWidth(run) + 2.5,
       capRounded: true,
@@ -273,12 +170,12 @@ export const buildFlightTrackLayers = ({
         getColor: altitudeColorUpdateTriggers,
       },
     }),
-    new PathLayer<FlightTrackRun>({
+    new PathLayer<RenderableFlightTrackRun>({
       ...sharedPathOptions,
       id: 'altitude-track-path-layer',
       extensions,
       data: style === 'altitude' ? data.solidRuns : [],
-      getPath: getSurfacePath,
+      getPath: (run) => run.displayPath,
       getColor: getAltitudeColor,
       capRounded: true,
       updateTriggers: {
@@ -286,12 +183,12 @@ export const buildFlightTrackLayers = ({
         getColor: altitudeColorUpdateTriggers,
       },
     }),
-    new PathLayer<FlightTrackRun>({
+    new PathLayer<RenderableFlightTrackRun>({
       ...sharedPathOptions,
       id: 'estimated-track-underlay-layer',
       extensions,
       data: data.estimatedRuns,
-      getPath: getSurfacePath,
+      getPath: (run) => run.displayPath,
       getColor: getEstimatedUnderlayColor,
       getWidth: (run) => getWidth(run) * ESTIMATED_UNDERLAY_WIDTH_SCALE,
       widthMinPixels: 1,
@@ -301,14 +198,14 @@ export const buildFlightTrackLayers = ({
         getColor: altitudeColorUpdateTriggers,
       },
     }),
-    new PathLayer<FlightTrackRun>({
+    new PathLayer<RenderableFlightTrackRun>({
       ...sharedPathOptions,
       id: 'estimated-track-path-layer',
       extensions: [...extensions, estimatedPathStyle],
       data: data.estimatedRuns,
-      getPath: getSurfacePath,
+      getPath: (run) => run.displayPath,
       getColor: style === 'standard' ? getStandardColor : getAltitudeColor,
-      getDashArray: (run) => {
+      getDashArray: (run: RenderableFlightTrackRun) => {
         const width = Math.max(1, getWidth(run));
         const halfWidth = width / 2;
         return [10 / halfWidth, (20 + 1.5 * width) / halfWidth];
@@ -324,13 +221,15 @@ export const buildFlightTrackLayers = ({
             : altitudeColorUpdateTriggers,
         getDashArray: widthUpdateTriggers,
       },
+    } as PathLayerProps<RenderableFlightTrackRun> & {
+      getDashArray: (run: RenderableFlightTrackRun) => [number, number];
     }),
-    new PathLayer<FlightTrackPath>({
+    new PathLayer<RenderableFlightTrackPath>({
       id: 'ghost-track-path',
       parameters,
       extensions,
       data: data.paths,
-      getPath: getSurfacePath,
+      getPath: (track) => track.displayPath,
       getColor: [0, 0, 0, 0],
       getWidth: 18,
       widthUnits: 'pixels',

--- a/src/lib/map/flight-track-layers.ts
+++ b/src/lib/map/flight-track-layers.ts
@@ -1,7 +1,7 @@
 import type { Color, Layer, LayerExtension } from '@deck.gl/core';
 import { PathStyleExtension } from '@deck.gl/extensions';
 import { PathLayer, type PathLayerProps } from '@deck.gl/layers';
-import { distance, greatCircle, point } from '@turf/turf';
+import { distance, point } from '@turf/turf';
 
 import type { FlightArc, FlightTrackPath } from './flight-layer-data';
 import {
@@ -48,7 +48,9 @@ const surfacePathCache = new WeakMap<
   [number, number][]
 >();
 
-const MAX_SURFACE_SEGMENT_DEGREES = 3;
+const GREAT_CIRCLE_MIN_DISTANCE_METERS = 30_000;
+const GREAT_CIRCLE_TARGET_SEGMENT_METERS = 19_000;
+const ESTIMATED_UNDERLAY_WIDTH_SCALE = 0.56;
 
 const normalizeLongitude = (longitude: number) =>
   ((((longitude + 180) % 360) + 360) % 360) - 180;
@@ -75,6 +77,56 @@ const interpolateLinearSegment = (
   }
 };
 
+const greatCircleMidpoint = (
+  from: [number, number],
+  to: [number, number],
+): [number, number] | null => {
+  const longitude1 = (from[0] * Math.PI) / 180;
+  const latitude1 = (from[1] * Math.PI) / 180;
+  const longitude2 = (to[0] * Math.PI) / 180;
+  const latitude2 = (to[1] * Math.PI) / 180;
+  const longitudeDifference = longitude2 - longitude1;
+  const bx = Math.cos(latitude2) * Math.cos(longitudeDifference);
+  const by = Math.cos(latitude2) * Math.sin(longitudeDifference);
+  const x = Math.cos(latitude1) + bx;
+  const y = by;
+
+  if (Math.hypot(x, y) < Number.EPSILON) return null;
+
+  const latitude = Math.atan2(
+    Math.sin(latitude1) + Math.sin(latitude2),
+    Math.hypot(x, y),
+  );
+  const longitude = longitude1 + Math.atan2(by, x);
+  return [
+    normalizeLongitude((longitude * 180) / Math.PI),
+    (latitude * 180) / Math.PI,
+  ];
+};
+
+const subdivideGreatCircle = (
+  start: [number, number],
+  end: [number, number],
+  depth: number,
+) => {
+  let coordinates = [start, end];
+
+  for (let level = 0; level < depth; level++) {
+    const subdivided: [number, number][] = [coordinates[0]!];
+    for (let index = 1; index < coordinates.length; index++) {
+      const midpoint = greatCircleMidpoint(
+        coordinates[index - 1]!,
+        coordinates[index]!,
+      );
+      if (!midpoint) return null;
+      subdivided.push(midpoint, coordinates[index]!);
+    }
+    coordinates = subdivided;
+  }
+
+  return coordinates;
+};
+
 export const buildFlightTrackDisplayPath = (
   sourcePath: FlightTrackPath['path'],
 ) => {
@@ -87,37 +139,52 @@ export const buildFlightTrackDisplayPath = (
   for (let index = 1; index < sourcePath.length; index++) {
     const start = sourcePath[index - 1]!;
     const end = sourcePath[index]!;
-    const startPoint = point([normalizeLongitude(start[0]), start[1]]);
-    const endPoint = point([normalizeLongitude(end[0]), end[1]]);
-    const angularDistance = distance(startPoint, endPoint, {
-      units: 'degrees',
-    });
-    const segmentCount = Math.max(
-      1,
-      Math.ceil(angularDistance / MAX_SURFACE_SEGMENT_DEGREES),
+    const normalizedStart: [number, number] = [
+      normalizeLongitude(start[0]),
+      start[1],
+    ];
+    const normalizedEnd: [number, number] = [
+      normalizeLongitude(end[0]),
+      end[1],
+    ];
+    const segmentDistance = distance(
+      point(normalizedStart),
+      point(normalizedEnd),
+      {
+        units: 'meters',
+      },
     );
+    const subdivisionDepth =
+      segmentDistance > GREAT_CIRCLE_MIN_DISTANCE_METERS
+        ? Math.ceil(
+            Math.log2(segmentDistance / GREAT_CIRCLE_TARGET_SEGMENT_METERS),
+          )
+        : 0;
 
-    if (segmentCount > 1) {
-      try {
-        const arc = greatCircle(startPoint, endPoint, {
-          npoints: segmentCount + 1,
-        });
-        const coordinates =
-          arc.geometry.type === 'MultiLineString'
-            ? arc.geometry.coordinates.flat()
-            : arc.geometry.coordinates;
+    if (subdivisionDepth > 0) {
+      const arc = subdivideGreatCircle(
+        normalizedStart,
+        normalizedEnd,
+        subdivisionDepth,
+      );
 
-        for (const coordinate of coordinates.slice(1, -1)) {
+      if (arc) {
+        for (const coordinate of arc.slice(1, -1)) {
           const previousLongitude = displayPath.at(-1)![0];
           displayPath.push([
-            unwrapLongitude(coordinate[0]!, previousLongitude),
-            coordinate[1]!,
+            unwrapLongitude(coordinate[0], previousLongitude),
+            coordinate[1],
           ]);
         }
-      } catch {
+      } else {
         // Antipodal points have no unique great-circle route. A deterministic
         // surface interpolation still avoids drawing a chord through the globe.
-        interpolateLinearSegment(displayPath, start, end, segmentCount);
+        interpolateLinearSegment(
+          displayPath,
+          start,
+          end,
+          2 ** subdivisionDepth,
+        );
       }
     }
 
@@ -226,8 +293,9 @@ export const buildFlightTrackLayers = ({
       data: data.estimatedRuns,
       getPath: getSurfacePath,
       getColor: getEstimatedUnderlayColor,
-      getWidth: (run) => Math.max(1, getWidth(run) * 0.3),
-      capRounded: false,
+      getWidth: (run) => getWidth(run) * ESTIMATED_UNDERLAY_WIDTH_SCALE,
+      widthMinPixels: 1,
+      capRounded: true,
       updateTriggers: {
         ...sharedPathOptions.updateTriggers,
         getColor: altitudeColorUpdateTriggers,
@@ -242,11 +310,12 @@ export const buildFlightTrackLayers = ({
       getColor: style === 'standard' ? getStandardColor : getAltitudeColor,
       getDashArray: (run) => {
         const width = Math.max(1, getWidth(run));
-        return [10 / width, (20 + 3 * width) / width];
+        const halfWidth = width / 2;
+        return [10 / halfWidth, (20 + 1.5 * width) / halfWidth];
       },
       dashJustified: false,
       dashGapPickable: false,
-      capRounded: false,
+      capRounded: true,
       updateTriggers: {
         ...sharedPathOptions.updateTriggers,
         getColor:

--- a/src/lib/map/flight-track-layers.ts
+++ b/src/lib/map/flight-track-layers.ts
@@ -18,6 +18,7 @@ export type FlightTrackLayerData = {
   paths: FlightTrackPath[];
   solidRuns: FlightTrackRun[];
   estimatedRuns: FlightTrackRun[];
+  groundRuns: FlightTrackRun[];
 };
 
 type FlightTrackLayerOptions = {
@@ -28,6 +29,7 @@ type FlightTrackLayerOptions = {
   getWidth: (track: FlightArc) => number;
   getStandardColor: (track: FlightTrackPath) => Color;
   getAltitudeColor: (run: FlightTrackRun) => Color;
+  getGroundCasingColor: (run: FlightTrackRun) => Color;
   getEstimatedUnderlayColor: (run: FlightTrackRun) => Color;
   widthUpdateTriggers: unknown[];
   standardColorUpdateTriggers: unknown[];
@@ -146,6 +148,7 @@ export const prepareFlightTrackLayerData = (
     paths,
     solidRuns: runs.filter((run) => !run.estimated),
     estimatedRuns: runs.filter((run) => run.estimated),
+    groundRuns: runs.filter((run) => run.ground),
   };
 };
 
@@ -157,6 +160,7 @@ export const buildFlightTrackLayers = ({
   getWidth,
   getStandardColor,
   getAltitudeColor,
+  getGroundCasingColor,
   getEstimatedUnderlayColor,
   widthUpdateTriggers,
   standardColorUpdateTriggers,
@@ -186,6 +190,20 @@ export const buildFlightTrackLayers = ({
       updateTriggers: {
         ...sharedPathOptions.updateTriggers,
         getColor: standardColorUpdateTriggers,
+      },
+    }),
+    new PathLayer<FlightTrackRun>({
+      ...sharedPathOptions,
+      id: 'ground-track-casing-layer',
+      extensions,
+      data: style === 'altitude' ? data.groundRuns : [],
+      getPath: getSurfacePath,
+      getColor: getGroundCasingColor,
+      getWidth: (run) => getWidth(run) + 2.5,
+      capRounded: true,
+      updateTriggers: {
+        ...sharedPathOptions.updateTriggers,
+        getColor: altitudeColorUpdateTriggers,
       },
     }),
     new PathLayer<FlightTrackRun>({

--- a/src/lib/map/flight-track-layers.ts
+++ b/src/lib/map/flight-track-layers.ts
@@ -1,6 +1,7 @@
 import type { Color, Layer, LayerExtension } from '@deck.gl/core';
 import { PathStyleExtension } from '@deck.gl/extensions';
 import { PathLayer, type PathLayerProps } from '@deck.gl/layers';
+import { distance, greatCircle, point } from '@turf/turf';
 
 import type { FlightTrackStyle } from './map-preferences.svelte';
 import type { FlightArc, FlightTrackPath } from './flight-layer-data';
@@ -45,13 +46,90 @@ const surfacePathCache = new WeakMap<
   [number, number][]
 >();
 
+const MAX_SURFACE_SEGMENT_DEGREES = 3;
+
+const normalizeLongitude = (longitude: number) =>
+  ((((longitude + 180) % 360) + 360) % 360) - 180;
+
+const unwrapLongitude = (longitude: number, previous: number) => {
+  let unwrapped = longitude;
+  while (unwrapped - previous > 180) unwrapped -= 360;
+  while (unwrapped - previous < -180) unwrapped += 360;
+  return unwrapped;
+};
+
+const interpolateLinearSegment = (
+  path: [number, number][],
+  start: FlightTrackPath['path'][number],
+  end: FlightTrackPath['path'][number],
+  segmentCount: number,
+) => {
+  for (let index = 1; index < segmentCount; index++) {
+    const progress = index / segmentCount;
+    path.push([
+      start[0] + (end[0] - start[0]) * progress,
+      start[1] + (end[1] - start[1]) * progress,
+    ]);
+  }
+};
+
+export const buildFlightTrackDisplayPath = (
+  sourcePath: FlightTrackPath['path'],
+) => {
+  if (!sourcePath.length) return [];
+
+  const displayPath: [number, number][] = [
+    [sourcePath[0]![0], sourcePath[0]![1]],
+  ];
+
+  for (let index = 1; index < sourcePath.length; index++) {
+    const start = sourcePath[index - 1]!;
+    const end = sourcePath[index]!;
+    const startPoint = point([normalizeLongitude(start[0]), start[1]]);
+    const endPoint = point([normalizeLongitude(end[0]), end[1]]);
+    const angularDistance = distance(startPoint, endPoint, {
+      units: 'degrees',
+    });
+    const segmentCount = Math.max(
+      1,
+      Math.ceil(angularDistance / MAX_SURFACE_SEGMENT_DEGREES),
+    );
+
+    if (segmentCount > 1) {
+      try {
+        const arc = greatCircle(startPoint, endPoint, {
+          npoints: segmentCount + 1,
+        });
+        const coordinates =
+          arc.geometry.type === 'MultiLineString'
+            ? arc.geometry.coordinates.flat()
+            : arc.geometry.coordinates;
+
+        for (const coordinate of coordinates.slice(1, -1)) {
+          const previousLongitude = displayPath.at(-1)![0];
+          displayPath.push([
+            unwrapLongitude(coordinate[0]!, previousLongitude),
+            coordinate[1]!,
+          ]);
+        }
+      } catch {
+        // Antipodal points have no unique great-circle route. A deterministic
+        // surface interpolation still avoids drawing a chord through the globe.
+        interpolateLinearSegment(displayPath, start, end, segmentCount);
+      }
+    }
+
+    displayPath.push([end[0], end[1]]);
+  }
+
+  return displayPath;
+};
+
 const getSurfacePath = (track: Pick<FlightTrackPath, 'path'>) => {
   const cached = surfacePathCache.get(track.path);
   if (cached) return cached;
 
-  const path = track.path.map(
-    (coordinate) => [coordinate[0], coordinate[1]] as [number, number],
-  );
+  const path = buildFlightTrackDisplayPath(track.path);
   surfacePathCache.set(track.path, path);
   return path;
 };

--- a/src/lib/map/flight-track-layers.ts
+++ b/src/lib/map/flight-track-layers.ts
@@ -3,12 +3,12 @@ import { PathStyleExtension } from '@deck.gl/extensions';
 import { PathLayer, type PathLayerProps } from '@deck.gl/layers';
 import { distance, greatCircle, point } from '@turf/turf';
 
-import type { FlightTrackStyle } from './map-preferences.svelte';
 import type { FlightArc, FlightTrackPath } from './flight-layer-data';
 import {
   buildFlightTrackRuns,
   type FlightTrackRun,
 } from './flight-track-style';
+import type { FlightTrackStyle } from './map-preferences.svelte';
 
 type PathParameters = PathLayerProps<FlightTrackPath>['parameters'];
 type PathHoverHandler = PathLayerProps<FlightTrackPath>['onHover'];
@@ -138,7 +138,9 @@ export const prepareFlightTrackLayerData = (
   paths: FlightTrackPath[],
   style: FlightTrackStyle,
 ): FlightTrackLayerData => {
-  const runs = style === 'altitude' ? buildFlightTrackRuns(paths) : [];
+  const runs = buildFlightTrackRuns(paths, {
+    splitByAltitude: style === 'altitude',
+  });
 
   return {
     paths,
@@ -177,7 +179,7 @@ export const buildFlightTrackLayers = ({
       ...sharedPathOptions,
       id: 'track-path-layer',
       extensions,
-      data: style === 'standard' ? data.paths : [],
+      data: style === 'standard' ? data.solidRuns : [],
       getPath: getSurfacePath,
       getColor: getStandardColor,
       capRounded: true,
@@ -190,7 +192,7 @@ export const buildFlightTrackLayers = ({
       ...sharedPathOptions,
       id: 'altitude-track-path-layer',
       extensions,
-      data: data.solidRuns,
+      data: style === 'altitude' ? data.solidRuns : [],
       getPath: getSurfacePath,
       getColor: getAltitudeColor,
       capRounded: true,
@@ -219,7 +221,7 @@ export const buildFlightTrackLayers = ({
       extensions: [...extensions, estimatedPathStyle],
       data: data.estimatedRuns,
       getPath: getSurfacePath,
-      getColor: getAltitudeColor,
+      getColor: style === 'standard' ? getStandardColor : getAltitudeColor,
       getDashArray: (run) => {
         const width = Math.max(1, getWidth(run));
         return [10 / width, (20 + 3 * width) / width];
@@ -229,7 +231,10 @@ export const buildFlightTrackLayers = ({
       capRounded: false,
       updateTriggers: {
         ...sharedPathOptions.updateTriggers,
-        getColor: altitudeColorUpdateTriggers,
+        getColor:
+          style === 'standard'
+            ? standardColorUpdateTriggers
+            : altitudeColorUpdateTriggers,
         getDashArray: widthUpdateTriggers,
       },
     }),

--- a/src/lib/map/flight-track-style.test.ts
+++ b/src/lib/map/flight-track-style.test.ts
@@ -39,7 +39,7 @@ describe('flight track styling', () => {
         ground: true,
         darkMode: true,
       }),
-    ).toEqual([161, 161, 170]);
+    ).toEqual([228, 228, 231]);
     expect(
       getFlightTrackColor({
         altitudeFeet: null,
@@ -56,7 +56,7 @@ describe('flight track styling', () => {
         estimated: true,
         darkMode: true,
       }),
-    ).toEqual([129, 129, 136]);
+    ).toEqual([182, 182, 185]);
   });
 
   it('exposes exact AirTrail palette anchors', () => {

--- a/src/lib/map/flight-track-style.test.ts
+++ b/src/lib/map/flight-track-style.test.ts
@@ -8,14 +8,18 @@ import {
   roundFlightTrackAltitude,
 } from './flight-track-style';
 
+import {
+  toFlightTrackSamples,
+  type FlightTrackCoordinate,
+} from '$lib/track/schema';
+
 const track = (
-  path: FlightTrackPath['path'],
-  options: Pick<FlightTrackPath, 'ground' | 'estimated'> = {},
+  coordinates: FlightTrackCoordinate[],
+  options: { ground?: boolean[]; estimated?: boolean[] } = {},
 ) =>
   ({
     flightId: 1,
-    path,
-    ...options,
+    samples: toFlightTrackSamples({ coordinates, ...options }),
   }) as FlightTrackPath;
 
 describe('flight track styling', () => {
@@ -191,5 +195,6 @@ describe('flight track styling', () => {
       ground: false,
       estimated: false,
     });
+    expect(runs[0]).not.toHaveProperty('samples');
   });
 });

--- a/src/lib/map/flight-track-style.test.ts
+++ b/src/lib/map/flight-track-style.test.ts
@@ -150,4 +150,27 @@ describe('flight track styling', () => {
       ],
     });
   });
+
+  it('only splits standard runs at estimated boundaries', () => {
+    const runs = buildFlightTrackRuns(
+      [
+        track(
+          [
+            [10, 55, 0],
+            [11, 56, 304.8],
+            [12, 57, 609.6],
+          ],
+          { ground: [true, false, false], estimated: [false, false, false] },
+        ),
+      ],
+      { splitByAltitude: false },
+    );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      altitudeFeet: null,
+      ground: false,
+      estimated: false,
+    });
+  });
 });

--- a/src/lib/map/flight-track-style.test.ts
+++ b/src/lib/map/flight-track-style.test.ts
@@ -56,7 +56,7 @@ describe('flight track styling', () => {
         estimated: true,
         darkMode: true,
       }),
-    ).toEqual([182, 182, 185]);
+    ).toEqual([179, 179, 188]);
   });
 
   it('exposes exact AirTrail palette anchors', () => {
@@ -80,7 +80,7 @@ describe('flight track styling', () => {
     ).toEqual([239, 68, 68]);
   });
 
-  it('darkens estimated segments in addition to dashing them', () => {
+  it('darkens estimated segments in HSL like tar1090', () => {
     const actual = getFlightTrackColor({
       altitudeFeet: 0,
       ground: false,
@@ -93,6 +93,7 @@ describe('flight track styling', () => {
     expect(estimated[0]).toBeLessThan(actual[0]);
     expect(estimated[1]).toBeLessThan(actual[1]);
     expect(estimated[2]).toBeLessThan(actual[2]);
+    expect(estimated).toEqual([211, 90, 5]);
   });
 
   it('merges consecutive edges with the same rounded style', () => {

--- a/src/lib/map/flight-track-style.test.ts
+++ b/src/lib/map/flight-track-style.test.ts
@@ -35,10 +35,28 @@ describe('flight track styling', () => {
     ).toEqual([82, 82, 91]);
     expect(
       getFlightTrackColor({
+        altitudeFeet: 30_000,
+        ground: true,
+        darkMode: true,
+      }),
+    ).toEqual([161, 161, 170]);
+    expect(
+      getFlightTrackColor({
         altitudeFeet: null,
         ground: false,
       }),
     ).toEqual([161, 161, 170]);
+  });
+
+  it('keeps estimated ground tracks visible in dark mode', () => {
+    expect(
+      getFlightTrackColor({
+        altitudeFeet: null,
+        ground: true,
+        estimated: true,
+        darkMode: true,
+      }),
+    ).toEqual([129, 129, 136]);
   });
 
   it('exposes exact AirTrail palette anchors', () => {

--- a/src/lib/map/flight-track-style.ts
+++ b/src/lib/map/flight-track-style.ts
@@ -125,13 +125,17 @@ export const getFlightTrackColor = ({
   altitudeFeet,
   ground,
   estimated = false,
+  darkMode = false,
 }: {
   altitudeFeet: number | null;
   ground: boolean;
   estimated?: boolean;
+  darkMode?: boolean;
 }): Color => {
   const color: Color = ground
-    ? [82, 82, 91]
+    ? darkMode
+      ? [161, 161, 170]
+      : [82, 82, 91]
     : altitudeFeet === null
       ? [161, 161, 170]
       : interpolateAirTrailColor(altitudeFeet);

--- a/src/lib/map/flight-track-style.ts
+++ b/src/lib/map/flight-track-style.ts
@@ -139,11 +139,15 @@ export const getFlightTrackColor = ({
   return estimated ? darkenEstimated(color) : color;
 };
 
-const getEdgeStyle = (track: FlightTrackPath, index: number) => {
+const getEdgeStyle = (
+  track: FlightTrackPath,
+  index: number,
+  splitByAltitude: boolean,
+) => {
   const coordinate = track.path[index]!;
-  const ground = track.ground?.[index] ?? false;
+  const ground = splitByAltitude && (track.ground?.[index] ?? false);
   const altitudeFeet =
-    ground || coordinate[2] === undefined
+    !splitByAltitude || ground || coordinate[2] === undefined
       ? null
       : roundFlightTrackAltitude(metersToFeet(coordinate[2]));
   return {
@@ -162,17 +166,20 @@ const stylesMatch = (
   left.ground === right.ground &&
   left.estimated === right.estimated;
 
-export const buildFlightTrackRuns = (tracks: FlightTrackPath[]) => {
+export const buildFlightTrackRuns = (
+  tracks: FlightTrackPath[],
+  { splitByAltitude = true }: { splitByAltitude?: boolean } = {},
+) => {
   const runs: FlightTrackRun[] = [];
 
   for (const track of tracks) {
     if (track.path.length < 2) continue;
 
-    let style = getEdgeStyle(track, 0);
+    let style = getEdgeStyle(track, 0, splitByAltitude);
     let path: FlightTrackCoordinate[] = [track.path[0]!];
 
     for (let index = 0; index < track.path.length - 1; index++) {
-      const edgeStyle = getEdgeStyle(track, index);
+      const edgeStyle = getEdgeStyle(track, index, splitByAltitude);
       if (!stylesMatch(style, edgeStyle)) {
         if (path.length >= 2) runs.push({ ...track, ...style, path });
         style = edgeStyle;

--- a/src/lib/map/flight-track-style.ts
+++ b/src/lib/map/flight-track-style.ts
@@ -134,7 +134,7 @@ export const getFlightTrackColor = ({
 }): Color => {
   const color: Color = ground
     ? darkMode
-      ? [161, 161, 170]
+      ? [228, 228, 231]
       : [82, 82, 91]
     : altitudeFeet === null
       ? [161, 161, 170]

--- a/src/lib/map/flight-track-style.ts
+++ b/src/lib/map/flight-track-style.ts
@@ -109,10 +109,67 @@ const interpolateAirTrailColor = (altitudeFeet: number): Color => {
   return [...last.color];
 };
 
-const darkenEstimated = (color: Color): Color =>
-  color.map((component, index) =>
-    index < 3 ? Math.round(component * 0.8) : component,
-  ) as Color;
+const rgbToHsl = (color: Color) => {
+  const red = color[0] / 255;
+  const green = color[1] / 255;
+  const blue = color[2] / 255;
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const lightness = (max + min) / 2;
+
+  if (max === min) return [0, 0, lightness] as const;
+
+  const difference = max - min;
+  const saturation =
+    lightness > 0.5 ? difference / (2 - max - min) : difference / (max + min);
+  const hue =
+    max === red
+      ? (green - blue) / difference + (green < blue ? 6 : 0)
+      : max === green
+        ? (blue - red) / difference + 2
+        : (red - green) / difference + 4;
+
+  return [hue / 6, saturation, lightness] as const;
+};
+
+const hueToRgb = (lower: number, upper: number, hue: number) => {
+  let wrappedHue = hue;
+  if (wrappedHue < 0) wrappedHue += 1;
+  if (wrappedHue > 1) wrappedHue -= 1;
+  if (wrappedHue < 1 / 6) return lower + (upper - lower) * 6 * wrappedHue;
+  if (wrappedHue < 1 / 2) return upper;
+  if (wrappedHue < 2 / 3)
+    return lower + (upper - lower) * (2 / 3 - wrappedHue) * 6;
+  return lower;
+};
+
+const hslToRgb = (
+  hue: number,
+  saturation: number,
+  lightness: number,
+): [number, number, number] => {
+  if (saturation === 0) {
+    const channel = Math.round(lightness * 255);
+    return [channel, channel, channel];
+  }
+
+  const upper =
+    lightness < 0.5
+      ? lightness * (1 + saturation)
+      : lightness + saturation - lightness * saturation;
+  const lower = 2 * lightness - upper;
+  return [
+    Math.round(hueToRgb(lower, upper, hue + 1 / 3) * 255),
+    Math.round(hueToRgb(lower, upper, hue) * 255),
+    Math.round(hueToRgb(lower, upper, hue - 1 / 3) * 255),
+  ];
+};
+
+const darkenEstimated = (color: Color): Color => {
+  const [hue, saturation, lightness] = rgbToHsl(color);
+  const darkened = hslToRgb(hue, saturation, lightness * 0.8);
+  return color[3] === undefined ? darkened : [...darkened, color[3]];
+};
 
 export const metersToFeet = (meters: number) => meters * METERS_TO_FEET;
 

--- a/src/lib/map/flight-track-style.ts
+++ b/src/lib/map/flight-track-style.ts
@@ -1,13 +1,10 @@
 import type { Color } from '@deck.gl/core';
 
-import type { FlightTrackPath } from './flight-layer-data';
+import type { FlightTrackIdentity, FlightTrackPath } from './flight-layer-data';
 
 import type { FlightTrackCoordinate } from '$lib/track/schema';
 
-export type FlightTrackRun = Omit<
-  FlightTrackPath,
-  'path' | 'ground' | 'estimated'
-> & {
+export type FlightTrackRun = FlightTrackIdentity & {
   path: FlightTrackCoordinate[];
   altitudeFeet: number | null;
   ground: boolean;
@@ -205,8 +202,9 @@ const getEdgeStyle = (
   index: number,
   splitByAltitude: boolean,
 ) => {
-  const coordinate = track.path[index]!;
-  const ground = splitByAltitude && (track.ground?.[index] ?? false);
+  const sample = track.samples[index]!;
+  const coordinate = sample.coordinate;
+  const ground = splitByAltitude && (sample.point.ground ?? false);
   const altitudeFeet =
     !splitByAltitude || ground || coordinate[2] === undefined
       ? null
@@ -214,8 +212,7 @@ const getEdgeStyle = (
   return {
     altitudeFeet,
     ground,
-    // readsb marks the current point when the interval leading to it is stale.
-    estimated: track.estimated?.[index + 1] ?? false,
+    estimated: track.samples[index + 1]?.incomingEdge.estimated ?? false,
   };
 };
 
@@ -234,22 +231,23 @@ export const buildFlightTrackRuns = (
   const runs: FlightTrackRun[] = [];
 
   for (const track of tracks) {
-    if (track.path.length < 2) continue;
+    const { samples, ...identity } = track;
+    if (samples.length < 2) continue;
 
     let style = getEdgeStyle(track, 0, splitByAltitude);
-    let path: FlightTrackCoordinate[] = [track.path[0]!];
+    let path: FlightTrackCoordinate[] = [samples[0]!.coordinate];
 
-    for (let index = 0; index < track.path.length - 1; index++) {
+    for (let index = 0; index < samples.length - 1; index++) {
       const edgeStyle = getEdgeStyle(track, index, splitByAltitude);
       if (!stylesMatch(style, edgeStyle)) {
-        if (path.length >= 2) runs.push({ ...track, ...style, path });
+        if (path.length >= 2) runs.push({ ...identity, ...style, path });
         style = edgeStyle;
-        path = [track.path[index]!];
+        path = [samples[index]!.coordinate];
       }
-      path.push(track.path[index + 1]!);
+      path.push(samples[index + 1]!.coordinate);
     }
 
-    if (path.length >= 2) runs.push({ ...track, ...style, path });
+    if (path.length >= 2) runs.push({ ...identity, ...style, path });
   }
 
   return runs;

--- a/src/lib/map/map-popup-position.test.ts
+++ b/src/lib/map/map-popup-position.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPopupAnchor } from './map-popup-position';
+
+describe('map popup position', () => {
+  const container = { clientWidth: 1_000, clientHeight: 800 };
+  const popupSize = { width: 320, height: 280 };
+
+  it('anchors away from map edges', () => {
+    expect(getPopupAnchor({ x: 100, y: 100 }, container, popupSize)).toBe(
+      'top-left',
+    );
+    expect(getPopupAnchor({ x: 900, y: 700 }, container, popupSize)).toBe(
+      'bottom-right',
+    );
+  });
+});

--- a/src/lib/map/map-popup-position.ts
+++ b/src/lib/map/map-popup-position.ts
@@ -1,0 +1,103 @@
+import type { PickingInfo } from '@deck.gl/core';
+import type { Map as MaplibreMap, Popup as MaplibrePopup } from 'maplibre-gl';
+
+export type MapPointerPixel = { x: number; y: number };
+
+export type DeckPointerEvent = {
+  offsetCenter?: MapPointerPixel;
+  srcEvent?: Event & {
+    point?: MapPointerPixel;
+    lngLat?: { lng: number; lat: number };
+    clientX?: number;
+    clientY?: number;
+  };
+};
+
+const POPUP_OFFSET = 20;
+const POPUP_FALLBACK_SIZE = { width: 320, height: 280 };
+
+export const getDeckPointerPixel = (
+  info: PickingInfo,
+  event?: DeckPointerEvent,
+): MapPointerPixel | undefined =>
+  event?.srcEvent?.point ??
+  event?.offsetCenter ??
+  (info.pixel ? { x: info.pixel[0], y: info.pixel[1] } : undefined) ??
+  (Number.isFinite(info.x) && Number.isFinite(info.y)
+    ? { x: info.x, y: info.y }
+    : undefined);
+
+export const getDeckPointerLngLat = (
+  info: PickingInfo,
+  event: DeckPointerEvent | undefined,
+  map: MaplibreMap | undefined,
+): [number, number] | undefined => {
+  if (event?.srcEvent?.lngLat) {
+    return [event.srcEvent.lngLat.lng, event.srcEvent.lngLat.lat];
+  }
+
+  const point = getDeckPointerPixel(info, event);
+  if (map && point) {
+    const lngLat = map.unproject([point.x, point.y]);
+    return [lngLat.lng, lngLat.lat];
+  }
+
+  const srcEvent = event?.srcEvent;
+  if (
+    map &&
+    typeof srcEvent?.clientX === 'number' &&
+    typeof srcEvent.clientY === 'number'
+  ) {
+    const rect = map.getContainer().getBoundingClientRect();
+    const lngLat = map.unproject([
+      srcEvent.clientX - rect.left,
+      srcEvent.clientY - rect.top,
+    ]);
+    return [lngLat.lng, lngLat.lat];
+  }
+
+  return info.coordinate?.length
+    ? ([info.coordinate[0], info.coordinate[1]] as [number, number])
+    : undefined;
+};
+
+export const getPopupAnchor = (
+  point: MapPointerPixel,
+  container: Pick<HTMLElement, 'clientWidth' | 'clientHeight'>,
+  popupSize = POPUP_FALLBACK_SIZE,
+) => {
+  const vertical =
+    point.y + POPUP_OFFSET + popupSize.height > container.clientHeight
+      ? 'bottom'
+      : 'top';
+  const horizontal =
+    point.x + POPUP_OFFSET + popupSize.width > container.clientWidth
+      ? 'right'
+      : 'left';
+  return `${vertical}-${horizontal}` as const;
+};
+
+export const createPopupPositionController = (
+  getMap: () => MaplibreMap | undefined,
+) => {
+  let popup: MaplibrePopup | undefined;
+
+  const update = (point: MapPointerPixel | undefined) => {
+    const map = getMap();
+    if (!popup || !map || !point) return;
+
+    const element = popup.getElement();
+    const popupSize = {
+      width: element?.offsetWidth || POPUP_FALLBACK_SIZE.width,
+      height: element?.offsetHeight || POPUP_FALLBACK_SIZE.height,
+    };
+    popup.options.anchor = getPopupAnchor(point, map.getContainer(), popupSize);
+  };
+
+  return {
+    setPopup(nextPopup: MaplibrePopup) {
+      popup = nextPopup;
+    },
+    update,
+  };
+};

--- a/src/lib/map/map-preferences.svelte.ts
+++ b/src/lib/map/map-preferences.svelte.ts
@@ -1,284 +1,256 @@
-import { browser } from '$app/environment';
-
+import { MAP_BASEMAPS, type MapBasemap } from './basemap';
 import {
   OPENAIP_DEFAULT_ENABLED_GROUPS,
   OPENAIP_OVERLAY_GROUPS,
   type OpenAipOverlayGroup,
 } from './openaip';
-import { MAP_BASEMAPS, type MapBasemap } from './basemap';
 
-export type AirportCirclesMode = 'off' | 'small' | 'medium' | 'large';
-export type AirportCircleRadiusMode = 'byFrequency' | 'uniform';
-export type ArcColorMode = 'default' | 'byFrequency';
-export type ArcThicknessMode = 'uniform' | 'byFrequency';
-export type ArcThicknessScale = 'thin' | 'normal' | 'thick';
-export type RouteDisplayMode = 'points' | 'tracks';
-export type FlightTrackStyle = 'standard' | 'altitude';
-export type AirportOverlayDetail = 'standard' | 'detailed';
-export type MapProjection = 'mercator' | 'globe';
+import { browser } from '$app/environment';
+
+export type AppearanceOption<T extends string> = {
+  value: T;
+  label: string;
+};
+
+const airportCircleOptions = [
+  { value: 'off', label: 'Off' },
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+] as const;
+const airportCircleRadiusOptions = [
+  { value: 'byFrequency', label: 'By frequency' },
+  { value: 'uniform', label: 'Uniform' },
+] as const;
+const arcColorOptions = [
+  { value: 'default', label: 'Default' },
+  { value: 'byFrequency', label: 'By frequency' },
+] as const;
+const arcThicknessOptions = [
+  { value: 'uniform', label: 'Uniform' },
+  { value: 'byFrequency', label: 'By frequency' },
+] as const;
+const arcThicknessScaleOptions = [
+  { value: 'thin', label: 'Thin' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'thick', label: 'Thick' },
+] as const;
+const routeDisplayOptions = [
+  { value: 'tracks', label: 'Flight tracks' },
+  { value: 'points', label: 'Point to point' },
+] as const;
+const flightTrackStyleOptions = [
+  { value: 'standard', label: 'Standard' },
+  { value: 'altitude', label: 'Altitude' },
+] as const;
+const airportOverlayDetailOptions = [
+  { value: 'standard', label: 'Standard' },
+  { value: 'detailed', label: 'Detailed' },
+] as const;
+const projectionOptions = [
+  { value: 'mercator', label: 'Flat' },
+  { value: 'globe', label: 'Globe' },
+] as const;
+const basemapLabels = {
+  default: 'Default',
+  satellite: 'Satellite',
+} as const satisfies Record<MapBasemap, string>;
+const basemapOptions = MAP_BASEMAPS.map((value) => ({
+  value,
+  label: basemapLabels[value],
+}));
+
+const openAipGroupLabels = {
+  airspaces: 'Airspaces',
+  airspaceLabels: 'Airspace labels',
+  airports: 'Airports',
+  navaids: 'Navaids',
+  reportingPoints: 'Reporting points',
+} as const satisfies Record<OpenAipOverlayGroup, string>;
+const openAipGroupOptions = OPENAIP_OVERLAY_GROUPS.map((value) => ({
+  value,
+  label: openAipGroupLabels[value],
+}));
+
+type OptionValue<T extends readonly AppearanceOption<string>[]> =
+  T[number]['value'];
+
+export type AirportCirclesMode = OptionValue<typeof airportCircleOptions>;
+export type AirportCircleRadiusMode = OptionValue<
+  typeof airportCircleRadiusOptions
+>;
+export type ArcColorMode = OptionValue<typeof arcColorOptions>;
+export type ArcThicknessMode = OptionValue<typeof arcThicknessOptions>;
+export type ArcThicknessScale = OptionValue<typeof arcThicknessScaleOptions>;
+export type RouteDisplayMode = OptionValue<typeof routeDisplayOptions>;
+export type FlightTrackStyle = OptionValue<typeof flightTrackStyleOptions>;
+export type AirportOverlayDetail = OptionValue<
+  typeof airportOverlayDetailOptions
+>;
+export type MapProjection = OptionValue<typeof projectionOptions>;
+
+type PreferenceDefinition<T> = {
+  defaultValue: T;
+  sanitize: (raw: unknown) => T;
+};
+
+const choicePreference = <T extends string>(
+  options: readonly AppearanceOption<T>[],
+  defaultValue: T,
+): PreferenceDefinition<T> & { options: readonly AppearanceOption<T>[] } => {
+  const values = new Set(options.map((option) => option.value));
+  return {
+    defaultValue,
+    options,
+    sanitize: (raw) =>
+      typeof raw === 'string' && values.has(raw as T)
+        ? (raw as T)
+        : defaultValue,
+  };
+};
+
+const booleanPreference = (
+  defaultValue: boolean,
+): PreferenceDefinition<boolean> => ({
+  defaultValue,
+  sanitize: (raw) => (typeof raw === 'boolean' ? raw : defaultValue),
+});
+
+const choiceArrayPreference = <T extends string>(
+  options: readonly AppearanceOption<T>[],
+  defaultValue: readonly T[],
+): PreferenceDefinition<T[]> & { options: readonly AppearanceOption<T>[] } => {
+  const values = new Set(options.map((option) => option.value));
+  return {
+    defaultValue: [...defaultValue],
+    options,
+    sanitize: (raw) =>
+      Array.isArray(raw)
+        ? raw.filter(
+            (value): value is T =>
+              typeof value === 'string' && values.has(value as T),
+          )
+        : [...defaultValue],
+  };
+};
+
+export const MAP_PREFERENCE_DEFINITIONS = {
+  basemap: choicePreference(basemapOptions, 'default'),
+  projection: choicePreference(projectionOptions, 'mercator'),
+  timeOfDayEnabled: booleanPreference(false),
+  rainViewerEnabled: booleanPreference(false),
+  airportCircles: choicePreference(airportCircleOptions, 'large'),
+  airportCircleRadius: choicePreference(
+    airportCircleRadiusOptions,
+    'byFrequency',
+  ),
+  arcColor: choicePreference(arcColorOptions, 'default'),
+  arcThickness: choicePreference(arcThicknessOptions, 'uniform'),
+  arcThicknessScale: choicePreference(arcThicknessScaleOptions, 'normal'),
+  routeDisplay: choicePreference(routeDisplayOptions, 'tracks'),
+  flightTrackStyle: choicePreference(flightTrackStyleOptions, 'standard'),
+  airportOverlayDetail: choicePreference(
+    airportOverlayDetailOptions,
+    'detailed',
+  ),
+  openAipEnabled: booleanPreference(false),
+  openAipGroups: choiceArrayPreference(
+    openAipGroupOptions,
+    OPENAIP_DEFAULT_ENABLED_GROUPS,
+  ),
+} as const;
+
+type DefinitionValue<T> =
+  T extends PreferenceDefinition<infer Value> ? Value : never;
 
 export type MapPreferences = {
-  basemap: MapBasemap;
-  projection: MapProjection;
-  timeOfDayEnabled: boolean;
-  rainViewerEnabled: boolean;
-  airportCircles: AirportCirclesMode;
-  airportCircleRadius: AirportCircleRadiusMode;
-  arcColor: ArcColorMode;
-  arcThickness: ArcThicknessMode;
-  arcThicknessScale: ArcThicknessScale;
-  routeDisplay: RouteDisplayMode;
-  flightTrackStyle: FlightTrackStyle;
-  airportOverlayDetail: AirportOverlayDetail;
-  openAipEnabled: boolean;
-  openAipGroups: OpenAipOverlayGroup[];
+  -readonly [Key in keyof typeof MAP_PREFERENCE_DEFINITIONS]: DefinitionValue<
+    (typeof MAP_PREFERENCE_DEFINITIONS)[Key]
+  >;
+};
+
+const preferenceKeys = Object.keys(
+  MAP_PREFERENCE_DEFINITIONS,
+) as (keyof MapPreferences)[];
+
+const clonePreferenceValue = <T>(value: T): T =>
+  (Array.isArray(value) ? [...value] : value) as T;
+
+const buildDefaults = () =>
+  Object.fromEntries(
+    preferenceKeys.map((key) => [
+      key,
+      clonePreferenceValue(MAP_PREFERENCE_DEFINITIONS[key].defaultValue),
+    ]),
+  ) as MapPreferences;
+
+export const MAP_PREFERENCE_DEFAULTS = buildDefaults();
+export const mapPreferences = $state<MapPreferences>(buildDefaults());
+
+export const sanitizeMapPreferences = (raw: unknown): MapPreferences => {
+  const input =
+    raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+  return Object.fromEntries(
+    preferenceKeys.map((key) => [
+      key,
+      MAP_PREFERENCE_DEFINITIONS[key].sanitize(input[key]),
+    ]),
+  ) as MapPreferences;
+};
+
+const assignMapPreferences = (preferences: MapPreferences) => {
+  Object.assign(mapPreferences, preferences);
 };
 
 const STORAGE_KEY = 'airtrail:map:prefs';
 const LEGACY_OPENAIP_KEY = 'airtrail:map:openaip-overlay';
-
-const AIRPORT_CIRCLES_MODES: readonly AirportCirclesMode[] = [
-  'off',
-  'small',
-  'medium',
-  'large',
-];
-const AIRPORT_CIRCLE_RADIUS_MODES: readonly AirportCircleRadiusMode[] = [
-  'byFrequency',
-  'uniform',
-];
-const ARC_COLOR_MODES: readonly ArcColorMode[] = ['default', 'byFrequency'];
-const ARC_THICKNESS_MODES: readonly ArcThicknessMode[] = [
-  'uniform',
-  'byFrequency',
-];
-const ARC_THICKNESS_SCALES: readonly ArcThicknessScale[] = [
-  'thin',
-  'normal',
-  'thick',
-];
-const ROUTE_DISPLAY_MODES: readonly RouteDisplayMode[] = ['points', 'tracks'];
-const FLIGHT_TRACK_STYLES: readonly FlightTrackStyle[] = [
-  'standard',
-  'altitude',
-];
-const AIRPORT_OVERLAY_DETAIL_MODES: readonly AirportOverlayDetail[] = [
-  'standard',
-  'detailed',
-];
-const MAP_PROJECTIONS: readonly MapProjection[] = ['mercator', 'globe'];
-
-export const MAP_PREFERENCE_DEFAULTS: MapPreferences = {
-  basemap: 'default',
-  projection: 'mercator',
-  timeOfDayEnabled: false,
-  rainViewerEnabled: false,
-  airportCircles: 'large',
-  airportCircleRadius: 'byFrequency',
-  arcColor: 'default',
-  arcThickness: 'uniform',
-  arcThicknessScale: 'normal',
-  routeDisplay: 'tracks',
-  flightTrackStyle: 'standard',
-  airportOverlayDetail: 'detailed',
-  openAipEnabled: false,
-  openAipGroups: [...OPENAIP_DEFAULT_ENABLED_GROUPS],
-};
-
-export const mapPreferences = $state<MapPreferences>({
-  ...MAP_PREFERENCE_DEFAULTS,
-  openAipGroups: [...MAP_PREFERENCE_DEFAULTS.openAipGroups],
-});
-
-const sanitize = (raw: unknown): MapPreferences => {
-  const result: MapPreferences = {
-    ...MAP_PREFERENCE_DEFAULTS,
-    openAipGroups: [...MAP_PREFERENCE_DEFAULTS.openAipGroups],
-  };
-
-  if (!raw || typeof raw !== 'object') return result;
-  const input = raw as Partial<Record<keyof MapPreferences, unknown>>;
-
-  if (
-    typeof input.basemap === 'string' &&
-    MAP_BASEMAPS.includes(input.basemap as MapBasemap)
-  ) {
-    result.basemap = input.basemap as MapBasemap;
-  }
-  if (
-    typeof input.projection === 'string' &&
-    MAP_PROJECTIONS.includes(input.projection as MapProjection)
-  ) {
-    result.projection = input.projection as MapProjection;
-  }
-  if (typeof input.timeOfDayEnabled === 'boolean') {
-    result.timeOfDayEnabled = input.timeOfDayEnabled;
-  }
-  if (typeof input.rainViewerEnabled === 'boolean') {
-    result.rainViewerEnabled = input.rainViewerEnabled;
-  }
-  if (
-    typeof input.airportCircles === 'string' &&
-    AIRPORT_CIRCLES_MODES.includes(input.airportCircles as AirportCirclesMode)
-  ) {
-    result.airportCircles = input.airportCircles as AirportCirclesMode;
-  }
-  if (
-    typeof input.airportCircleRadius === 'string' &&
-    AIRPORT_CIRCLE_RADIUS_MODES.includes(
-      input.airportCircleRadius as AirportCircleRadiusMode,
-    )
-  ) {
-    result.airportCircleRadius =
-      input.airportCircleRadius as AirportCircleRadiusMode;
-  }
-  if (
-    typeof input.arcColor === 'string' &&
-    ARC_COLOR_MODES.includes(input.arcColor as ArcColorMode)
-  ) {
-    result.arcColor = input.arcColor as ArcColorMode;
-  }
-  if (
-    typeof input.arcThickness === 'string' &&
-    ARC_THICKNESS_MODES.includes(input.arcThickness as ArcThicknessMode)
-  ) {
-    result.arcThickness = input.arcThickness as ArcThicknessMode;
-  }
-  if (
-    typeof input.arcThicknessScale === 'string' &&
-    ARC_THICKNESS_SCALES.includes(input.arcThicknessScale as ArcThicknessScale)
-  ) {
-    result.arcThicknessScale = input.arcThicknessScale as ArcThicknessScale;
-  }
-  if (
-    typeof input.routeDisplay === 'string' &&
-    ROUTE_DISPLAY_MODES.includes(input.routeDisplay as RouteDisplayMode)
-  ) {
-    result.routeDisplay = input.routeDisplay as RouteDisplayMode;
-  }
-  if (
-    typeof input.flightTrackStyle === 'string' &&
-    FLIGHT_TRACK_STYLES.includes(input.flightTrackStyle as FlightTrackStyle)
-  ) {
-    result.flightTrackStyle = input.flightTrackStyle as FlightTrackStyle;
-  }
-  if (
-    typeof input.airportOverlayDetail === 'string' &&
-    AIRPORT_OVERLAY_DETAIL_MODES.includes(
-      input.airportOverlayDetail as AirportOverlayDetail,
-    )
-  ) {
-    result.airportOverlayDetail =
-      input.airportOverlayDetail as AirportOverlayDetail;
-  }
-  if (typeof input.openAipEnabled === 'boolean') {
-    result.openAipEnabled = input.openAipEnabled;
-  }
-  if (Array.isArray(input.openAipGroups)) {
-    const validGroups = new Set<string>(OPENAIP_OVERLAY_GROUPS);
-    result.openAipGroups = input.openAipGroups.filter(
-      (g): g is OpenAipOverlayGroup =>
-        typeof g === 'string' && validGroups.has(g),
-    );
-  }
-
-  return result;
-};
-
 let initialized = false;
 
 export const initMapPreferences = () => {
   if (!browser || initialized) return;
   initialized = true;
 
-  let parsed: unknown = undefined;
+  let parsed: unknown;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) parsed = JSON.parse(raw);
   } catch {
-    // corrupt JSON — fall through to defaults
+    // Corrupt JSON falls back to defaults.
   }
 
   const legacyOpenAip = localStorage.getItem(LEGACY_OPENAIP_KEY);
   if (legacyOpenAip !== null) {
-    const legacyValue = legacyOpenAip === 'true';
     const base =
       parsed && typeof parsed === 'object'
         ? (parsed as Record<string, unknown>)
         : {};
     if (!('openAipEnabled' in base)) {
-      parsed = { ...base, openAipEnabled: legacyValue };
+      parsed = { ...base, openAipEnabled: legacyOpenAip === 'true' };
     }
     localStorage.removeItem(LEGACY_OPENAIP_KEY);
   }
 
-  const hydrated = sanitize(parsed);
-  mapPreferences.basemap = hydrated.basemap;
-  mapPreferences.projection = hydrated.projection;
-  mapPreferences.timeOfDayEnabled = hydrated.timeOfDayEnabled;
-  mapPreferences.rainViewerEnabled = hydrated.rainViewerEnabled;
-  mapPreferences.airportCircles = hydrated.airportCircles;
-  mapPreferences.airportCircleRadius = hydrated.airportCircleRadius;
-  mapPreferences.arcColor = hydrated.arcColor;
-  mapPreferences.arcThickness = hydrated.arcThickness;
-  mapPreferences.arcThicknessScale = hydrated.arcThicknessScale;
-  mapPreferences.routeDisplay = hydrated.routeDisplay;
-  mapPreferences.flightTrackStyle = hydrated.flightTrackStyle;
-  mapPreferences.airportOverlayDetail = hydrated.airportOverlayDetail;
-  mapPreferences.openAipEnabled = hydrated.openAipEnabled;
-  mapPreferences.openAipGroups = hydrated.openAipGroups;
+  assignMapPreferences(sanitizeMapPreferences(parsed));
 
   $effect.root(() => {
     $effect(() => {
-      const snapshot: MapPreferences = {
-        basemap: mapPreferences.basemap,
-        projection: mapPreferences.projection,
-        timeOfDayEnabled: mapPreferences.timeOfDayEnabled,
-        rainViewerEnabled: mapPreferences.rainViewerEnabled,
-        airportCircles: mapPreferences.airportCircles,
-        airportCircleRadius: mapPreferences.airportCircleRadius,
-        arcColor: mapPreferences.arcColor,
-        arcThickness: mapPreferences.arcThickness,
-        arcThicknessScale: mapPreferences.arcThicknessScale,
-        routeDisplay: mapPreferences.routeDisplay,
-        flightTrackStyle: mapPreferences.flightTrackStyle,
-        airportOverlayDetail: mapPreferences.airportOverlayDetail,
-        openAipEnabled: mapPreferences.openAipEnabled,
-        openAipGroups: [...mapPreferences.openAipGroups],
-      };
+      const snapshot = sanitizeMapPreferences(mapPreferences);
       try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
       } catch {
-        // quota or private mode — ignore
+        // Storage can fail in private mode or when quota is exhausted.
       }
     });
   });
 };
 
 export const resetMapPreferences = () => {
-  mapPreferences.basemap = MAP_PREFERENCE_DEFAULTS.basemap;
-  mapPreferences.projection = MAP_PREFERENCE_DEFAULTS.projection;
-  mapPreferences.timeOfDayEnabled = MAP_PREFERENCE_DEFAULTS.timeOfDayEnabled;
-  mapPreferences.rainViewerEnabled = MAP_PREFERENCE_DEFAULTS.rainViewerEnabled;
-  mapPreferences.airportCircles = MAP_PREFERENCE_DEFAULTS.airportCircles;
-  mapPreferences.airportCircleRadius =
-    MAP_PREFERENCE_DEFAULTS.airportCircleRadius;
-  mapPreferences.arcColor = MAP_PREFERENCE_DEFAULTS.arcColor;
-  mapPreferences.arcThickness = MAP_PREFERENCE_DEFAULTS.arcThickness;
-  mapPreferences.arcThicknessScale = MAP_PREFERENCE_DEFAULTS.arcThicknessScale;
-  mapPreferences.routeDisplay = MAP_PREFERENCE_DEFAULTS.routeDisplay;
-  mapPreferences.flightTrackStyle = MAP_PREFERENCE_DEFAULTS.flightTrackStyle;
-  mapPreferences.airportOverlayDetail =
-    MAP_PREFERENCE_DEFAULTS.airportOverlayDetail;
-  mapPreferences.openAipEnabled = MAP_PREFERENCE_DEFAULTS.openAipEnabled;
-  mapPreferences.openAipGroups = [...MAP_PREFERENCE_DEFAULTS.openAipGroups];
+  assignMapPreferences(buildDefaults());
 };
 
 export const toggleOpenAipGroup = (group: OpenAipOverlayGroup) => {
   const current = mapPreferences.openAipGroups;
-  if (current.includes(group)) {
-    mapPreferences.openAipGroups = current.filter((g) => g !== group);
-  } else {
-    mapPreferences.openAipGroups = [...current, group];
-  }
+  mapPreferences.openAipGroups = current.includes(group)
+    ? current.filter((value) => value !== group)
+    : [...current, group];
 };

--- a/src/lib/map/map-preferences.test.ts
+++ b/src/lib/map/map-preferences.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAP_PREFERENCE_DEFAULTS,
+  sanitizeMapPreferences,
+} from './map-preferences.svelte';
+
+describe('map preferences', () => {
+  it('sanitizes every preference from the canonical definitions', () => {
+    const preferences = sanitizeMapPreferences({
+      projection: 'globe',
+      routeDisplay: 'invalid',
+      openAipGroups: ['airports', 'invalid'],
+    });
+
+    expect(preferences.projection).toBe('globe');
+    expect(preferences.routeDisplay).toBe(MAP_PREFERENCE_DEFAULTS.routeDisplay);
+    expect(preferences.openAipGroups).toEqual(['airports']);
+    expect(Object.keys(preferences)).toEqual(
+      Object.keys(MAP_PREFERENCE_DEFAULTS),
+    );
+  });
+});

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -64,9 +64,11 @@ export type MapDetailsSelection =
 export const mapDetailsState = $state<{
   selection: MapDetailsSelection | null;
   focusRequest: number;
+  hoveredFlightTrackId: number | null;
 }>({
   selection: null,
   focusRequest: 0,
+  hoveredFlightTrackId: null,
 });
 
 export const openAirportDetails = (airportId: number) => {

--- a/src/lib/track/render.ts
+++ b/src/lib/track/render.ts
@@ -1,7 +1,9 @@
 import {
+  fromFlightTrackSamples,
   MAX_RENDERED_FLIGHT_TRACK_POINTS,
-  pickFlightTrackPoints,
+  toFlightTrackSamples,
   type FlightTrackPayload,
+  type FlightTrackSample,
 } from './schema';
 
 const METERS_PER_DEGREE = 111_320;
@@ -12,28 +14,39 @@ const AIRBORNE_ESTIMATED_GAP_SECONDS = 75;
 const GROUND_ESTIMATED_GAP_SECONDS = 90;
 
 const materializeEstimatedGaps = (
-  track: FlightTrackPayload,
-): FlightTrackPayload => {
-  if (!track.times) return track;
+  samples: FlightTrackSample[],
+): FlightTrackSample[] => {
+  if (!samples.some((sample) => sample.point.time !== undefined)) {
+    return samples;
+  }
 
-  let estimated = track.estimated;
+  let result = samples;
 
-  for (let index = 1; index < track.coordinates.length; index++) {
-    const previousTime = track.times[index - 1];
-    const currentTime = track.times[index];
+  for (let index = 1; index < samples.length; index++) {
+    const previousTime = samples[index - 1]?.point.time;
+    const currentTime = samples[index]?.point.time;
     if (previousTime === undefined || currentTime === undefined) continue;
 
-    const timeout = track.ground?.[index]
+    const timeout = samples[index]?.point.ground
       ? GROUND_ESTIMATED_GAP_SECONDS
       : AIRBORNE_ESTIMATED_GAP_SECONDS;
     if (Math.abs(currentTime - previousTime) <= timeout) continue;
-    if (estimated?.[index]) continue;
+    if (samples[index]?.incomingEdge.estimated) continue;
 
-    estimated = estimated ? [...estimated] : track.coordinates.map(() => false);
-    estimated[index] = true;
+    if (result === samples) {
+      result = samples.map((sample) => ({
+        ...sample,
+        point: { ...sample.point },
+        incomingEdge: {
+          ...sample.incomingEdge,
+          estimated: sample.incomingEdge.estimated ?? false,
+        },
+      }));
+    }
+    result[index]!.incomingEdge.estimated = true;
   }
 
-  return estimated === track.estimated ? track : { ...track, estimated };
+  return result;
 };
 
 const addTransitionBoundaries = <T>(
@@ -48,13 +61,19 @@ const addTransitionBoundaries = <T>(
   }
 };
 
-const collectTransitionGroups = (track: FlightTrackPayload) => {
+const collectTransitionGroups = (samples: FlightTrackSample[]) => {
   const boundaries = new Set<number>();
-  addTransitionBoundaries(boundaries, track.ground);
-  addTransitionBoundaries(boundaries, track.estimated);
   addTransitionBoundaries(
     boundaries,
-    track.coordinates.map((coordinate) => coordinate[2] !== undefined),
+    samples.map((sample) => sample.point.ground),
+  );
+  addTransitionBoundaries(
+    boundaries,
+    samples.map((sample) => sample.incomingEdge.estimated),
+  );
+  addTransitionBoundaries(
+    boundaries,
+    samples.map((sample) => sample.coordinate[2] !== undefined),
   );
 
   const sorted = [...boundaries].sort((a, b) => a - b);
@@ -72,16 +91,16 @@ const collectTransitionGroups = (track: FlightTrackPayload) => {
   return groups;
 };
 
-const getAltitude = (track: FlightTrackPayload, index: number) =>
-  track.coordinates[index]?.[2] ?? null;
+const getAltitude = (samples: FlightTrackSample[], index: number) =>
+  samples[index]?.coordinate[2] ?? null;
 
-const collectAltitudeIndices = (track: FlightTrackPayload) => {
+const collectAltitudeIndices = (samples: FlightTrackSample[]) => {
   const selected = new Set<number>();
 
-  for (let index = 1; index < track.coordinates.length - 1; index++) {
-    const previous = getAltitude(track, index - 1);
-    const current = getAltitude(track, index);
-    const next = getAltitude(track, index + 1);
+  for (let index = 1; index < samples.length - 1; index++) {
+    const previous = getAltitude(samples, index - 1);
+    const current = getAltitude(samples, index);
+    const next = getAltitude(samples, index + 1);
 
     if (
       previous === null ||
@@ -120,14 +139,15 @@ const squaredDistanceToSegment = (
   return (point[0] - projectedX) ** 2 + (point[1] - projectedY) ** 2;
 };
 
-const collectSpatialCornerIndices = (track: FlightTrackPayload) => {
+const collectSpatialCornerIndices = (samples: FlightTrackSample[]) => {
   const selected = new Set<number>();
   const referenceLat =
-    track.coordinates.reduce((sum, coordinate) => sum + coordinate[1], 0) /
-    track.coordinates.length;
+    samples.reduce((sum, sample) => sum + sample.coordinate[1], 0) /
+    samples.length;
   const xScale = METERS_PER_DEGREE * Math.cos((referenceLat * Math.PI) / 180);
-  const points = track.coordinates.map(
-    ([lon, lat]) => [lon * xScale, lat * METERS_PER_DEGREE] as const,
+  const points = samples.map(
+    ({ coordinate: [lon, lat] }) =>
+      [lon * xScale, lat * METERS_PER_DEGREE] as const,
   );
   const thresholdSquared = SPATIAL_CORNER_THRESHOLD_METERS ** 2;
 
@@ -203,13 +223,18 @@ export const reduceFlightTrackForMap = (
   track: FlightTrackPayload,
   maxPoints = MAX_RENDERED_FLIGHT_TRACK_POINTS,
 ): FlightTrackPayload => {
-  const renderTrack = materializeEstimatedGaps(track);
+  const samples = toFlightTrackSamples(track);
+  const renderSamples = materializeEstimatedGaps(samples);
 
-  if (renderTrack.coordinates.length <= maxPoints) return renderTrack;
+  if (renderSamples.length <= maxPoints) {
+    return renderSamples === samples
+      ? track
+      : fromFlightTrackSamples(renderSamples);
+  }
   if (maxPoints < 2) throw new RangeError('A rendered track needs two points');
 
-  const lastIndex = renderTrack.coordinates.length - 1;
-  const transitionGroups = collectTransitionGroups(renderTrack);
+  const lastIndex = renderSamples.length - 1;
+  const transitionGroups = collectTransitionGroups(renderSamples);
   const semanticIndices = new Set<number>([0, lastIndex]);
   transitionGroups.forEach((group) =>
     group.forEach((index) => semanticIndices.add(index)),
@@ -218,26 +243,30 @@ export const reduceFlightTrackForMap = (
   if (semanticIndices.size > maxPoints) {
     const selected = new Set([0, lastIndex]);
     addTransitionGroupsUntilFull(selected, transitionGroups, maxPoints);
-    return pickFlightTrackPoints(
-      renderTrack,
-      [...selected].sort((a, b) => a - b),
+    return fromFlightTrackSamples(
+      [...selected].sort((a, b) => a - b).map((index) => renderSamples[index]!),
     );
   }
 
-  addUntilFull(semanticIndices, collectAltitudeIndices(renderTrack), maxPoints);
   addUntilFull(
     semanticIndices,
-    collectSpatialCornerIndices(renderTrack),
+    collectAltitudeIndices(renderSamples),
     maxPoints,
   );
   addUntilFull(
     semanticIndices,
-    Array.from({ length: renderTrack.coordinates.length }, (_, index) => index),
+    collectSpatialCornerIndices(renderSamples),
+    maxPoints,
+  );
+  addUntilFull(
+    semanticIndices,
+    Array.from({ length: renderSamples.length }, (_, index) => index),
     maxPoints,
   );
 
-  return pickFlightTrackPoints(
-    renderTrack,
-    [...semanticIndices].sort((a, b) => a - b),
+  return fromFlightTrackSamples(
+    [...semanticIndices]
+      .sort((a, b) => a - b)
+      .map((index) => renderSamples[index]!),
   );
 };

--- a/src/lib/track/schema.test.ts
+++ b/src/lib/track/schema.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  fromFlightTrackSamples,
   flightTrackPayloadSchema,
+  toFlightTrackSamples,
   toFlightTrackInput,
   toFlightTrackPayload,
 } from './schema';
@@ -29,8 +31,43 @@ describe('flight track schema helpers', () => {
     ).toBe(false);
   });
 
+  it('rejects coordinates outside valid longitude and latitude ranges', () => {
+    expect(
+      flightTrackPayloadSchema.safeParse({
+        coordinates: [
+          [181, 55],
+          [11, 56],
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      flightTrackPayloadSchema.safeParse({
+        coordinates: [
+          [10, -91],
+          [11, 56],
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   it('copies every aligned property into database payloads', () => {
     expect(toFlightTrackPayload(track)).toEqual(track);
+  });
+
+  it('converts persistence columns to explicit point and edge samples', () => {
+    const samples = toFlightTrackSamples(track);
+
+    expect(samples[1]).toEqual({
+      coordinate: [11, 56, 304.8],
+      point: {
+        time: 1_700_000_060,
+        groundSpeedKt: 120,
+        trackDeg: 95,
+        ground: false,
+      },
+      incomingEdge: { estimated: true },
+    });
+    expect(fromFlightTrackSamples(samples)).toEqual(track);
   });
 
   it('can omit shared timestamps without dropping point flags', () => {

--- a/src/lib/track/schema.ts
+++ b/src/lib/track/schema.ts
@@ -17,27 +17,82 @@ export const flightTrackCoordinateSchema = z
   .refine(
     ([lon, lat, alt]) =>
       Number.isFinite(lon) &&
+      lon >= -180 &&
+      lon <= 180 &&
       Number.isFinite(lat) &&
+      lat >= -90 &&
+      lat <= 90 &&
       (alt === undefined || Number.isFinite(alt)),
     'Invalid track coordinate',
   );
 
-const flightTrackAlignedPropertySchemas = {
-  times: z
-    .number()
-    .int()
-    .array()
-    .max(MAX_STORED_FLIGHT_TRACK_POINTS)
-    .optional(),
-  groundSpeedKt: z
-    .number()
-    .array()
-    .max(MAX_STORED_FLIGHT_TRACK_POINTS)
-    .optional(),
-  trackDeg: z.number().array().max(MAX_STORED_FLIGHT_TRACK_POINTS).optional(),
-  ground: z.boolean().array().max(MAX_STORED_FLIGHT_TRACK_POINTS).optional(),
-  estimated: z.boolean().array().max(MAX_STORED_FLIGHT_TRACK_POINTS).optional(),
+export type FlightTrackSample = {
+  coordinate: FlightTrackCoordinate;
+  point: {
+    time?: number;
+    groundSpeedKt?: number;
+    trackDeg?: number;
+    ground?: boolean;
+  };
+  incomingEdge: {
+    estimated?: boolean;
+  };
 };
+
+const alignedProperty = <T>(
+  schema: z.ZodType<T>,
+  get: (sample: FlightTrackSample) => T | undefined,
+  set: (sample: FlightTrackSample, value: T) => void,
+) => ({
+  schema,
+  get,
+  set: (sample: FlightTrackSample, value: unknown) => set(sample, value as T),
+});
+
+const flightTrackAlignedPropertyDefinitions = {
+  times: alignedProperty(
+    z.number().int(),
+    (sample) => sample.point.time,
+    (sample, value) => (sample.point.time = value),
+  ),
+  groundSpeedKt: alignedProperty(
+    z.number(),
+    (sample) => sample.point.groundSpeedKt,
+    (sample, value) => (sample.point.groundSpeedKt = value),
+  ),
+  trackDeg: alignedProperty(
+    z.number(),
+    (sample) => sample.point.trackDeg,
+    (sample, value) => (sample.point.trackDeg = value),
+  ),
+  ground: alignedProperty(
+    z.boolean(),
+    (sample) => sample.point.ground,
+    (sample, value) => (sample.point.ground = value),
+  ),
+  estimated: alignedProperty(
+    z.boolean(),
+    (sample) => sample.incomingEdge.estimated,
+    (sample, value) => (sample.incomingEdge.estimated = value),
+  ),
+} as const;
+
+type AlignedPropertySchemas<
+  Definitions extends Record<string, { schema: z.ZodTypeAny }>,
+> = {
+  [Key in keyof Definitions]: z.ZodOptional<
+    z.ZodArray<Definitions[Key]['schema']>
+  >;
+};
+
+const flightTrackAlignedPropertySchemas = Object.fromEntries(
+  Object.entries(flightTrackAlignedPropertyDefinitions).map(
+    ([key, definition]) => [
+      key,
+      definition.schema.array().max(MAX_STORED_FLIGHT_TRACK_POINTS).optional(),
+    ],
+  ),
+) as AlignedPropertySchemas<typeof flightTrackAlignedPropertyDefinitions>;
 type FlightTrackAlignedPropertyKey =
   keyof typeof flightTrackAlignedPropertySchemas;
 const flightTrackAlignedPropertyKeys = Object.keys(
@@ -105,10 +160,62 @@ export const copyFlightTrackAlignedProperties = (
   for (const key of flightTrackAlignedPropertyKeys) {
     if (key === 'times' && !includeTimes) continue;
     const values = track[key];
-    if (values !== undefined) Object.assign(properties, { [key]: values });
+    if (values !== undefined) {
+      Object.assign(properties, { [key]: values });
+    }
   }
 
   return properties;
+};
+
+export const toFlightTrackSamples = (
+  track: FlightTrackPayloadSource,
+): FlightTrackSample[] => {
+  const samples = track.coordinates.map((coordinate) => ({
+    coordinate,
+    point: {},
+    incomingEdge: {},
+  }));
+
+  for (const key of flightTrackAlignedPropertyKeys) {
+    const values = track[key];
+    if (values === undefined) continue;
+    const definition = flightTrackAlignedPropertyDefinitions[key];
+    values.forEach((value, index) => definition.set(samples[index]!, value));
+  }
+
+  return samples;
+};
+
+const collectSampleProperty = <T>(
+  samples: FlightTrackSample[],
+  getValue: (sample: FlightTrackSample) => T | undefined,
+) => {
+  const values = samples.map(getValue);
+  if (values.every((value) => value === undefined)) return undefined;
+  if (values.some((value) => value === undefined)) {
+    throw new Error('Track sample properties must be present for every point');
+  }
+  return values as T[];
+};
+
+export const fromFlightTrackSamples = (
+  samples: FlightTrackSample[],
+): FlightTrackPayload => {
+  const properties: FlightTrackAlignedProperties = {};
+
+  for (const key of flightTrackAlignedPropertyKeys) {
+    const definition = flightTrackAlignedPropertyDefinitions[key];
+    const values = collectSampleProperty(samples, definition.get);
+    if (values !== undefined) {
+      Object.assign(properties, { [key]: values });
+    }
+  }
+
+  return {
+    coordinates: samples.map((sample) => sample.coordinate),
+    ...properties,
+  };
 };
 
 export const pickFlightTrackPoints = (
@@ -119,10 +226,11 @@ export const pickFlightTrackPoints = (
 
   for (const key of flightTrackAlignedPropertyKeys) {
     const values = track[key];
-    if (values === undefined) continue;
-    Object.assign(properties, {
-      [key]: indices.map((index) => values[index]!),
-    });
+    if (values !== undefined) {
+      Object.assign(properties, {
+        [key]: indices.map((index) => values[index]!),
+      });
+    }
   }
 
   return {

--- a/src/lib/utils/data/airport-visits.test.ts
+++ b/src/lib/utils/data/airport-visits.test.ts
@@ -1,25 +1,27 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  getAirportVisitSummary,
-  type AirportVisitFlight,
-} from './airport-visits';
+import type { Flight } from '$lib/db/types';
+import { getAirportVisitSummary } from './airport-visits';
+import { prepareFlightData } from './data';
 
-const baseFlight = (): AirportVisitFlight => ({
-  from: { id: 1, tz: 'America/Los_Angeles' },
-  to: { id: 2, tz: 'America/New_York' },
-  datePrecision: 'day',
-  duration: 14_400,
-  departure: null,
-  arrival: null,
-  departureScheduled: null,
-  arrivalScheduled: null,
-  takeoffScheduled: null,
-  takeoffActual: null,
-  landingScheduled: null,
-  landingActual: null,
-  raw: { date: '2024-06-14' },
-});
+const baseFlight = (): Flight =>
+  ({
+    from: { id: 1, tz: 'America/Los_Angeles', lon: -118, lat: 34 },
+    to: { id: 2, tz: 'America/New_York', lon: -74, lat: 40 },
+    date: '2024-06-14',
+    datePrecision: 'day',
+    duration: 14_400,
+    departure: null,
+    arrival: null,
+    departureScheduled: null,
+    arrivalScheduled: null,
+    takeoffScheduled: null,
+    takeoffActual: null,
+    landingScheduled: null,
+    landingActual: null,
+  }) as Flight;
+
+const prepare = (flight: Flight) => prepareFlightData([flight])[0]!;
 
 describe('airport visit summary', () => {
   it('uses day precision for an exact timestamp on a coarse flight date', () => {
@@ -27,11 +29,14 @@ describe('airport visit summary', () => {
       ...baseFlight(),
       datePrecision: 'month',
       arrivalScheduled: '2024-06-14T09:45:00.000Z',
-    } satisfies AirportVisitFlight;
+    } as Flight;
 
     expect(
-      getAirportVisitSummary([flight], 2, new Date('2024-07-01T00:00:00Z'))
-        .last,
+      getAirportVisitSummary(
+        [prepare(flight)],
+        2,
+        new Date('2024-07-01T00:00:00Z'),
+      ).last,
     ).toContain('14');
   });
 
@@ -39,11 +44,14 @@ describe('airport visit summary', () => {
     const flight = {
       ...baseFlight(),
       departureScheduled: '2024-06-15T06:00:00.000Z',
-    } satisfies AirportVisitFlight;
+    } as Flight;
 
     expect(
-      getAirportVisitSummary([flight], 2, new Date('2024-07-01T00:00:00Z'))
-        .last,
+      getAirportVisitSummary(
+        [prepare(flight)],
+        2,
+        new Date('2024-07-01T00:00:00Z'),
+      ).last,
     ).toContain('15');
   });
 
@@ -51,14 +59,18 @@ describe('airport visit summary', () => {
     const flight = { ...baseFlight(), duration: null };
 
     expect(
-      getAirportVisitSummary([flight], 2, new Date('2024-07-01T00:00:00Z')),
+      getAirportVisitSummary(
+        [prepare(flight)],
+        2,
+        new Date('2024-07-01T00:00:00Z'),
+      ),
     ).toEqual({ last: null, next: null });
   });
 
   it('does not classify an imprecise range that contains now', () => {
     expect(
       getAirportVisitSummary(
-        [baseFlight()],
+        [prepare(baseFlight())],
         1,
         new Date('2024-06-14T12:00:00Z'),
       ),

--- a/src/lib/utils/data/airport-visits.ts
+++ b/src/lib/utils/data/airport-visits.ts
@@ -1,94 +1,14 @@
-import { TZDate } from '@date-fns/tz';
-
-import type { FlightDatePrecision } from '$lib/db/types';
+import { formatAsFlightDate } from '$lib/utils/datetime';
+import type { FlightData } from './data';
 import {
-  formatAsFlightDate,
-  getFlightDateRange,
-  parseLocalizeISO,
-} from '$lib/utils/datetime';
-
-type AirportRef = { id: number; tz: string };
-
-export type AirportVisitFlight = {
-  from: AirportRef | null;
-  to: AirportRef | null;
-  datePrecision: FlightDatePrecision;
-  duration: number | null;
-  departure: TZDate | null;
-  arrival: TZDate | null;
-  departureScheduled: string | null;
-  arrivalScheduled: string | null;
-  takeoffScheduled: string | null;
-  takeoffActual: string | null;
-  landingScheduled: string | null;
-  landingActual: string | null;
-  raw: { date: string };
-};
-
-type VisitWindow = {
-  start: TZDate;
-  end: TZDate;
-  precision: FlightDatePrecision;
-};
-
-const parseTime = (value: string | null, tz: string) =>
-  value ? parseLocalizeISO(value, tz) : null;
-
-const exactWindow = (date: TZDate): VisitWindow => ({
-  start: date,
-  end: date,
-  precision: 'day',
-});
-
-const departureTime = (flight: AirportVisitFlight) => {
-  const tz = flight.from?.tz ?? 'UTC';
-  return (
-    flight.departure ??
-    parseTime(flight.takeoffActual, tz) ??
-    parseTime(flight.departureScheduled, tz) ??
-    parseTime(flight.takeoffScheduled, tz)
-  );
-};
-
-const arrivalTime = (flight: AirportVisitFlight, departure: TZDate | null) => {
-  const tz = flight.to?.tz ?? 'UTC';
-  const recorded =
-    flight.arrival ??
-    parseTime(flight.landingActual, tz) ??
-    parseTime(flight.arrivalScheduled, tz) ??
-    parseTime(flight.landingScheduled, tz);
-
-  if (recorded || !departure || flight.duration === null) return recorded;
-  return new TZDate(departure.getTime() + flight.duration * 1_000, tz);
-};
-
-const visitWindow = (
-  flight: AirportVisitFlight,
-  direction: 'departure' | 'arrival',
-): VisitWindow | null => {
-  const departure = departureTime(flight);
-  const exact =
-    direction === 'departure' ? departure : arrivalTime(flight, departure);
-  if (exact) return exactWindow(exact);
-  if (direction === 'arrival') return null;
-
-  const range = getFlightDateRange(
-    flight.raw.date,
-    flight.datePrecision,
-    flight.from?.tz ?? 'UTC',
-  );
-  if (!range.start || !range.end) return null;
-  return {
-    start: range.start,
-    end: range.end,
-    precision: flight.datePrecision,
-  };
-};
+  getFlightTimelineWindow,
+  resolveFlightTimeline,
+} from './flight-timeline';
 
 type Visit = { label: string; time: number };
 
 export const getAirportVisitSummary = (
-  flights: AirportVisitFlight[],
+  flights: FlightData[],
   airportId: number,
   now: Date,
 ) => {
@@ -96,9 +16,14 @@ export const getAirportVisitSummary = (
   let next: Visit | null = null;
 
   for (const flight of flights) {
+    const timeline = resolveFlightTimeline(flight.raw);
     const windows = [
-      flight.from?.id === airportId ? visitWindow(flight, 'departure') : null,
-      flight.to?.id === airportId ? visitWindow(flight, 'arrival') : null,
+      flight.from?.id === airportId
+        ? getFlightTimelineWindow(timeline, 'departure')
+        : null,
+      flight.to?.id === airportId
+        ? getFlightTimelineWindow(timeline, 'arrival')
+        : null,
     ];
 
     for (const window of windows) {

--- a/src/lib/utils/data/data.ts
+++ b/src/lib/utils/data/data.ts
@@ -1,14 +1,12 @@
 import { TZDate } from '@date-fns/tz';
 import { isAfter } from 'date-fns';
 
+import { resolveFlightTimeline } from './flight-timeline';
+
 import { page } from '$app/state';
 import type { Airport, Flight, FlightSeat } from '$lib/db/types';
 import { distanceBetween, toTitleCase } from '$lib/utils';
-import {
-  getFlightDateRange,
-  nowIn,
-  parseLocalizeISO,
-} from '$lib/utils/datetime';
+import { nowIn } from '$lib/utils/datetime';
 
 type ExcludedType<T, U> = {
   [P in keyof T as P extends keyof U ? never : P]: T[P];
@@ -26,37 +24,33 @@ type FlightOverrides = {
 export type FlightData = ExcludedType<Flight, FlightOverrides> &
   FlightOverrides;
 
+export const formatSimpleFlight = (flight: FlightData) => ({
+  id: flight.id,
+  airports: [flight.from?.id, flight.to?.id],
+  fromCode: flight.from?.iata ?? flight.from?.icao ?? 'N/A',
+  toCode: flight.to?.iata ?? flight.to?.icao ?? 'N/A',
+  date: flight.date,
+  dateStart: flight.dateStart,
+  datePrecision: flight.datePrecision,
+  airline: flight.airline ?? '',
+});
+
+export type SimpleFlight = ReturnType<typeof formatSimpleFlight>;
+
 export const prepareFlightData = (data: Flight[]): FlightData[] => {
   if (!data) return [];
 
   return data
     .map((flight) => {
-      const { start: dateStart, end: dateEnd } = getFlightDateRange(
-        flight.date,
-        flight.datePrecision,
-        flight.from?.tz ?? 'UTC',
-      );
-      const hasExactDateTime = flight.datePrecision === 'day';
-
-      const departure =
-        hasExactDateTime && flight.departure && flight.from
-          ? parseLocalizeISO(flight.departure, flight.from.tz)
-          : hasExactDateTime && flight.departure
-            ? parseLocalizeISO(flight.departure, 'UTC')
-            : null;
+      const timeline = resolveFlightTimeline(flight);
 
       return {
         ...flight,
-        date: departure ?? dateStart,
-        dateStart,
-        dateEnd,
-        departure,
-        arrival:
-          hasExactDateTime && flight.arrival && flight.to
-            ? parseLocalizeISO(flight.arrival, flight.to.tz)
-            : hasExactDateTime && flight.arrival
-              ? parseLocalizeISO(flight.arrival, 'UTC')
-              : null,
+        date: timeline.recordedDeparture ?? timeline.dateStart,
+        dateStart: timeline.dateStart,
+        dateEnd: timeline.dateEnd,
+        departure: timeline.recordedDeparture,
+        arrival: timeline.recordedArrival,
         distance:
           flight.from && flight.to
             ? distanceBetween(
@@ -78,7 +72,7 @@ export const prepareFlightArcData = (data: FlightData[]) => {
       distance: number;
       from: Airport;
       to: Airport;
-      flights: ReturnType<typeof formatSimpleFlight>[];
+      flights: SimpleFlight[];
       airlines: number[];
       exclusivelyFuture: boolean;
       frequency: number;
@@ -142,7 +136,7 @@ export const prepareVisitedAirports = (data: FlightData[]) => {
     arrivals: number;
     departures: number;
     airlines: number[];
-    flights: ReturnType<typeof formatSimpleFlight>[];
+    flights: SimpleFlight[];
     frequency: number;
   })[] = [];
   const formatAirport = (flight: FlightData, direction: 'from' | 'to') => {
@@ -199,18 +193,6 @@ export const prepareVisitedAirports = (data: FlightData[]) => {
   });
 
   return visited;
-};
-
-const formatSimpleFlight = (f: FlightData) => {
-  return {
-    id: f.id,
-    airports: [f.from?.id, f.to?.id],
-    route: `${f.from?.iata ?? f.from?.icao ?? 'N/A'} - ${f.to?.iata ?? f.to?.icao ?? 'N/A'}`,
-    date: f.date,
-    dateStart: f.dateStart,
-    datePrecision: f.datePrecision,
-    airline: f.airline ?? '',
-  };
 };
 
 export const formatSeat = (f: FlightData) => {

--- a/src/lib/utils/data/flight-timeline.ts
+++ b/src/lib/utils/data/flight-timeline.ts
@@ -1,0 +1,87 @@
+import { TZDate } from '@date-fns/tz';
+
+import type { Flight, FlightDatePrecision } from '$lib/db/types';
+import { getFlightDateRange, parseLocalizeISO } from '$lib/utils/datetime';
+
+export type FlightTimeline = {
+  precision: FlightDatePrecision;
+  dateStart: TZDate | null;
+  dateEnd: TZDate | null;
+  recordedDeparture: TZDate | null;
+  recordedArrival: TZDate | null;
+  effectiveDeparture: TZDate | null;
+  effectiveArrival: TZDate | null;
+};
+
+export type FlightTimelineWindow = {
+  start: TZDate;
+  end: TZDate;
+  precision: FlightDatePrecision;
+};
+
+const parseTime = (value: string | null, timezone: string) =>
+  value ? parseLocalizeISO(value, timezone) : null;
+
+export const resolveFlightTimeline = (flight: Flight): FlightTimeline => {
+  const fromTimezone = flight.from?.tz ?? 'UTC';
+  const toTimezone = flight.to?.tz ?? 'UTC';
+  const { start: dateStart, end: dateEnd } = getFlightDateRange(
+    flight.date,
+    flight.datePrecision,
+    fromTimezone,
+  );
+  const hasExactDate = flight.datePrecision === 'day';
+  const recordedDeparture = hasExactDate
+    ? parseTime(flight.departure, fromTimezone)
+    : null;
+  const recordedArrival = hasExactDate
+    ? parseTime(flight.arrival, toTimezone)
+    : null;
+  const effectiveDeparture =
+    recordedDeparture ??
+    parseTime(flight.takeoffActual, fromTimezone) ??
+    parseTime(flight.departureScheduled, fromTimezone) ??
+    parseTime(flight.takeoffScheduled, fromTimezone);
+  const recordedOrScheduledArrival =
+    recordedArrival ??
+    parseTime(flight.landingActual, toTimezone) ??
+    parseTime(flight.arrivalScheduled, toTimezone) ??
+    parseTime(flight.landingScheduled, toTimezone);
+  const effectiveArrival =
+    recordedOrScheduledArrival ??
+    (effectiveDeparture && flight.duration !== null
+      ? new TZDate(
+          effectiveDeparture.getTime() + flight.duration * 1_000,
+          toTimezone,
+        )
+      : null);
+
+  return {
+    precision: flight.datePrecision,
+    dateStart,
+    dateEnd,
+    recordedDeparture,
+    recordedArrival,
+    effectiveDeparture,
+    effectiveArrival,
+  };
+};
+
+export const getFlightTimelineWindow = (
+  timeline: FlightTimeline,
+  direction: 'departure' | 'arrival',
+): FlightTimelineWindow | null => {
+  const exact =
+    direction === 'departure'
+      ? timeline.effectiveDeparture
+      : timeline.effectiveArrival;
+  if (exact) return { start: exact, end: exact, precision: 'day' };
+  if (direction === 'arrival' || !timeline.dateStart || !timeline.dateEnd) {
+    return null;
+  }
+  return {
+    start: timeline.dateStart,
+    end: timeline.dateEnd,
+    precision: timeline.precision,
+  };
+};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,6 +4,7 @@ export { parseCsv } from './csv';
 export { readFile } from './file';
 export {
   type FlightData,
+  type SimpleFlight,
   formatSeatForUser,
   getFlightPassengerLabels,
   getSeatPassengerLabel,


### PR DESCRIPTION
Fix #643

Interpolating coordinates along great circle with turf.js, and flatten when returns MultiLineString when crossing antimeridian.

Pass user preferences to the function used to display the date, similar to the preview.svelte. Does fix the panel but not 100% sure it fixes tooltip as I cannot invoke it.

Before:

<img width="1306" height="1159" alt="beforeGlobe" src="https://github.com/user-attachments/assets/4ff1484a-1b72-4b18-9358-61b634885bdd" />
<img width="3200" height="1572" alt="before" src="https://github.com/user-attachments/assets/4f24554f-fc34-41b4-b243-46943e0b3518" />

After:

<img width="1482" height="1312" alt="afterGlobe" src="https://github.com/user-attachments/assets/c9905814-6aac-4e87-8164-ebaf55ddfe5c" />
<img width="3200" height="1579" alt="after" src="https://github.com/user-attachments/assets/495c4664-8456-4c58-948e-70667f8371dd" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add globe-aware great-circle flight track paths and dark mode track coloring to the map
> - Introduces great-circle subdivision for flight track display paths in [flight-track-display-geometry.ts](https://github.com/johanohly/AirTrail/pull/657/files#diff-5f678a64e5e39f23fb1d523cfe9bba1a22ea03be39102c122bfbec35ca1e574a), respecting a shared global point budget (`MAX_FLIGHT_TRACK_DISPLAY_POINTS`) across all rendered layers.
> - Adds dark mode awareness to flight track colors and the legend; ground tracks and estimated segments now use HSL-based darkening instead of uniform RGB scaling.
> - Tracks now use a sample-based data model (`FlightTrackSample[]`) throughout the rendering pipeline, replacing parallel `path`/`ground`/`estimated` arrays.
> - Introduces `hoveredFlightTrackId` in shared map state, with green indicator dots in airport and route detail panels when a track is hovered on the map.
> - Centralizes map preferences in `MAP_PREFERENCE_DEFINITIONS` with typed factories for boolean, choice, and array preferences, replacing scattered constants and manual sanitization.
> - Adds a reusable `PopupFlightList` component for map popups showing up to 5 recent flights with airline, route, and date.
> - Risk: `buildFlightTrackPaths` no longer applies longitude unwrapping; longitudes are passed through as-is from source data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85b6687.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->