### PR TITLE
fix: secure AirTrail backup imports

### DIFF
--- a/docs/content/docs/features/import.mdx
+++ b/docs/content/docs/features/import.mdx
@@ -177,3 +177,16 @@ Once you have the JSON file, you can import it into AirTrail by following these 
 6. Click on the "Import" button to start the import process.
 
 After the import process is complete, you will see your flights on the map.
+
+AirTrail offers two import modes:
+
+- Personal import is available to every user. Select the account in the export
+  that belongs to you. AirTrail imports only that account's flights and adds
+  other passengers as guests.
+- Instance restore is available to admins and owners. Enable "Restore flights
+  for all mapped users" to preserve user assignments and deduplicate against
+  every flight on the instance.
+
+AirTrail treats uploaded files as untrusted. The server rejects personal
+imports that assign flights to another local user, even if the file or client
+requests those assignments.

--- a/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
@@ -9,6 +9,7 @@
 
   import { Info } from '@o7/icon/lucide';
 
+  import { page } from '$app/state';
   import * as Alert from '$lib/components/ui/alert';
   import { Button } from '$lib/components/ui/button';
   import { Card } from '$lib/components/ui/card';
@@ -52,6 +53,14 @@
   let ownerOnly = $state(false);
   let matchAirlineFromFlightNumber = $state(true);
   let dedupeImportedFlights = $state(true);
+  let restoreMode = $state(false);
+
+  const importMode = $derived<'personal' | 'restore'>(
+    platform.value === 'airtrail' && restoreMode ? 'restore' : 'personal',
+  );
+  const canRestore = $derived(
+    !!page.data.user && page.data.user.role !== 'user',
+  );
 
   const steps = $derived(
     platform.value === 'airtrail'
@@ -116,6 +125,7 @@
       const stats = await $createMany.mutateAsync({
         flights: batch.map(({ flight }) => flight),
         dedupe: dedupeImportedFlights,
+        mode: importMode,
       });
 
       return {
@@ -159,6 +169,7 @@
     const result = await processFile(originalFile, platform.value, {
       filterOwner: ownerOnly,
       airlineFromFlightNumber: matchAirlineFromFlightNumber,
+      importMode,
       airportMapping: mapping?.airportMapping,
       airlineMapping: mapping?.airlineMapping,
       userMapping: mapping?.userMapping,
@@ -244,14 +255,8 @@
       const result = await processFile(file, platform.value, {
         filterOwner: ownerOnly,
         airlineFromFlightNumber: matchAirlineFromFlightNumber,
+        importMode,
       });
-
-      if (!result.flights.length) {
-        toast.error('No flights found in the file');
-        files = null;
-        importing = false;
-        return;
-      }
 
       unknownUsers = result.unknownUsers;
       exportedUsers = result.exportedUsers;
@@ -265,6 +270,13 @@
         files = null;
         importing = false;
         step = 4;
+        return;
+      }
+
+      if (!result.flights.length) {
+        toast.error('No flights found in the file');
+        files = null;
+        importing = false;
         return;
       }
 
@@ -325,6 +337,7 @@
     ownerOnly = false;
     matchAirlineFromFlightNumber = true;
     dedupeImportedFlights = true;
+    restoreMode = false;
     platform = platforms[0];
     step = 1;
     open = false;
@@ -386,6 +399,10 @@
         <Alert.Description>
           Custom field values are included in the export for reference, but are
           not restored during import.
+          {#if !canRestore}
+            Only flights belonging to the exported account you map to yourself
+            will be imported. Other passengers will be added as guests.
+          {/if}
         </Alert.Description>
       </Alert.Root>
     {/if}
@@ -405,9 +422,11 @@
     <OptionsStep
       showAirlineFromFlightNumber={platform.options.airlineFromFlightNumber}
       showFilterOwner={platform.options.filterOwner}
+      showRestoreMode={platform.value === 'airtrail' && canRestore}
       bind:ownerOnly
       bind:matchAirlineFromFlightNumber
       bind:dedupeImportedFlights
+      bind:restoreMode
       {importing}
       {canImport}
       onback={() => (step = 2)}
@@ -417,6 +436,7 @@
     <UserMappingStep
       {exportedUsers}
       {userMapping}
+      {restoreMode}
       busy={importing}
       onback={() => (step = 3)}
       onnext={handleUserMappingNext}

--- a/src/lib/components/modals/settings/pages/import-page/OptionsStep.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/OptionsStep.svelte
@@ -8,9 +8,11 @@
   let {
     showAirlineFromFlightNumber = false,
     showFilterOwner = false,
+    showRestoreMode = false,
     ownerOnly = $bindable(false),
     matchAirlineFromFlightNumber = $bindable(true),
     dedupeImportedFlights = $bindable(true),
+    restoreMode = $bindable(false),
     importing = false,
     canImport = false,
     onback,
@@ -18,9 +20,11 @@
   }: {
     showAirlineFromFlightNumber?: boolean;
     showFilterOwner?: boolean;
+    showRestoreMode?: boolean;
     ownerOnly?: boolean;
     matchAirlineFromFlightNumber?: boolean;
     dedupeImportedFlights?: boolean;
+    restoreMode?: boolean;
     importing?: boolean;
     canImport?: boolean;
     onback?: () => void;
@@ -56,6 +60,24 @@
         <Label id="owner-only-label" for="owner-only"
           >Only import your flights</Label
         >
+      </div>
+    {/if}
+    {#if showRestoreMode}
+      <div class="flex items-start gap-2">
+        <Checkbox
+          id="restore-all-users"
+          bind:checked={restoreMode}
+          aria-labelledby="restore-all-users-label"
+        />
+        <div class="space-y-0.5">
+          <Label id="restore-all-users-label" for="restore-all-users">
+            Restore flights for all mapped users
+          </Label>
+          <p class="text-xs text-muted-foreground">
+            Deduplicates against every flight on this instance. Admin access is
+            required.
+          </p>
+        </div>
       </div>
     {/if}
     <div class="flex items-center gap-2">

--- a/src/lib/components/modals/settings/pages/import-page/UserMappingStep.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/UserMappingStep.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Users } from '@o7/icon/lucide';
 
+  import { page } from '$app/state';
   import { Button } from '$lib/components/ui/button';
   import { Card } from '$lib/components/ui/card';
   import * as Select from '$lib/components/ui/select';
@@ -9,6 +10,7 @@
   let {
     exportedUsers = [],
     userMapping = {},
+    restoreMode = false,
     busy = false,
     onback,
     onnext,
@@ -20,6 +22,7 @@
       mappedUserId: string | null;
     }[];
     userMapping?: Record<string, string>;
+    restoreMode?: boolean;
     busy?: boolean;
     onback?: () => void;
     onnext?: (userMapping: Record<string, string>) => void;
@@ -30,9 +33,31 @@
   let localMapping = $state<Record<string, string>>({ ...userMapping });
 
   const mappedCount = $derived(Object.keys(localMapping).length);
+  const canContinue = $derived(
+    restoreMode ||
+      Object.values(localMapping).filter(
+        (mappedUserId) => mappedUserId === page.data.user?.id,
+      ).length === 1,
+  );
+
+  type MappableUser = {
+    id: string;
+    username: string;
+    displayName: string;
+  };
+
+  const selectableUsers = (users: MappableUser[]) =>
+    restoreMode
+      ? users
+      : users.filter((user) => user.id === page.data.user?.id);
 
   const setUserMapping = (exportedUserId: string, mappedUserId: string) => {
     if (mappedUserId) {
+      if (!restoreMode) {
+        for (const id of Object.keys(localMapping)) {
+          delete localMapping[id];
+        }
+      }
       localMapping[exportedUserId] = mappedUserId;
     } else {
       delete localMapping[exportedUserId];
@@ -41,15 +66,23 @@
 </script>
 
 <div class="space-y-4">
-  <h3 class="text-sm font-medium">Map exported users</h3>
+  <h3 class="text-sm font-medium">
+    {restoreMode ? 'Map exported users' : 'Choose your exported account'}
+  </h3>
 
   <Card class="p-4 space-y-4">
     <div class="flex items-start gap-3">
       <Users class="text-muted-foreground mt-0.5 shrink-0" size={20} />
       <div>
-        <p class="text-sm">Review and adjust user mapping before import.</p>
+        <p class="text-sm">
+          {restoreMode
+            ? 'Review and adjust user mapping before import.'
+            : 'Choose which account in the export belongs to you.'}
+        </p>
         <p class="text-xs text-muted-foreground mt-1">
-          Username matches are pre-selected when possible.
+          {restoreMode
+            ? 'Unmapped users are imported as guests.'
+            : 'Only flights belonging to this account will be imported.'}
         </p>
       </div>
     </div>
@@ -79,15 +112,20 @@
                     {#if selectedUser}
                       {selectedUser.displayName} (@{selectedUser.username})
                     {:else}
-                      Select local user...
+                      {restoreMode ? 'Select local user...' : 'Not me'}
                     {/if}
                   {:else}
-                    No mapping (import as guest)
+                    {restoreMode ? 'No mapping (import as guest)' : 'Not me'}
                   {/if}
                 </Select.Trigger>
                 <Select.Content>
-                  <Select.Item value="" label="No mapping (import as guest)" />
-                  {#each users as user (user.id)}
+                  <Select.Item
+                    value=""
+                    label={restoreMode
+                      ? 'No mapping (import as guest)'
+                      : 'Not me'}
+                  />
+                  {#each selectableUsers(users) as user (user.id)}
                     <Select.Item
                       value={user.id}
                       label={`${user.displayName} (@${user.username})`}
@@ -102,7 +140,13 @@
 
       <div class="mt-4 p-3 bg-muted/30 rounded-md border border-muted">
         <p class="text-xs text-muted-foreground">
-          {mappedCount} of {exportedUsers.length} users mapped
+          {#if restoreMode}
+            {mappedCount} of {exportedUsers.length} users mapped
+          {:else}
+            {canContinue
+              ? 'Your exported account is selected'
+              : 'Select your exported account to continue'}
+          {/if}
         </p>
       </div>
     {/await}
@@ -111,8 +155,9 @@
       <Button variant="outline" onclick={() => onback?.()} disabled={busy}
         >Back</Button
       >
-      <Button onclick={() => onnext?.(localMapping)} disabled={busy}
-        >Continue Import</Button
+      <Button
+        onclick={() => onnext?.(localMapping)}
+        disabled={busy || !canContinue}>Continue Import</Button
       >
     </div>
   </Card>

--- a/src/lib/components/modals/settings/pages/import-page/index.ts
+++ b/src/lib/components/modals/settings/pages/import-page/index.ts
@@ -8,6 +8,7 @@ export type ImportFailure = {
 export type PlatformOptions = {
   filterOwner: boolean;
   airlineFromFlightNumber: boolean;
+  importMode: 'personal' | 'restore';
   airportMapping?: Record<string, Airport>;
   airlineMapping?: Record<string, Airline>;
   userMapping?: Record<string, string>; // exported user id -> local user id

--- a/src/lib/import/airtrail.test.ts
+++ b/src/lib/import/airtrail.test.ts
@@ -9,6 +9,7 @@ const {
   getAircraftByIcao,
   getAircraftByName,
   userListQuery,
+  currentUser,
 } = vi.hoisted(() => ({
   getAirportByIcao: vi.fn(async (icao: string) => ({
     id: 1,
@@ -42,15 +43,17 @@ const {
       displayName: 'John Local',
     },
   ]),
+  currentUser: {
+    id: 'local-user',
+    username: 'john',
+    role: 'user',
+  },
 }));
 
 vi.mock('$app/state', () => ({
   page: {
     data: {
-      user: {
-        id: 'local-user',
-        username: 'john',
-      },
+      user: currentUser,
     },
   },
 }));
@@ -82,6 +85,7 @@ vi.mock('$lib/utils/data/aircraft', () => ({
 const baseOptions = {
   filterOwner: false,
   airlineFromFlightNumber: false,
+  importMode: 'personal' as const,
 };
 
 const exportedUsers = [
@@ -130,6 +134,18 @@ const airportObject = (icao: string, id?: number) => ({
 describe('processAirTrailFile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.assign(currentUser, {
+      id: 'local-user',
+      username: 'john',
+      role: 'user',
+    });
+    userListQuery.mockResolvedValue([
+      {
+        id: 'local-user',
+        username: 'john',
+        displayName: 'John Local',
+      },
+    ]);
   });
 
   it('imports later v3 JSON exports with nested airport, airline, and aircraft objects', async () => {
@@ -255,5 +271,142 @@ describe('processAirTrailFile', () => {
     expect(result.flights[0]?.aircraft).toMatchObject({
       name: 'Unknown Aircraft',
     });
+  });
+
+  it('limits personal imports to the selected exported account', async () => {
+    const otherUser = {
+      id: 'export-other',
+      username: 'jane',
+      displayName: 'Jane Export',
+    };
+    userListQuery.mockResolvedValue([
+      {
+        id: 'local-user',
+        username: 'john',
+        displayName: 'John Local',
+      },
+      {
+        id: 'local-other',
+        username: 'jane',
+        displayName: 'Jane Local',
+      },
+    ]);
+
+    const content = JSON.stringify({
+      users: [...exportedUsers, otherUser],
+      flights: [
+        {
+          ...flightBase,
+          from: airportObject('EKCH'),
+          to: airportObject('EIDW'),
+          airline: null,
+          aircraft: null,
+          seats: [
+            seat,
+            {
+              ...seat,
+              userId: otherUser.id,
+              seatNumber: '12B',
+            },
+          ],
+        },
+        {
+          ...flightBase,
+          flightNumber: 'SK456',
+          from: airportObject('EIDW'),
+          to: airportObject('EKCH'),
+          airline: null,
+          aircraft: null,
+          seats: [{ ...seat, userId: otherUser.id }],
+        },
+      ],
+    });
+
+    const result = await processAirTrailFile(content, {
+      ...baseOptions,
+      userMapping: { 'export-user': 'local-user' },
+    });
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0]?.seats).toEqual([
+      { ...seat, userId: 'local-user' },
+      {
+        ...seat,
+        userId: null,
+        guestName: 'Jane Export',
+        seatNumber: '12B',
+      },
+    ]);
+  });
+
+  it('restores mapped passengers without adding the importing admin', async () => {
+    Object.assign(currentUser, {
+      id: 'import-admin',
+      username: 'admin',
+      role: 'admin',
+    });
+    userListQuery.mockResolvedValue([
+      {
+        id: 'import-admin',
+        username: 'admin',
+        displayName: 'Import Admin',
+      },
+      {
+        id: 'local-user',
+        username: 'john',
+        displayName: 'John Local',
+      },
+    ]);
+
+    const content = JSON.stringify({
+      users: exportedUsers,
+      flights: [
+        {
+          ...flightBase,
+          from: airportObject('EKCH'),
+          to: airportObject('EIDW'),
+          airline: null,
+          aircraft: null,
+        },
+      ],
+    });
+
+    const result = await processAirTrailFile(content, {
+      ...baseOptions,
+      importMode: 'restore',
+      userMapping: { 'export-user': 'local-user' },
+    });
+
+    expect(result.flights[0]?.seats).toEqual([
+      { ...seat, userId: 'local-user' },
+    ]);
+    expect(result.flights[0]?.seats).not.toContainEqual(
+      expect.objectContaining({ userId: 'import-admin' }),
+    );
+  });
+
+  it('treats an explicit empty restore mapping as guest passengers', async () => {
+    const content = JSON.stringify({
+      users: exportedUsers,
+      flights: [
+        {
+          ...flightBase,
+          from: airportObject('EKCH'),
+          to: airportObject('EIDW'),
+          airline: null,
+          aircraft: null,
+        },
+      ],
+    });
+
+    const result = await processAirTrailFile(content, {
+      ...baseOptions,
+      importMode: 'restore',
+      userMapping: {},
+    });
+
+    expect(result.flights[0]?.seats).toEqual([
+      { ...seat, userId: null, guestName: 'John Export' },
+    ]);
   });
 });

--- a/src/lib/import/airtrail.ts
+++ b/src/lib/import/airtrail.ts
@@ -165,12 +165,30 @@ export const processAirTrailFile = async (
     return acc;
   }, {});
   const users = await api.user.list.query();
+  const localUsers =
+    options.importMode === 'restore'
+      ? users
+      : users.filter((localUser) => localUser.id === user.id);
+
+  const getMappedUserId = (exportedUserId: string) => {
+    const exportedUser = dataUsers[exportedUserId];
+    if (!exportedUser) return null;
+
+    const requestedUserId = options.userMapping?.[exportedUser.id];
+    const requestedUser = requestedUserId
+      ? localUsers.find((localUser) => localUser.id === requestedUserId)
+      : null;
+    if (options.userMapping) return requestedUser?.id ?? null;
+
+    return (
+      localUsers.find(
+        (localUser) => localUser.username === exportedUser.username,
+      )?.id ?? null
+    );
+  };
 
   const exportedUsers = data.users.map((exportedUser) => {
-    const mappedUserId =
-      options.userMapping?.[exportedUser.id] ??
-      users.find((user) => user.username === exportedUser.username)?.id ??
-      null;
+    const mappedUserId = getMappedUserId(exportedUser.id);
 
     return {
       id: exportedUser.id,
@@ -192,19 +210,27 @@ export const processAirTrailFile = async (
     records[key] = flightIndexes;
     flightIndexes.push(flightIndex);
   };
-  for (const rawFlight of data.flights) {
+  const rawFlights =
+    options.importMode === 'restore'
+      ? data.flights
+      : data.flights.filter((flight) =>
+          flight.seats.some(
+            (seat) =>
+              seat.userId != null && getMappedUserId(seat.userId) === user.id,
+          ),
+        );
+
+  for (const rawFlight of rawFlights) {
     const flightIndex = flights.length;
 
     const seats = rawFlight.seats.map((seat) => {
       const dataUser = dataUsers?.[seat.userId ?? ''];
-      const mappedUserId = dataUser
-        ? exportedUsers.find((u) => u.id === dataUser.id)?.mappedUserId
-        : null;
+      const mappedUserId = dataUser ? getMappedUserId(dataUser.id) : null;
       const user = mappedUserId
         ? users.find((user) => user.id === mappedUserId)
         : null;
 
-      if (dataUser && !user) {
+      if (options.importMode === 'restore' && dataUser && !user) {
         const key = `${dataUser.id}|${dataUser.username}|${dataUser.displayName}`;
         addUnknownFlightIndex(unknownUsers, key, flightIndex);
       }
@@ -227,23 +253,6 @@ export const processAirTrailFile = async (
         guestName,
       };
     });
-
-    // If exported with a different username, add the user to the list manually.
-    if (
-      !seats.some(
-        (seat) =>
-          users.find((usr) => usr.id === seat.userId)?.username ===
-          user.username,
-      )
-    ) {
-      seats.push({
-        userId: user.id,
-        guestName: null,
-        seat: null,
-        seatClass: null,
-        seatNumber: null,
-      });
-    }
 
     const fromCode = getAirportCode(rawFlight.from);
     const toCode = getAirportCode(rawFlight.to);

--- a/src/lib/import/fr24.test.ts
+++ b/src/lib/import/fr24.test.ts
@@ -47,6 +47,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(1);
@@ -62,6 +63,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(1);
@@ -77,6 +79,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(0);
@@ -89,6 +92,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(0);
@@ -103,6 +107,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(1);
@@ -116,6 +121,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(1);
@@ -130,6 +136,7 @@ describe('processFR24File', () => {
     const result = await processFR24File(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(1);

--- a/src/lib/import/jetlovers.test.ts
+++ b/src/lib/import/jetlovers.test.ts
@@ -51,6 +51,7 @@ describe('processJetLoversFile', () => {
     const result = await processJetLoversFile(content, {
       filterOwner: false,
       airlineFromFlightNumber: true,
+      importMode: 'personal',
     });
 
     expect(result.flights).toHaveLength(1);

--- a/src/lib/import/legacy-airtrail.ts
+++ b/src/lib/import/legacy-airtrail.ts
@@ -8,7 +8,6 @@ import {
   SeatClasses,
   SeatTypes,
 } from '$lib/db/types';
-import { api } from '$lib/trpc';
 import { getAircraftByIcao } from '$lib/utils/data/aircraft';
 import { getAirlineByIcao } from '$lib/utils/data/airlines';
 import { getAirportByIcao } from '$lib/utils/data/airports/cache';
@@ -117,22 +116,19 @@ export const processLegacyAirTrailFile = async (
     acc[user.id] = user;
     return acc;
   }, {});
-  const users = await api.user.list.query();
-
   const unknownAirports: Record<string, number[]> = {};
   const unknownAirlines: Record<string, number[]> = {};
   for (const rawFlight of data.flights) {
     const seats = rawFlight.seats.map((seat) => {
       const dataUser = dataUsers?.[seat.userId ?? ''];
-      const user = dataUser
-        ? users.find((user) => user.username === dataUser?.username)
-        : null;
+      const mappedUserId =
+        dataUser?.username === user.username ? user.id : null;
       /*
         1. If the user is known, no guest name is needed.
         2. If the user is unknown, but the guest name is known, use the guest name.
         3. If the user is unknown and the guest name is unknown, use the provided display name (this could happen if the user is not in the database).
          */
-      const guestName = user
+      const guestName = mappedUserId
         ? null
         : seat.guestName
           ? seat.guestName
@@ -142,19 +138,13 @@ export const processLegacyAirTrailFile = async (
 
       return {
         ...seat,
-        userId: user?.id ?? null,
+        userId: mappedUserId,
         guestName,
       };
     });
 
     // If exported with a different username, add the user to the list manually.
-    if (
-      !seats.some(
-        (seat) =>
-          users.find((usr) => usr.id === seat.userId)?.username ===
-          user.username,
-      )
-    ) {
+    if (!seats.some((seat) => seat.userId === user.id)) {
       seats.push({
         userId: user.id,
         guestName: null,

--- a/src/lib/server/routes/flight.ts
+++ b/src/lib/server/routes/flight.ts
@@ -16,6 +16,7 @@ import {
 } from '$lib/server/utils/flight';
 import { getAircraftFromReg } from '$lib/server/utils/flight-lookup/aerodatabox';
 import { getFlightRoute } from '$lib/server/utils/flight-lookup/flight-lookup';
+import { validateFlightImportPermissions } from '$lib/server/utils/flight-import';
 import { generateCsv } from '$lib/utils/csv';
 import { generateBackup, serializeBackup } from '$lib/server/utils/backup';
 
@@ -189,6 +190,7 @@ export const flightRouter = router({
       z.object({
         flights: z.custom<CreateFlight[]>(),
         dedupe: z.boolean().optional(),
+        mode: z.enum(['personal', 'restore']).default('personal'),
       }),
     )
     .mutation(async ({ ctx: { user }, input }) => {
@@ -198,10 +200,20 @@ export const flightRouter = router({
           throw new Error(dateError);
         }
       }
+      const permissionError = validateFlightImportPermissions(
+        user,
+        input.flights,
+        input.mode,
+      );
+      if (permissionError) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: permissionError });
+      }
+
       return await createManyFlights(
         input.flights,
         user.id,
         input.dedupe ?? true,
+        input.mode,
       );
     }),
   exportJson: authedProcedure.query(async ({ ctx: { user } }) => {

--- a/src/lib/server/utils/flight-import.test.ts
+++ b/src/lib/server/utils/flight-import.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CreateFlight, User } from '$lib/db/types';
+
+import { validateFlightImportPermissions } from './flight-import';
+
+const user = {
+  id: 'current-user',
+  role: 'user',
+} as Pick<User, 'id' | 'role'>;
+
+const flightWithSeats = (seats: CreateFlight['seats']): CreateFlight =>
+  ({ seats }) as CreateFlight;
+
+describe('validateFlightImportPermissions', () => {
+  it('allows personal imports owned by the importing user', () => {
+    const error = validateFlightImportPermissions(
+      user,
+      [
+        flightWithSeats([
+          {
+            userId: user.id,
+            guestName: null,
+            seat: null,
+            seatNumber: null,
+            seatClass: null,
+          },
+          {
+            userId: null,
+            guestName: 'Guest Passenger',
+            seat: null,
+            seatNumber: null,
+            seatClass: null,
+          },
+        ]),
+      ],
+      'personal',
+    );
+
+    expect(error).toBeNull();
+  });
+
+  it('rejects personal imports that assign another local user', () => {
+    const error = validateFlightImportPermissions(
+      user,
+      [
+        flightWithSeats([
+          {
+            userId: user.id,
+            guestName: null,
+            seat: null,
+            seatNumber: null,
+            seatClass: null,
+          },
+          {
+            userId: 'other-user',
+            guestName: null,
+            seat: null,
+            seatNumber: null,
+            seatClass: null,
+          },
+        ]),
+      ],
+      'personal',
+    );
+
+    expect(error).toBe('Flight 1 assigns a seat to another user');
+  });
+
+  it('requires the importing user on every personal flight', () => {
+    const error = validateFlightImportPermissions(
+      user,
+      [
+        flightWithSeats([
+          {
+            userId: null,
+            guestName: 'Guest Passenger',
+            seat: null,
+            seatNumber: null,
+            seatClass: null,
+          },
+        ]),
+      ],
+      'personal',
+    );
+
+    expect(error).toBe('Flight 1 must include the importing user');
+  });
+
+  it('reserves restore mode for admins and owners', () => {
+    const flight = flightWithSeats([
+      {
+        userId: 'other-user',
+        guestName: null,
+        seat: null,
+        seatNumber: null,
+        seatClass: null,
+      },
+    ]);
+
+    expect(validateFlightImportPermissions(user, [flight], 'restore')).toBe(
+      'Only admins and owners can restore flights for other users',
+    );
+    expect(
+      validateFlightImportPermissions(
+        { ...user, role: 'admin' },
+        [flight],
+        'restore',
+      ),
+    ).toBeNull();
+    expect(
+      validateFlightImportPermissions(
+        { ...user, role: 'owner' },
+        [flight],
+        'restore',
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/server/utils/flight-import.test.ts
+++ b/src/lib/server/utils/flight-import.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { CreateFlight, User } from '$lib/db/types';
 
-import { validateFlightImportPermissions } from './flight-import';
+import {
+  getMissingImportSeats,
+  validateFlightImportPermissions,
+} from './flight-import';
 
 const user = {
   id: 'current-user',
@@ -11,6 +14,55 @@ const user = {
 
 const flightWithSeats = (seats: CreateFlight['seats']): CreateFlight =>
   ({ seats }) as CreateFlight;
+
+const guestSeat = (
+  guestName: string,
+  seatNumber: string | null = null,
+): CreateFlight['seats'][number] => ({
+  userId: null,
+  guestName,
+  seat: null,
+  seatNumber,
+  seatClass: null,
+});
+
+describe('getMissingImportSeats', () => {
+  it('preserves same-name guests with different seat details', () => {
+    const incoming = [
+      guestSeat('Guest Passenger', '12A'),
+      guestSeat('Guest Passenger', '12B'),
+    ];
+
+    expect(getMissingImportSeats([], incoming)).toEqual(incoming);
+  });
+
+  it('only skips the guest seat already on the flight', () => {
+    const existing = [guestSeat('Guest Passenger', '12A')];
+    const missing = getMissingImportSeats(existing, [
+      ...existing,
+      guestSeat('Guest Passenger', '12B'),
+    ]);
+
+    expect(missing).toEqual([guestSeat('Guest Passenger', '12B')]);
+  });
+
+  it('preserves the number of identical guest rows', () => {
+    const guest = guestSeat('Guest Passenger', '12A');
+
+    expect(getMissingImportSeats([guest], [guest, guest])).toEqual([guest]);
+    expect(getMissingImportSeats([guest, guest], [guest, guest])).toEqual([]);
+  });
+
+  it('deduplicates repeated seats for the same local user', () => {
+    const userSeat = {
+      ...guestSeat('Ignored'),
+      userId: 'local-user',
+      guestName: null,
+    };
+
+    expect(getMissingImportSeats([], [userSeat, userSeat])).toEqual([userSeat]);
+  });
+});
 
 describe('validateFlightImportPermissions', () => {
   it('allows personal imports owned by the importing user', () => {

--- a/src/lib/server/utils/flight-import.ts
+++ b/src/lib/server/utils/flight-import.ts
@@ -1,0 +1,31 @@
+import type { CreateFlight, User } from '$lib/db/types';
+
+export type FlightImportMode = 'personal' | 'restore';
+
+export const validateFlightImportPermissions = (
+  user: Pick<User, 'id' | 'role'>,
+  flights: CreateFlight[],
+  mode: FlightImportMode,
+): string | null => {
+  if (mode === 'restore') {
+    return user.role === 'user'
+      ? 'Only admins and owners can restore flights for other users'
+      : null;
+  }
+
+  for (const [index, flight] of flights.entries()) {
+    if (
+      flight.seats.some(
+        (seat) => seat.userId != null && seat.userId !== user.id,
+      )
+    ) {
+      return `Flight ${index + 1} assigns a seat to another user`;
+    }
+
+    if (!flight.seats.some((seat) => seat.userId === user.id)) {
+      return `Flight ${index + 1} must include the importing user`;
+    }
+  }
+
+  return null;
+};

--- a/src/lib/server/utils/flight-import.ts
+++ b/src/lib/server/utils/flight-import.ts
@@ -2,6 +2,54 @@ import type { CreateFlight, User } from '$lib/db/types';
 
 export type FlightImportMode = 'personal' | 'restore';
 
+type FlightImportSeat = Pick<
+  CreateFlight['seats'][number],
+  'userId' | 'guestName' | 'seat' | 'seatNumber' | 'seatClass'
+>;
+
+const flightImportSeatKey = (seat: FlightImportSeat) =>
+  seat.userId
+    ? JSON.stringify(['user', seat.userId])
+    : JSON.stringify([
+        'guest',
+        seat.guestName,
+        seat.seat,
+        seat.seatNumber,
+        seat.seatClass,
+      ]);
+
+export const getMissingImportSeats = <Seat extends FlightImportSeat>(
+  existingSeats: readonly FlightImportSeat[],
+  incomingSeats: readonly Seat[],
+): Seat[] => {
+  const remainingExisting = new Map<string, number>();
+  for (const seat of existingSeats) {
+    const key = flightImportSeatKey(seat);
+    remainingExisting.set(key, (remainingExisting.get(key) ?? 0) + 1);
+  }
+
+  const seenIncomingUsers = new Set<string>();
+  const missingSeats: Seat[] = [];
+  for (const seat of incomingSeats) {
+    const key = flightImportSeatKey(seat);
+
+    if (seat.userId) {
+      if (seenIncomingUsers.has(key)) continue;
+      seenIncomingUsers.add(key);
+    }
+
+    const remaining = remainingExisting.get(key) ?? 0;
+    if (remaining > 0) {
+      remainingExisting.set(key, remaining - 1);
+      continue;
+    }
+
+    missingSeats.push(seat);
+  }
+
+  return missingSeats;
+};
+
 export const validateFlightImportPermissions = (
   user: Pick<User, 'id' | 'role'>,
   flights: CreateFlight[],

--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -22,6 +22,7 @@ import {
   CustomFieldValidationError,
   persistEntityCustomFields,
 } from '$lib/server/utils/custom-fields';
+import type { FlightImportMode } from '$lib/server/utils/flight-import';
 import { distanceBetween } from '$lib/utils';
 import {
   estimateFlightDuration,
@@ -482,6 +483,7 @@ export const createManyFlights = async (
   data: CreateFlight[],
   userId: string,
   dedupe = true,
+  mode: FlightImportMode = 'personal',
 ): Promise<{ insertedFlights: number; attachedSeats: number }> => {
   if (!dedupe) {
     const insertedFlights = data.length;
@@ -517,7 +519,8 @@ export const createManyFlights = async (
   let existingFlights: Flight[] = [];
 
   if (dates.size && froms.size && tos.size) {
-    const listQuery = listFlightsQuery(userId);
+    const listQuery =
+      mode === 'restore' ? listFlightBaseQuery(db) : listFlightsQuery(userId);
     existingFlights = await listQuery
       .where('date', 'in', Array.from(dates))
       .where('fromId', 'in', Array.from(froms))
@@ -531,17 +534,16 @@ export const createManyFlights = async (
     if (!existingBySig.has(key)) existingBySig.set(key, ef.id);
   }
 
-  // Fetch user's existing seats among those flights
-  const existingIds = Array.from(new Set(existingFlights.map((f) => f.id)));
   const userSeatByFlight = new Set<number>();
-  if (existingIds.length) {
-    const userSeats = await db
-      .selectFrom('seat')
-      .select(['flightId'])
-      .where('userId', '=', userId)
-      .where('flightId', 'in', existingIds)
-      .execute();
-    userSeats.forEach((s) => userSeatByFlight.add(s.flightId));
+  const existingSeatKeys = new Map<number, Set<string>>();
+  const seatKey = (seat: {
+    userId: string | null;
+    guestName: string | null;
+  }) => (seat.userId ? `user:${seat.userId}` : `guest:${seat.guestName ?? ''}`);
+  for (const flight of existingFlights) {
+    const keys = new Set(flight.seats.map(seatKey));
+    existingSeatKeys.set(flight.id, keys);
+    if (keys.has(`user:${userId}`)) userSeatByFlight.add(flight.id);
   }
 
   const flightsToInsert: CreateFlight[] = [];
@@ -560,12 +562,17 @@ export const createManyFlights = async (
         tracksToUpsert.push({ flightId: existingId, track: f.track });
       }
 
-      // If user already has a seat on this flight, skip entirely
-      if (userSeatByFlight.has(existingId)) {
+      // Personal imports only deduplicate flights already owned by the importer.
+      if (mode === 'personal' && userSeatByFlight.has(existingId)) {
         continue;
       }
-      // Otherwise, attach incoming seats to existing flight
+
+      const existingKeys =
+        existingSeatKeys.get(existingId) ?? new Set<string>();
       for (const seat of f.seats) {
+        const key = seatKey(seat);
+        if (existingKeys.has(key)) continue;
+        existingKeys.add(key);
         seatsToAttach.push({
           flightId: existingId,
           userId: seat.userId,
@@ -587,14 +594,12 @@ export const createManyFlights = async (
     insertedFlights = flightsToInsert.length;
   }
 
-  // Attach seats to existing flights (dedup seats per user/flight)
+  // Attach seats to existing flights.
   let attachedSeats = 0;
   if (seatsToAttach.length || tracksToUpsert.length) {
-    const seatKey = (s: { flightId: number; userId: string | null }) =>
-      `${s.flightId}|${s.userId ?? ''}`;
     const uniqueSeatsMap = new Map<string, (typeof seatsToAttach)[number]>();
     for (const s of seatsToAttach) {
-      const k = seatKey(s);
+      const k = `${s.flightId}|${seatKey(s)}`;
       if (!uniqueSeatsMap.has(k)) uniqueSeatsMap.set(k, s);
     }
     const uniqueSeats = Array.from(uniqueSeatsMap.values());

--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -22,7 +22,10 @@ import {
   CustomFieldValidationError,
   persistEntityCustomFields,
 } from '$lib/server/utils/custom-fields';
-import type { FlightImportMode } from '$lib/server/utils/flight-import';
+import {
+  getMissingImportSeats,
+  type FlightImportMode,
+} from '$lib/server/utils/flight-import';
 import { distanceBetween } from '$lib/utils';
 import {
   estimateFlightDuration,
@@ -535,15 +538,12 @@ export const createManyFlights = async (
   }
 
   const userSeatByFlight = new Set<number>();
-  const existingSeatKeys = new Map<number, Set<string>>();
-  const seatKey = (seat: {
-    userId: string | null;
-    guestName: string | null;
-  }) => (seat.userId ? `user:${seat.userId}` : `guest:${seat.guestName ?? ''}`);
+  const existingSeatsByFlight = new Map<number, Flight['seats'][number][]>();
   for (const flight of existingFlights) {
-    const keys = new Set(flight.seats.map(seatKey));
-    existingSeatKeys.set(flight.id, keys);
-    if (keys.has(`user:${userId}`)) userSeatByFlight.add(flight.id);
+    existingSeatsByFlight.set(flight.id, flight.seats);
+    if (flight.seats.some((seat) => seat.userId === userId)) {
+      userSeatByFlight.add(flight.id);
+    }
   }
 
   const flightsToInsert: CreateFlight[] = [];
@@ -567,12 +567,11 @@ export const createManyFlights = async (
         continue;
       }
 
-      const existingKeys =
-        existingSeatKeys.get(existingId) ?? new Set<string>();
-      for (const seat of f.seats) {
-        const key = seatKey(seat);
-        if (existingKeys.has(key)) continue;
-        existingKeys.add(key);
+      const missingSeats = getMissingImportSeats(
+        existingSeatsByFlight.get(existingId) ?? [],
+        f.seats,
+      );
+      for (const seat of missingSeats) {
         seatsToAttach.push({
           flightId: existingId,
           userId: seat.userId,
@@ -597,21 +596,14 @@ export const createManyFlights = async (
   // Attach seats to existing flights.
   let attachedSeats = 0;
   if (seatsToAttach.length || tracksToUpsert.length) {
-    const uniqueSeatsMap = new Map<string, (typeof seatsToAttach)[number]>();
-    for (const s of seatsToAttach) {
-      const k = `${s.flightId}|${seatKey(s)}`;
-      if (!uniqueSeatsMap.has(k)) uniqueSeatsMap.set(k, s);
-    }
-    const uniqueSeats = Array.from(uniqueSeatsMap.values());
-
     await db.transaction().execute(async (trx) => {
       for (const { flightId, track } of tracksToUpsert) {
         await upsertFlightTrackPrimitiveWithConnection(trx, flightId, track);
       }
 
-      if (uniqueSeats.length) {
-        await trx.insertInto('seat').values(uniqueSeats).execute();
-        attachedSeats = uniqueSeats.length;
+      if (seatsToAttach.length) {
+        await trx.insertInto('seat').values(seatsToAttach).execute();
+        attachedSeats = seatsToAttach.length;
       }
     });
   }


### PR DESCRIPTION
Closes #632

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Secure AirTrail backup imports with personal and restore import modes
> - Adds two import modes: `personal` (per-user, restricts seat mappings to the importing user) and `restore` (admin/owner only, preserves full user assignments and deduplicates across the entire instance).
> - The server validates import permissions in `flightRouter.createMany`, rejecting personal imports that assign seats to other users and blocking restore mode for non-admin roles.
> - `processAirTrailFile` filters flights to only those where the selected exported account maps to the importing user in personal mode, and limits unknown-user reporting to restore mode.
> - The import UI ([ImportPage.svelte](https://github.com/johanohly/AirTrail/pull/662/files#diff-8730d8595b8bbfb8b76c7ab36ff119f6d87c80ce06faeec3af357a868cc02d00)) gates the restore toggle by user role and enforces a single self-mapping in personal mode before allowing continuation.
> - Behavioral Change: the importer is no longer auto-added to every imported flight; personal imports skip flights already owned by the importer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13a6842.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->