### PR TITLE
feat: add seat extras

### DIFF
--- a/prisma/migrations/20260714120000_add_seat_extras/migration.sql
+++ b/prisma/migrations/20260714120000_add_seat_extras/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "seat" ADD COLUMN "seat_extras" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -190,6 +190,8 @@ model seat {
   seat_number String?
   /// @kyselyType('economy' | 'economy+' | 'business' | 'first' | 'private')
   seat_class  String?
+  /// @kyselyType(('extra_legroom' | 'exit_row' | 'bulkhead' | 'overwing' | 'preferred' | 'front_row' | 'last_row' | 'bassinet'))
+  seat_extras String[] @default([])
 
   user   user?  @relation(fields: [user_id], references: [id], onDelete: Cascade)
   flight flight @relation(fields: [flight_id], references: [id], onDelete: Cascade)

--- a/src/lib/components/modals/flight-form/SeatInformation.svelte
+++ b/src/lib/components/modals/flight-form/SeatInformation.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import autoAnimate from '@formkit/auto-animate';
-  import { Plus, X } from '@o7/icon/lucide';
+  import { Armchair, Plus, Tags, X } from '@o7/icon/lucide';
   import type { SuperForm } from 'sveltekit-superforms';
   import { z } from 'zod';
 
@@ -12,7 +12,7 @@
   import { Input } from '$lib/components/ui/input';
   import * as Select from '$lib/components/ui/select';
   import { Separator } from '$lib/components/ui/separator';
-  import { SeatClasses, SeatTypes } from '$lib/db/types';
+  import { SeatClasses, SeatExtras, SeatTypes } from '$lib/db/types';
   import { cn, toTitleCase } from '$lib/utils';
   import type { flightSchema } from '$lib/zod/flight';
   import {
@@ -35,6 +35,17 @@
     copilot: 'Co-pilot',
     jumpseat: 'Jumpseat',
     other: 'Other',
+  };
+
+  const seatExtraLabels: Record<string, string> = {
+    extra_legroom: 'Extra Leg Room',
+    exit_row: 'Exit Row',
+    bulkhead: 'Bulkhead',
+    overwing: 'Over Wing',
+    preferred: 'Preferred',
+    front_row: 'Front Row',
+    last_row: 'Last Row',
+    bassinet: 'Bassinet',
   };
 
   const getExcludedUserIds = (currentIndex: number): string[] => {
@@ -154,7 +165,10 @@
               <Form.ElementField {form} name="seats[{index}].seat">
                 <Form.Control>
                   {#snippet children({ props })}
-                    <Form.Label class="sr-only">Seat Type</Form.Label>
+                    <Form.Label
+                      class="flex items-center gap-1 text-xs text-muted-foreground"
+                      ><Armchair size={12} />Position</Form.Label
+                    >
                     <div class="flex flex-wrap gap-1.5">
                       {#each SeatTypes as type}
                         <button
@@ -186,6 +200,47 @@
                   {/snippet}
                 </Form.Control>
               </Form.ElementField>
+
+              <Form.ElementField {form} name="seats[{index}].seatExtras">
+                <Form.Control>
+                  {#snippet children({ props })}
+                    <Form.Label
+                      class="flex items-center gap-1 text-xs text-muted-foreground"
+                      ><Tags size={12} />Extras</Form.Label
+                    >
+                    <div class="flex flex-wrap gap-1.5">
+                      {#each SeatExtras as extra}
+                        {@const selected = (
+                          $formData.seats[index]?.seatExtras ?? []
+                        ).includes(extra)}
+                        <button
+                          type="button"
+                          class={cn(
+                            'px-2.5 py-1 rounded-md text-xs font-medium border transition-colors',
+                            selected
+                              ? 'bg-primary text-primary-foreground border-primary'
+                              : 'bg-background text-muted-foreground border-input hover:border-foreground/20 hover:text-foreground',
+                          )}
+                          onclick={() => {
+                            if ($formData.seats[index]) {
+                              const current =
+                                $formData.seats[index].seatExtras ?? [];
+                              $formData.seats[index].seatExtras = selected
+                                ? current.filter((e) => e !== extra)
+                                : [...current, extra];
+                            }
+                          }}
+                        >
+                          {seatExtraLabels[extra] ?? toTitleCase(extra)}
+                        </button>
+                      {/each}
+                    </div>
+                    {#each $formData.seats[index]?.seatExtras ?? [] as extra}
+                      <input type="hidden" value={extra} name={props.name} />
+                    {/each}
+                  {/snippet}
+                </Form.Control>
+              </Form.ElementField>
             </div>
           </Card>
         {/if}
@@ -203,6 +258,7 @@
             seat: null,
             seatNumber: null,
             seatClass: null,
+            seatExtras: [],
           },
         ];
       }}

--- a/src/lib/components/modals/statistics/charts/PieCharts.svelte
+++ b/src/lib/components/modals/statistics/charts/PieCharts.svelte
@@ -24,6 +24,9 @@
   const seatClassDistribution = $derived.by(() =>
     FLIGHT_CHARTS['seat-class'].aggregate(flights, ctx),
   );
+  const seatExtrasDistribution = $derived.by(() =>
+    FLIGHT_CHARTS['seat-extras'].aggregate(flights, ctx),
+  );
   const reasonDistribution = $derived.by(() =>
     FLIGHT_CHARTS['reason'].aggregate(flights, ctx),
   );
@@ -54,6 +57,9 @@
   </div>
   <div class="cursor-pointer" onclick={() => onOpenChart?.('seat')}>
     <PieChart data={seatDistribution} title="Seat Preference" />
+  </div>
+  <div class="cursor-pointer" onclick={() => onOpenChart?.('seat-extras')}>
+    <PieChart data={seatExtrasDistribution} title="Seat Extras" />
   </div>
   <div class="cursor-pointer" onclick={() => onOpenChart?.('reason')}>
     <PieChart data={reasonDistribution} title="Flight Reasons" />

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -171,6 +171,7 @@ export const createFlightPrimitiveWithConnection = async (
     seat: seat.seat,
     seatNumber: seat.seatNumber,
     seatClass: seat.seatClass,
+    seatExtras: seat.seatExtras ?? [],
   }));
 
   await db.insertInto('seat').values(seatData).executeTakeFirstOrThrow();
@@ -230,6 +231,7 @@ export const updateFlightPrimitiveWithConnection = async (
     seat: seat.seat,
     seatNumber: seat.seatNumber,
     seatClass: seat.seatClass,
+    seatExtras: seat.seatExtras ?? [],
   }));
 
   await db.insertInto('seat').values(seatData).executeTakeFirstOrThrow();
@@ -315,6 +317,7 @@ export const createManyFlightsPrimitive = async (
           seat: seat.seat,
           seatNumber: seat.seatNumber,
           seatClass: seat.seatClass,
+          seatExtras: seat.seatExtras ?? [],
         }));
       }
 

--- a/src/lib/db/schema.d.ts
+++ b/src/lib/db/schema.d.ts
@@ -199,6 +199,10 @@ export type seat = {
      * @kyselyType('economy' | 'economy+' | 'business' | 'first' | 'private')
      */
     seatClass: 'economy' | 'economy+' | 'business' | 'first' | 'private' | null;
+    /**
+     * @kyselyType(('extra_legroom' | 'exit_row' | 'bulkhead' | 'overwing' | 'preferred' | 'front_row' | 'last_row' | 'bassinet'))
+     */
+    seatExtras: Generated<('extra_legroom' | 'exit_row' | 'bulkhead' | 'overwing' | 'preferred' | 'front_row' | 'last_row' | 'bassinet')[]>;
 };
 export type session = {
     id: string;

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -107,6 +107,17 @@ export const SeatClasses = [
   'first',
   'private',
 ] as const;
+export const SeatExtras = [
+  'extra_legroom',
+  'exit_row',
+  'bulkhead',
+  'overwing',
+  'preferred',
+  'front_row',
+  'last_row',
+  'bassinet',
+] as const;
+export type SeatExtra = (typeof SeatExtras)[number];
 export const FlightReasons = ['leisure', 'business', 'crew', 'other'] as const;
 export const FlightDatePrecisions = ['day', 'month', 'year'] as const;
 export type FlightDatePrecision = (typeof FlightDatePrecisions)[number];

--- a/src/lib/import/airtrail.test.ts
+++ b/src/lib/import/airtrail.test.ts
@@ -102,6 +102,7 @@ const seat = {
   seat: 'window',
   seatNumber: '12A',
   seatClass: 'economy',
+  seatExtras: [],
 };
 
 const flightBase = {

--- a/src/lib/import/aita.ts
+++ b/src/lib/import/aita.ts
@@ -136,6 +136,7 @@ export const processAITAFile = async (
             seat: null,
             seatNumber,
             seatClass,
+            seatExtras: [],
             guestName: null,
           },
         ],

--- a/src/lib/import/byair.ts
+++ b/src/lib/import/byair.ts
@@ -253,6 +253,7 @@ export const processByAirFile = async (
             mapSeatTypeFromClass(row.seat_class) ?? mapSeatType(row.seat_type),
           seatClass: mapSeatClass(row.seat_class),
           seatNumber: row.seat_number ? row.seat_number.substring(0, 5) : null,
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/import/flighty.ts
+++ b/src/lib/import/flighty.ts
@@ -290,6 +290,7 @@ export const processFlightyFile = async (
           seat: mapSeatType(row.seat_type),
           seatClass: mapSeatClass(row.cabin_class),
           seatNumber: row.seat ? row.seat.substring(0, 5) : null,
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/import/fr24.ts
+++ b/src/lib/import/fr24.ts
@@ -271,6 +271,7 @@ export const processFR24File = async (
           seat: seatType,
           seatNumber: row.seat_number,
           seatClass,
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/import/jetlog.ts
+++ b/src/lib/import/jetlog.ts
@@ -193,6 +193,7 @@ export const processJetLogFile = async (
           seat: row.seat as Seat['seat'],
           seatClass: seatClass as Seat['seatClass'],
           seatNumber: null,
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/import/jetlovers.ts
+++ b/src/lib/import/jetlovers.ts
@@ -191,6 +191,7 @@ export const processJetLoversFile = async (
           seat: mapSeatType(row.seat_type),
           seatClass: mapSeatClass(row.class),
           seatNumber: row.seat ? row.seat.substring(0, 5) : null,
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/import/legacy-airtrail.ts
+++ b/src/lib/import/legacy-airtrail.ts
@@ -6,6 +6,7 @@ import {
   type CreateFlight,
   FlightReasons,
   SeatClasses,
+  SeatExtras,
   SeatTypes,
 } from '$lib/db/types';
 import { getAircraftByIcao } from '$lib/utils/data/aircraft';
@@ -48,6 +49,7 @@ const AirTrailFile = z.object({
           seat: z.enum(SeatTypes).nullable(),
           seatNumber: z.string().max(5, 'Seat number is too long').nullable(), // 12A-1 for example
           seatClass: z.enum(SeatClasses).nullable(),
+          seatExtras: z.array(z.enum(SeatExtras)).default([]),
         })
         .refine((data) => data.userId ?? data.guestName, {
           message: 'Select a user or add a guest name',
@@ -151,6 +153,7 @@ export const processLegacyAirTrailFile = async (
         seat: null,
         seatClass: null,
         seatNumber: null,
+        seatExtras: [],
       });
     }
 

--- a/src/lib/import/openflights.ts
+++ b/src/lib/import/openflights.ts
@@ -486,6 +486,7 @@ export const processOpenFlightsFile = async (
           seat: mapSeatType(row.seat_type),
           seatNumber: row.seat,
           seatClass: mapSeatClass(row.class),
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/import/tripit.ts
+++ b/src/lib/import/tripit.ts
@@ -233,6 +233,7 @@ export const processTripItFile = async (
           seat: null,
           seatNumber: null,
           seatClass: null,
+          seatExtras: [],
           guestName: null,
         },
       ],

--- a/src/lib/server/utils/flight-import.test.ts
+++ b/src/lib/server/utils/flight-import.test.ts
@@ -24,6 +24,7 @@ const guestSeat = (
   seat: null,
   seatNumber,
   seatClass: null,
+  seatExtras: [],
 });
 
 describe('getMissingImportSeats', () => {
@@ -76,6 +77,7 @@ describe('validateFlightImportPermissions', () => {
             seat: null,
             seatNumber: null,
             seatClass: null,
+            seatExtras: [],
           },
           {
             userId: null,
@@ -83,6 +85,7 @@ describe('validateFlightImportPermissions', () => {
             seat: null,
             seatNumber: null,
             seatClass: null,
+            seatExtras: [],
           },
         ]),
       ],
@@ -103,6 +106,7 @@ describe('validateFlightImportPermissions', () => {
             seat: null,
             seatNumber: null,
             seatClass: null,
+            seatExtras: [],
           },
           {
             userId: 'other-user',
@@ -110,6 +114,7 @@ describe('validateFlightImportPermissions', () => {
             seat: null,
             seatNumber: null,
             seatClass: null,
+            seatExtras: [],
           },
         ]),
       ],
@@ -130,6 +135,7 @@ describe('validateFlightImportPermissions', () => {
             seat: null,
             seatNumber: null,
             seatClass: null,
+            seatExtras: [],
           },
         ]),
       ],
@@ -147,6 +153,7 @@ describe('validateFlightImportPermissions', () => {
         seat: null,
         seatNumber: null,
         seatClass: null,
+        seatExtras: [],
       },
     ]);
 

--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -579,6 +579,7 @@ export const createManyFlights = async (
           seat: seat.seat,
           seatNumber: seat.seatNumber,
           seatClass: seat.seatClass,
+          seatExtras: seat.seatExtras ?? [],
         });
       }
       continue;

--- a/src/lib/stats/aggregations.ts
+++ b/src/lib/stats/aggregations.ts
@@ -1,5 +1,6 @@
 import {
   ContinentMap,
+  SeatExtras,
   type VisitedCountry,
   VisitedCountryStatus,
   wasVisited,
@@ -10,6 +11,7 @@ import { type FlightData, toTitleCase } from '$lib/utils';
 export type FlightChartKey =
   | 'seat-class'
   | 'seat'
+  | 'seat-extras'
   | 'reason'
   | 'continents'
   | 'airlines'
@@ -160,7 +162,10 @@ export const routeLabelForFlight = (flight: FlightData): string | null => {
 
 export const flightChartBucketForFlight = (
   flight: FlightData,
-  key: Exclude<FlightChartKey, 'seat' | 'seat-class' | 'airports'>,
+  key: Exclude<
+    FlightChartKey,
+    'seat' | 'seat-class' | 'seat-extras' | 'airports'
+  >,
 ): string | null => {
   switch (key) {
     case 'airlines':
@@ -203,6 +208,25 @@ export const flightMatchesChartBucket = (
 
     return seats.some(
       (seat) => seat[field] && toTitleCase(seat[field]) === bucket,
+    );
+  }
+
+  if (chartKey === 'seat-extras') {
+    const seats = ctx.userId
+      ? flight.seats.filter((seat) => seat.userId === ctx.userId)
+      : flight.seats;
+
+    if (bucket === 'No Data') {
+      if (ctx.userId) {
+        return (
+          seats.length === 0 || seats.some((seat) => !seat.seatExtras?.length)
+        );
+      }
+      return seats.some((seat) => !seat.seatExtras?.length);
+    }
+
+    return seats.some((seat) =>
+      seat.seatExtras?.some((e) => seatExtraLabel(e) === bucket),
     );
   }
 
@@ -359,6 +383,66 @@ export function continentDistribution(
   return sortAndLimit(counts, options);
 }
 
+const SEAT_EXTRA_LABELS: Record<string, string> = {
+  extra_legroom: 'Extra Leg Room',
+  exit_row: 'Exit Row',
+  bulkhead: 'Bulkhead',
+  overwing: 'Over Wing',
+  preferred: 'Preferred',
+  front_row: 'Front Row',
+  last_row: 'Last Row',
+  bassinet: 'Bassinet',
+};
+
+export const seatExtraLabel = (extra: string): string =>
+  SEAT_EXTRA_LABELS[extra] ?? toTitleCase(extra);
+
+export function seatExtrasDistribution(
+  flights: FlightData[],
+  ctx: StatsContext,
+  options?: AggregationOptions,
+): Record<string, number> {
+  const categories = [...SeatExtras];
+
+  if (!ctx.userId) {
+    const seats = flights.flatMap((flight) => flight.seats);
+    const counts = categories.reduce<Record<string, number>>((acc, extra) => {
+      acc[seatExtraLabel(extra)] = seats.filter((seat) =>
+        seat.seatExtras?.includes(extra),
+      ).length;
+      return acc;
+    }, {});
+
+    const totalClassified = Object.values(counts).reduce((a, b) => a + b, 0);
+    const noData = seats.filter((s) => !s.seatExtras?.length).length;
+    if (totalClassified === 0 || noData > 0) {
+      counts['No Data'] = noData;
+    }
+
+    return sortAndLimit(counts, options);
+  }
+
+  const counts = categories.reduce<Record<string, number>>((acc, extra) => {
+    acc[seatExtraLabel(extra)] = flights.filter((f) =>
+      f.seats.some(
+        (v) => v.userId === ctx.userId && v.seatExtras?.includes(extra),
+      ),
+    ).length;
+    return acc;
+  }, {});
+
+  const totalClassified = Object.values(counts).reduce((a, b) => a + b, 0);
+  const noData = flights.filter(
+    (f) =>
+      !f.seats.some((v) => v.userId === ctx.userId && v.seatExtras?.length),
+  ).length;
+  if (totalClassified === 0 || noData > 0) {
+    counts['No Data'] = noData;
+  }
+
+  return sortAndLimit(counts, options);
+}
+
 export function routeDistribution(
   flights: FlightData[],
   _ctx: StatsContext,
@@ -444,6 +528,7 @@ export const FLIGHT_CHARTS: Record<
 > = {
   'seat-class': { title: 'Seat Class', aggregate: seatClassDistribution },
   seat: { title: 'Seat Preference', aggregate: seatDistribution },
+  'seat-extras': { title: 'Seat Extras', aggregate: seatExtrasDistribution },
   reason: { title: 'Flight Reasons', aggregate: reasonDistribution },
   continents: { title: 'Continents', aggregate: continentDistribution },
   airlines: { title: 'Airlines', aggregate: airlineDistribution },

--- a/src/lib/zod/flight.ts
+++ b/src/lib/zod/flight.ts
@@ -4,6 +4,7 @@ import {
   FlightDatePrecisions,
   FlightReasons,
   SeatClasses,
+  SeatExtras,
   SeatTypes,
 } from '$lib/db/types';
 import { flightAirportSchema } from '$lib/zod/airport';
@@ -108,6 +109,7 @@ export const flightSeatInformationSchema = z.object({
       seat: z.enum(SeatTypes).nullable(),
       seatNumber: z.string().max(5, 'Seat number is too long').nullable(), // 12A-1 for example
       seatClass: z.enum(SeatClasses).nullable(),
+      seatExtras: z.array(z.enum(SeatExtras)).default([]),
     })
     .refine((data) => data.userId ?? data.guestName, {
       message: 'Select a user or add a guest name',


### PR DESCRIPTION
For det første: Tak for dette utroligt nyttige tip!

### What problem does this solve?

Allows users to track any extras that comes with their seat.
For me as a tall person, this is primarily useful to track how often I managed to get a (free) extra legroom and/or emergency exit seat.


### What does this MR do?

* Adds a new field `seatExtras`, defaulting to `[]`
  * Multiple tags can be selected at once
* Adds a PieChart for those
* Extends tests accordingly 
 
### Screenshots

<img width="412" height="457" alt="image" src="https://github.com/user-attachments/assets/61249877-0b10-4f68-a2aa-0559badb4b0d" />
<img width="569" height="272" alt="image" src="https://github.com/user-attachments/assets/775a0d5b-ded2-40df-9670-c22f74998c21" />
 

### Feedback needed
* The current tags are a suggestion. Let me know if one is missing or should be removed from the list.


AI-Disclaimer: AI assisted in this MR. I have manually reviewed and verified suggestions where applicable.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add seat extras field to flight seat records with statistics and form support
> - Adds a `seatExtras` string array field to the `seat` table via a new Prisma migration, with a default of `[]`.
> - Extends the seat information form in [SeatInformation.svelte](https://github.com/johanohly/AirTrail/pull/667/files#diff-d3ca9aba366de91f76f0a01fbf27b2e1a00e7ba2bcb744edae1688076957d892) with toggle buttons for selecting multiple extras per seat.
> - Adds a 'Seat Extras' pie chart to the statistics modal and implements the full aggregation and filter-matching logic in [aggregations.ts](https://github.com/johanohly/AirTrail/pull/667/files#diff-72fb24b5ddb9d8309636b26aa58b40ff8d207593d9550388d305ade841bf79ea).
> - Updates all import processors (AITA, ByAir, Flighty, FR24, JetLog, OpenFlights, TripIt, etc.) to include `seatExtras: []` on imported seats.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aad157e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->