### PR TITLE
feat: add unknown aircraft mapping to imports

### DIFF
--- a/src/lib/components/form-fields/AircraftPicker.svelte
+++ b/src/lib/components/form-fields/AircraftPicker.svelte
@@ -16,12 +16,14 @@
     disabled = false,
     compact = false,
     onchange,
+    onCreateNew,
   }: {
     value?: Aircraft | null;
     placeholder?: string;
     disabled?: boolean;
     compact?: boolean;
     onchange?: (aircraft: Aircraft | null) => void;
+    onCreateNew?: () => void;
   } = $props();
 
   const selected = writable(
@@ -199,6 +201,17 @@
                 {compact ? 'Type to search' : 'Start typing to search...'}
               {/if}
             </li>
+          {:else if onCreateNew}
+            <button
+              onclick={() => {
+                open.set(false);
+                onCreateNew?.();
+              }}
+              class="flex flex-col relative cursor-pointer scroll-my-2 rounded-md p-2 bg-popover dark:bg-dark-1 border text-left hover:bg-accent transition-colors"
+            >
+              <span class="text-sm">No results found</span>
+              <span class="text-xs opacity-75">Create a new aircraft?</span>
+            </button>
           {:else}
             <li
               class="relative cursor-default scroll-my-2 rounded-md p-2 bg-popover dark:bg-dark-1 border text-sm text-muted-foreground"

--- a/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
@@ -51,6 +51,9 @@
 
   let platform = $state<(typeof platforms)[0]>(platforms[0]);
   let userMapping = $state<Record<string, string>>({});
+  let appliedAirportMapping = $state<Record<string, Airport>>({});
+  let appliedAirlineMapping = $state<Record<string, Airline>>({});
+  let appliedAircraftMapping = $state<Record<string, Aircraft>>({});
   let ownerOnly = $state(false);
   let matchAirlineFromFlightNumber = $state(true);
   let dedupeImportedFlights = $state(true);
@@ -315,14 +318,37 @@
     airportMapping: Record<string, Airport>,
     airlineMapping: Record<string, Airline>,
     aircraftMapping: Record<string, Aircraft>,
-  ) => {
-    if (!originalFile) return;
+  ): Promise<boolean> => {
+    if (!originalFile) return false;
+    const nextAirportMapping = {
+      ...appliedAirportMapping,
+      ...airportMapping,
+    };
+    const nextAirlineMapping = {
+      ...appliedAirlineMapping,
+      ...airlineMapping,
+    };
+    const nextAircraftMapping = {
+      ...appliedAircraftMapping,
+      ...aircraftMapping,
+    };
+
     importing = true;
     try {
-      await executeImport({ airportMapping, airlineMapping, aircraftMapping, userMapping });
+      await executeImport({
+        airportMapping: nextAirportMapping,
+        airlineMapping: nextAirlineMapping,
+        aircraftMapping: nextAircraftMapping,
+        userMapping,
+      });
+      appliedAirportMapping = nextAirportMapping;
+      appliedAirlineMapping = nextAirlineMapping;
+      appliedAircraftMapping = nextAircraftMapping;
+      return true;
     } catch (error) {
       toast.error(getImportErrorMessage(error, 'Failed to reprocess file'));
       console.error(error);
+      return false;
     } finally {
       importing = false;
     }
@@ -331,9 +357,13 @@
   const closeAndReset = () => {
     unknownAirports = {};
     unknownAirlines = {};
+    unknownAircraft = {};
     unknownUsers = {};
     exportedUsers = [];
     userMapping = {};
+    appliedAirportMapping = {};
+    appliedAirlineMapping = {};
+    appliedAircraftMapping = {};
     importedCount = 0;
     skippedRows = 0;
     importFailures = [];

--- a/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
@@ -13,7 +13,7 @@
   import * as Alert from '$lib/components/ui/alert';
   import { Button } from '$lib/components/ui/button';
   import { Card } from '$lib/components/ui/card';
-  import type { Airline, Airport, CreateFlight } from '$lib/db/types';
+  import type { Airline, Airport, Aircraft, CreateFlight } from '$lib/db/types';
   import { processFile } from '$lib/import';
   import { flightAddedState } from '$lib/state.svelte';
   import { trpc } from '$lib/trpc';
@@ -38,6 +38,7 @@
   let importFailures = $state<ImportFailure[]>([]);
   let unknownAirports = $state<Record<string, number[]>>({});
   let unknownAirlines = $state<Record<string, number[]>>({});
+  let unknownAircraft = $state<Record<string, number[]>>({});
   let unknownUsers = $state<Record<string, number[]>>({});
   let exportedUsers = $state<
     {
@@ -162,6 +163,7 @@
   const executeImport = async (mapping?: {
     airportMapping?: Record<string, Airport>;
     airlineMapping?: Record<string, Airline>;
+    aircraftMapping?: Record<string, Aircraft>;
     userMapping?: Record<string, string>;
   }) => {
     if (!originalFile) return;
@@ -172,6 +174,7 @@
       importMode,
       airportMapping: mapping?.airportMapping,
       airlineMapping: mapping?.airlineMapping,
+      aircraftMapping: mapping?.aircraftMapping,
       userMapping: mapping?.userMapping,
     });
 
@@ -180,6 +183,7 @@
       toast.info('No new flights to import');
       unknownAirports = result.unknownAirports;
       unknownAirlines = result.unknownAirlines;
+      unknownAircraft = result.unknownAircraft;
       unknownUsers = result.unknownUsers;
       exportedUsers = result.exportedUsers;
       skippedRows = result.skippedRows ?? 0;
@@ -192,12 +196,13 @@
       return;
     }
 
-    // Exclude flights with unknown airports/airlines so they aren't
+    // Exclude flights with unknown airports/airlines/aircraft so they aren't
     // inserted with null references (which would cause duplicates when
     // the user maps the unknowns and re-imports).
     const unknownIndices = new Set([
       ...Object.values(result.unknownAirports).flat(),
       ...Object.values(result.unknownAirlines).flat(),
+      ...Object.values(result.unknownAircraft).flat(),
     ]);
     const flightsToImport = flights
       .map((flight, index) => ({ flight, index }))
@@ -221,6 +226,7 @@
 
     unknownAirports = result.unknownAirports;
     unknownAirlines = result.unknownAirlines;
+    unknownAircraft = result.unknownAircraft;
     unknownUsers = result.unknownUsers;
     exportedUsers = result.exportedUsers;
     skippedRows = result.skippedRows ?? 0;
@@ -308,11 +314,12 @@
   const handleReprocess = async (
     airportMapping: Record<string, Airport>,
     airlineMapping: Record<string, Airline>,
+    aircraftMapping: Record<string, Aircraft>,
   ) => {
     if (!originalFile) return;
     importing = true;
     try {
-      await executeImport({ airportMapping, airlineMapping, userMapping });
+      await executeImport({ airportMapping, airlineMapping, aircraftMapping, userMapping });
     } catch (error) {
       toast.error(getImportErrorMessage(error, 'Failed to reprocess file'));
       console.error(error);
@@ -448,6 +455,7 @@
       {importFailures}
       {unknownAirports}
       {unknownAirlines}
+      {unknownAircraft}
       busy={importing}
       onreprocess={handleReprocess}
       onclose={closeAndReset}

--- a/src/lib/components/modals/settings/pages/import-page/StatusStep.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/StatusStep.svelte
@@ -5,13 +5,14 @@
 
   import AirlinePicker from '$lib/components/form-fields/AirlinePicker.svelte';
   import AirportPicker from '$lib/components/form-fields/AirportPicker.svelte';
+  import AircraftPicker from '$lib/components/form-fields/AircraftPicker.svelte';
   import CreateAirline from '$lib/components/modals/settings/pages/data-page/airline/CreateAirline.svelte';
   import CreateAirport from '$lib/components/modals/settings/pages/data-page/airport/CreateAirport.svelte';
   import { Button } from '$lib/components/ui/button';
   import { Card } from '$lib/components/ui/card';
   import { ScrollArea } from '$lib/components/ui/scroll-area';
   import { Separator } from '$lib/components/ui/separator';
-  import type { Airline, Airport } from '$lib/db/types';
+  import type { Airline, Airport, Aircraft } from '$lib/db/types';
   import { pluralize } from '$lib/utils';
   import type { ImportFailure } from './';
 
@@ -21,6 +22,7 @@
     importFailures = [],
     unknownAirports = {},
     unknownAirlines = {},
+    unknownAircraft = {},
     busy = false,
     onreprocess,
     onclose,
@@ -30,32 +32,39 @@
     importFailures?: ImportFailure[];
     unknownAirports?: Record<string, number[]>;
     unknownAirlines?: Record<string, number[]>;
+    unknownAircraft?: Record<string, number[]>;
     busy?: boolean;
     onreprocess?: (
       airportMapping: Record<string, Airport>,
       airlineMapping: Record<string, Airline>,
+      aircraftMapping: Record<string, Aircraft>,
     ) => void;
     onclose?: () => void;
   } = $props();
 
   const unknownAirportCodes = $derived(Object.keys(unknownAirports));
   const unknownAirlineCodes = $derived(Object.keys(unknownAirlines));
+  const unknownAircraftCodes = $derived(Object.keys(unknownAircraft));
 
   let airportMapping: Record<string, Airport> = $state({});
   let airlineMapping: Record<string, Airline> = $state({});
+  let aircraftMapping: Record<string, Aircraft> = $state({});
 
   const canReprocess = $derived(
     (Object.values(airportMapping).some(Boolean) ||
-      Object.values(airlineMapping).some(Boolean)) &&
+      Object.values(airlineMapping).some(Boolean) ||
+      Object.values(aircraftMapping).some(Boolean)) &&
       !busy,
   );
   const mappedAirportCount = $derived(Object.keys(airportMapping).length);
   const mappedAirlineCount = $derived(Object.keys(airlineMapping).length);
+  const mappedAircraftCount = $derived(Object.keys(aircraftMapping).length);
 
   const isAdmin = $derived(page.data.user?.role !== 'user');
 
   let createAirport = $state(false);
   let createAirline = $state(false);
+  let createAircraft = $state(false);
 
   const setAirportMapping = (code: string, airport: Airport | null) => {
     if (airport) {
@@ -73,8 +82,16 @@
     }
   };
 
+  const setAircraftMapping = (code: string, aircraft: Aircraft | null) => {
+    if (aircraft) {
+      aircraftMapping[code] = aircraft;
+    } else {
+      delete aircraftMapping[code];
+    }
+  };
+
   const handleReprocess = () => {
-    onreprocess?.(airportMapping, airlineMapping);
+    onreprocess?.(airportMapping, airlineMapping, aircraftMapping);
   };
 </script>
 
@@ -142,7 +159,7 @@
       </div>
     {/if}
 
-    {#if unknownAirportCodes.length || unknownAirlineCodes.length}
+    {#if unknownAirportCodes.length || unknownAirlineCodes.length || unknownAircraftCodes.length}
       <Separator class="my-4" />
 
       <div class="flex items-start gap-3">
@@ -152,14 +169,14 @@
         />
         <div class="flex-1">
           <p class="font-medium text-sm">
-            {unknownAirportCodes.length + unknownAirlineCodes.length} Unknown
+            {unknownAirportCodes.length + unknownAirlineCodes.length + unknownAircraftCodes.length} Unknown
             {pluralize(
-              unknownAirportCodes.length + unknownAirlineCodes.length,
+              unknownAirportCodes.length + unknownAirlineCodes.length + unknownAircraftCodes.length,
               'Code',
             )}
           </p>
           <p class="text-sm text-muted-foreground mt-0.5">
-            Match unknown airports and airlines, then re-import.
+            Match unknown airports, airlines, and aircraft, then re-import.
           </p>
         </div>
       </div>
@@ -221,23 +238,58 @@
               {/each}
             </div>
           {/if}
+
+          {#if unknownAircraftCodes.length}
+            <div class="space-y-2" class:mt-4={unknownAircraftCodes.length}>
+              <p class="text-xs font-medium text-muted-foreground uppercase">
+                Aircraft ({unknownAircraftCodes.length})
+              </p>
+              {#each unknownAircraftCodes as code (code)}
+                <div class="flex items-center gap-3">
+                  <div
+                    class="flex items-center justify-center w-20 h-9 bg-muted/50 rounded-md border shrink-0"
+                  >
+                    <span class="text-sm font-mono font-medium">{code}</span>
+                  </div>
+                  <div class="flex-1">
+                  <AircraftPicker
+                      placeholder="Search for aircraft..."
+                      onchange={(aircraft) => setAircraftMapping(code, aircraft)}
+                      disabled={busy}
+                      compact
+                    />
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
         </div>
       </ScrollArea>
 
-      {#if mappedAirportCount > 0 || mappedAirlineCount > 0}
+      {#if mappedAirportCount > 0 || mappedAirlineCount > 0 || mappedAircraftCount > 0}
         <div class="mt-4 p-3 bg-muted/30 rounded-md border border-muted">
           <p class="text-xs text-muted-foreground">
-            {#if mappedAirportCount > 0}
-              {mappedAirportCount} of {unknownAirportCodes.length}
-              {pluralize(unknownAirportCodes.length, 'airport')} mapped
-            {/if}
-            {#if mappedAirportCount > 0 && mappedAirlineCount > 0}
-              <span class="mx-1">•</span>
-            {/if}
-            {#if mappedAirlineCount > 0}
-              {mappedAirlineCount} of {unknownAirlineCodes.length}
-              {pluralize(unknownAirlineCodes.length, 'airline')} mapped
-            {/if}
+            { 
+              [
+                mappedAirportCount > 0
+                  ? `${mappedAirportCount} of ${unknownAirportCodes.length} ${pluralize(
+                      unknownAirportCodes.length,
+                      'airport',
+                    )} mapped`
+                  : null,
+                mappedAirlineCount > 0
+                  ? `${mappedAirlineCount} of ${unknownAirlineCodes.length} ${pluralize(
+                      unknownAirlineCodes.length,
+                      'airline',
+                    )} mapped`
+                  : null,
+                mappedAircraftCount > 0
+                  ? `${mappedAircraftCount} of ${unknownAircraftCodes.length} ${pluralize(
+                      unknownAircraftCodes.length,
+                      'aircraft',
+                    )} mapped`
+                  : null,
+              ].filter(s => s !== null).join(' • ') }
           </p>
         </div>
       {/if}

--- a/src/lib/components/modals/settings/pages/import-page/StatusStep.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/StatusStep.svelte
@@ -6,6 +6,7 @@
   import AirlinePicker from '$lib/components/form-fields/AirlinePicker.svelte';
   import AirportPicker from '$lib/components/form-fields/AirportPicker.svelte';
   import AircraftPicker from '$lib/components/form-fields/AircraftPicker.svelte';
+  import CreateAircraft from '$lib/components/modals/settings/pages/data-page/aircraft/CreateAircraft.svelte';
   import CreateAirline from '$lib/components/modals/settings/pages/data-page/airline/CreateAirline.svelte';
   import CreateAirport from '$lib/components/modals/settings/pages/data-page/airport/CreateAirport.svelte';
   import { Button } from '$lib/components/ui/button';
@@ -38,7 +39,7 @@
       airportMapping: Record<string, Airport>,
       airlineMapping: Record<string, Airline>,
       aircraftMapping: Record<string, Aircraft>,
-    ) => void;
+    ) => Promise<boolean>;
     onclose?: () => void;
   } = $props();
 
@@ -59,6 +60,41 @@
   const mappedAirportCount = $derived(Object.keys(airportMapping).length);
   const mappedAirlineCount = $derived(Object.keys(airlineMapping).length);
   const mappedAircraftCount = $derived(Object.keys(aircraftMapping).length);
+  const unmatchedCount = $derived(
+    unknownAirportCodes.length +
+      unknownAirlineCodes.length +
+      unknownAircraftCodes.length,
+  );
+  const mappingSummary = $derived.by(() => {
+    const summaries: string[] = [];
+
+    if (mappedAirportCount > 0) {
+      summaries.push(
+        `${mappedAirportCount} of ${unknownAirportCodes.length} ${pluralize(
+          unknownAirportCodes.length,
+          'airport',
+        )} mapped`,
+      );
+    }
+    if (mappedAirlineCount > 0) {
+      summaries.push(
+        `${mappedAirlineCount} of ${unknownAirlineCodes.length} ${pluralize(
+          unknownAirlineCodes.length,
+          'airline',
+        )} mapped`,
+      );
+    }
+    if (mappedAircraftCount > 0) {
+      summaries.push(
+        `${mappedAircraftCount} of ${unknownAircraftCodes.length} ${pluralize(
+          unknownAircraftCodes.length,
+          'aircraft',
+        )} mapped`,
+      );
+    }
+
+    return summaries.join(' • ');
+  });
 
   const isAdmin = $derived(page.data.user?.role !== 'user');
 
@@ -90,8 +126,17 @@
     }
   };
 
-  const handleReprocess = () => {
-    onreprocess?.(airportMapping, airlineMapping, aircraftMapping);
+  const handleReprocess = async () => {
+    const succeeded = await onreprocess?.(
+      airportMapping,
+      airlineMapping,
+      aircraftMapping,
+    );
+    if (!succeeded) return;
+
+    airportMapping = {};
+    airlineMapping = {};
+    aircraftMapping = {};
   };
 </script>
 
@@ -100,15 +145,30 @@
 
   <Card class="p-4">
     <div class="flex items-start gap-3">
-      <Check
-        class="text-green-600 dark:text-green-500 mt-0.5 shrink-0"
-        size={20}
-      />
+      {#if unmatchedCount > 0}
+        <CircleAlert
+          class="text-amber-600 dark:text-amber-500 mt-0.5 shrink-0"
+          size={20}
+        />
+      {:else}
+        <Check
+          class="text-green-600 dark:text-green-500 mt-0.5 shrink-0"
+          size={20}
+        />
+      {/if}
       <div class="flex-1">
-        <p class="font-medium text-sm">Import Complete</p>
+        <p class="font-medium text-sm">
+          {unmatchedCount > 0 ? 'Import Needs Mapping' : 'Import Complete'}
+        </p>
         <p class="text-sm text-muted-foreground mt-0.5">
-          Successfully imported {importedCount}
-          {pluralize(importedCount, 'flight')}
+          {#if importedCount > 0}
+            Successfully imported {importedCount}
+            {pluralize(importedCount, 'flight')}
+          {:else if unmatchedCount > 0}
+            No flights were imported yet.
+          {:else}
+            No new flights were imported.
+          {/if}
         </p>
       </div>
     </div>
@@ -159,7 +219,7 @@
       </div>
     {/if}
 
-    {#if unknownAirportCodes.length || unknownAirlineCodes.length || unknownAircraftCodes.length}
+    {#if unmatchedCount > 0}
       <Separator class="my-4" />
 
       <div class="flex items-start gap-3">
@@ -169,14 +229,10 @@
         />
         <div class="flex-1">
           <p class="font-medium text-sm">
-            {unknownAirportCodes.length + unknownAirlineCodes.length + unknownAircraftCodes.length} Unknown
-            {pluralize(
-              unknownAirportCodes.length + unknownAirlineCodes.length + unknownAircraftCodes.length,
-              'Code',
-            )}
+            {unmatchedCount} Unmatched {pluralize(unmatchedCount, 'Item')}
           </p>
           <p class="text-sm text-muted-foreground mt-0.5">
-            Match unknown airports, airlines, and aircraft, then re-import.
+            Choose a match for each item you recognize, then re-import.
           </p>
         </div>
       </div>
@@ -189,13 +245,18 @@
                 Airports ({unknownAirportCodes.length})
               </p>
               {#each unknownAirportCodes as code (code)}
-                <div class="flex items-center gap-3">
+                <div
+                  class="grid grid-cols-1 items-start gap-2 min-[440px]:grid-cols-[minmax(7rem,2fr)_minmax(0,3fr)] min-[440px]:gap-3"
+                >
                   <div
-                    class="flex items-center justify-center w-20 h-9 bg-muted/50 rounded-md border shrink-0"
+                    class="flex min-h-9 min-w-0 items-center rounded-md border bg-muted/50 px-3 py-2"
                   >
-                    <span class="text-sm font-mono font-medium">{code}</span>
+                    <span
+                      class="min-w-0 text-sm font-medium leading-5 [overflow-wrap:anywhere]"
+                      title={code}>{code}</span
+                    >
                   </div>
-                  <div class="flex-1">
+                  <div class="min-w-0">
                     <AirportPicker
                       placeholder="Search for airport..."
                       onchange={(airport) => setAirportMapping(code, airport)}
@@ -217,13 +278,18 @@
                 Airlines ({unknownAirlineCodes.length})
               </p>
               {#each unknownAirlineCodes as code (code)}
-                <div class="flex items-center gap-3">
+                <div
+                  class="grid grid-cols-1 items-start gap-2 min-[440px]:grid-cols-[minmax(7rem,2fr)_minmax(0,3fr)] min-[440px]:gap-3"
+                >
                   <div
-                    class="flex items-center justify-center w-20 h-9 bg-muted/50 rounded-md border shrink-0"
+                    class="flex min-h-9 min-w-0 items-center rounded-md border bg-muted/50 px-3 py-2"
                   >
-                    <span class="text-sm font-mono font-medium">{code}</span>
+                    <span
+                      class="min-w-0 text-sm font-medium leading-5 [overflow-wrap:anywhere]"
+                      title={code}>{code}</span
+                    >
                   </div>
-                  <div class="flex-1">
+                  <div class="min-w-0">
                     <AirlinePicker
                       placeholder="Search for airline..."
                       onchange={(airline) => setAirlineMapping(code, airline)}
@@ -240,21 +306,34 @@
           {/if}
 
           {#if unknownAircraftCodes.length}
-            <div class="space-y-2" class:mt-4={unknownAircraftCodes.length}>
+            <div
+              class="space-y-2"
+              class:mt-4={unknownAirportCodes.length ||
+                unknownAirlineCodes.length}
+            >
               <p class="text-xs font-medium text-muted-foreground uppercase">
                 Aircraft ({unknownAircraftCodes.length})
               </p>
               {#each unknownAircraftCodes as code (code)}
-                <div class="flex items-center gap-3">
+                <div
+                  class="grid grid-cols-1 items-start gap-2 min-[440px]:grid-cols-[minmax(7rem,2fr)_minmax(0,3fr)] min-[440px]:gap-3"
+                >
                   <div
-                    class="flex items-center justify-center w-20 h-9 bg-muted/50 rounded-md border shrink-0"
+                    class="flex min-h-9 min-w-0 items-center rounded-md border bg-muted/50 px-3 py-2"
                   >
-                    <span class="text-sm font-mono font-medium">{code}</span>
+                    <span
+                      class="min-w-0 text-sm font-medium leading-5 [overflow-wrap:anywhere]"
+                      title={code}>{code}</span
+                    >
                   </div>
-                  <div class="flex-1">
-                  <AircraftPicker
+                  <div class="min-w-0">
+                    <AircraftPicker
                       placeholder="Search for aircraft..."
-                      onchange={(aircraft) => setAircraftMapping(code, aircraft)}
+                      onchange={(aircraft) =>
+                        setAircraftMapping(code, aircraft)}
+                      onCreateNew={isAdmin
+                        ? () => (createAircraft = true)
+                        : undefined}
                       disabled={busy}
                       compact
                     />
@@ -268,29 +347,7 @@
 
       {#if mappedAirportCount > 0 || mappedAirlineCount > 0 || mappedAircraftCount > 0}
         <div class="mt-4 p-3 bg-muted/30 rounded-md border border-muted">
-          <p class="text-xs text-muted-foreground">
-            { 
-              [
-                mappedAirportCount > 0
-                  ? `${mappedAirportCount} of ${unknownAirportCodes.length} ${pluralize(
-                      unknownAirportCodes.length,
-                      'airport',
-                    )} mapped`
-                  : null,
-                mappedAirlineCount > 0
-                  ? `${mappedAirlineCount} of ${unknownAirlineCodes.length} ${pluralize(
-                      unknownAirlineCodes.length,
-                      'airline',
-                    )} mapped`
-                  : null,
-                mappedAircraftCount > 0
-                  ? `${mappedAircraftCount} of ${unknownAircraftCodes.length} ${pluralize(
-                      unknownAircraftCodes.length,
-                      'aircraft',
-                    )} mapped`
-                  : null,
-              ].filter(s => s !== null).join(' • ') }
-          </p>
+          <p class="text-xs text-muted-foreground">{mappingSummary}</p>
         </div>
       {/if}
 
@@ -302,15 +359,17 @@
         >
           Apply Mapping & Re-import
         </Button>
-        <Button
-          href="https://ourairports.com/"
-          target="_blank"
-          variant="outline"
-          class="gap-1"
-        >
-          Search OurAirports
-          <ExternalLink size={14} />
-        </Button>
+        {#if unknownAirportCodes.length}
+          <Button
+            href="https://ourairports.com/"
+            target="_blank"
+            variant="outline"
+            class="gap-1"
+          >
+            Search OurAirports
+            <ExternalLink size={14} />
+          </Button>
+        {/if}
         <Button variant="ghost" onclick={() => onclose?.()} class="ml-auto">
           Close
         </Button>
@@ -326,4 +385,5 @@
 {#if isAdmin}
   <CreateAirport bind:open={createAirport} withoutTrigger />
   <CreateAirline bind:open={createAirline} withoutTrigger />
+  <CreateAircraft bind:open={createAircraft} withoutTrigger />
 {/if}

--- a/src/lib/components/modals/settings/pages/import-page/index.ts
+++ b/src/lib/components/modals/settings/pages/import-page/index.ts
@@ -1,4 +1,4 @@
-import type { Airline, Airport } from '$lib/db/types';
+import type { Airline, Airport, Aircraft } from '$lib/db/types';
 
 export type ImportFailure = {
   index: number;
@@ -11,6 +11,7 @@ export type PlatformOptions = {
   importMode: 'personal' | 'restore';
   airportMapping?: Record<string, Airport>;
   airlineMapping?: Record<string, Airline>;
+  aircraftMapping?: Record<string, Aircraft>;
   userMapping?: Record<string, string>; // exported user id -> local user id
 };
 

--- a/src/lib/import/flighty.test.ts
+++ b/src/lib/import/flighty.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { processFlightyFile } from './flighty';
+
+const { getAirportByIata, getAircraftByName } = vi.hoisted(() => ({
+  getAirportByIata: vi.fn(async (iata: string) => ({
+    id: iata,
+    iata,
+    tz: 'UTC',
+  })),
+  getAircraftByName: vi.fn(async () => null),
+}));
+
+vi.mock('$app/state', () => ({
+  page: {
+    data: {
+      user: {
+        id: 'user-1',
+      },
+    },
+  },
+}));
+
+vi.mock('$lib/utils/data/airports/cache', () => ({
+  getAirportByIata,
+}));
+
+vi.mock('$lib/utils/data/airlines', () => ({
+  getAirlineByIata: vi.fn(),
+  getAirlineByIcao: vi.fn(),
+}));
+
+vi.mock('$lib/utils/data/aircraft', () => ({
+  getAircraftByName,
+}));
+
+const createFlightyCsv = (aircraftName: string) => {
+  const headers = [
+    'From',
+    'To',
+    'Gate Departure (Actual)',
+    'Gate Departure (Scheduled)',
+    'Gate Arrival (Actual)',
+    'Gate Arrival (Scheduled)',
+    'Take off (Scheduled)',
+    'Take off (Actual)',
+    'Landing (Scheduled)',
+    'Landing (Actual)',
+    'Dep Terminal',
+    'Dep Gate',
+    'Arr Terminal',
+    'Arr Gate',
+    'PNR',
+    'Canceled',
+    'Diverted To',
+    'Airline',
+    'Flight',
+    'Seat Type',
+    'Seat',
+    'Cabin Class',
+    'Flight Reason',
+    'Tail Number',
+    'Aircraft Type Name',
+    'Notes',
+  ];
+  const values = [
+    'CPH',
+    'LHR',
+    '',
+    '2025-01-01T10:00',
+    '',
+    '2025-01-01T12:00',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    'false',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    aircraftName,
+    '',
+  ];
+
+  return `${headers.join(',')}\n${values.join(',')}`;
+};
+
+describe('processFlightyFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports and applies mappings for unknown Flighty aircraft names', async () => {
+    const content = createFlightyCsv('Boeing 737-900ER');
+    const options = {
+      filterOwner: false,
+      airlineFromFlightNumber: false,
+      importMode: 'personal' as const,
+    };
+
+    const unresolved = await processFlightyFile(content, options);
+
+    expect(unresolved.flights).toHaveLength(1);
+    expect(unresolved.flights[0]?.aircraft).toBeNull();
+    expect(unresolved.unknownAircraft).toEqual({
+      'Boeing 737-900ER': [0],
+    });
+    expect(getAircraftByName).toHaveBeenCalledWith('Boeing 737-900ER');
+
+    const mappedAircraft = {
+      id: 7,
+      name: 'Boeing 737-900',
+      icao: 'B739',
+      sourceId: 'boeing-737-900',
+    };
+    const resolved = await processFlightyFile(content, {
+      ...options,
+      aircraftMapping: {
+        'Boeing 737-900ER': mappedAircraft,
+      },
+    });
+
+    expect(resolved.flights[0]?.aircraft).toEqual(mappedAircraft);
+    expect(resolved.unknownAircraft).toEqual({});
+    expect(getAircraftByName).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/import/flighty.ts
+++ b/src/lib/import/flighty.ts
@@ -154,6 +154,7 @@ export const processFlightyFile = async (
       flights: [],
       unknownAirports: {},
       unknownAirlines: {},
+      unknownAircraft: {},
       skippedRows: skipped.length,
     };
   }
@@ -161,6 +162,7 @@ export const processFlightyFile = async (
   const flights: CreateFlight[] = [];
   const unknownAirports: Record<string, number[]> = {};
   const unknownAirlines: Record<string, number[]> = {};
+  const unknownAircraft: Record<string, number[]> = {};
 
   for (const row of data) {
     const mappedFrom = options.airportMapping?.[row.from];
@@ -226,8 +228,10 @@ export const processFlightyFile = async (
       }
     }
 
-    const aircraft = row.aircraft_type_name
-      ? await getAircraftByName(row.aircraft_type_name)
+    const aircraftName = row.aircraft_type_name?.trim() || null;
+    const aircraft = aircraftName
+      ? (options.aircraftMapping?.[aircraftName] ??
+        (await getAircraftByName(aircraftName)))
       : null;
 
     const flightNumber =
@@ -250,6 +254,10 @@ export const processFlightyFile = async (
     if (!airline && airlineIcao) {
       if (!unknownAirlines[airlineIcao]) unknownAirlines[airlineIcao] = [];
       unknownAirlines[airlineIcao]!.push(flightIndex);
+    }
+    if (!aircraft && aircraftName) {
+      if (!unknownAircraft[aircraftName]) unknownAircraft[aircraftName] = [];
+      unknownAircraft[aircraftName]!.push(flightIndex);
     }
 
     flights.push({
@@ -300,6 +308,7 @@ export const processFlightyFile = async (
     flights,
     unknownAirports,
     unknownAirlines,
+    unknownAircraft,
     skippedRows: skipped.length,
   };
 };

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -21,6 +21,7 @@ type ProcessResult = {
   flights: CreateFlight[];
   unknownAirports: Record<string, number[]>; // code -> flight indices
   unknownAirlines: Record<string, number[]>; // code -> flight indices
+  unknownAircraft: Record<string, number[]>; // name -> flight indices
   unknownUsers: Record<string, number[]>; // encoded user key -> flight indices
   exportedUsers: {
     id: string;
@@ -36,37 +37,39 @@ type Processor = (
   options: PlatformOptions,
 ) => Promise<ProcessResult>;
 
-const withDefaultUnknownUsers = async (
-  fn: () => Promise<Omit<ProcessResult, 'unknownUsers' | 'exportedUsers'>>,
+const withDefaultUnknownValues = async (
+  fn: () => Promise<Partial<ProcessResult>>,
 ): Promise<ProcessResult> => {
   const res = await fn();
   return {
     ...res,
-    unknownUsers: {},
-    exportedUsers: [],
-  };
+    unknownUsers: res.unknownUsers ?? {},
+    exportedUsers: res.exportedUsers ?? [],
+    unknownAircraft: res.unknownAircraft ?? {},
+  } as ProcessResult;
 };
 
 const processors: Record<PlatformValue, Processor> = {
-  airtrail: async (content, options) => processAirTrailFile(content, options),
+  airtrail: async (content, options) => 
+    withDefaultUnknownValues(() => processAirTrailFile(content, options)),
   'legacy-airtrail': async (content, options) =>
-    withDefaultUnknownUsers(() => processLegacyAirTrailFile(content, options)),
+    withDefaultUnknownValues(() => processLegacyAirTrailFile(content, options)),
   jetlog: async (content, options) =>
-    withDefaultUnknownUsers(() => processJetLogFile(content, options)),
+    withDefaultUnknownValues(() => processJetLogFile(content, options)),
   fr24: async (content, options) =>
-    withDefaultUnknownUsers(() => processFR24File(content, options)),
+    withDefaultUnknownValues(() => processFR24File(content, options)),
   aita: async (content, options) =>
-    withDefaultUnknownUsers(() => processAITAFile(content, options)),
+    withDefaultUnknownValues(() => processAITAFile(content, options)),
   tripit: async (content, options) =>
-    withDefaultUnknownUsers(() => processTripItFile(content, options)),
+    withDefaultUnknownValues(() => processTripItFile(content, options)),
   flighty: async (content, options) =>
-    withDefaultUnknownUsers(() => processFlightyFile(content, options)),
+    withDefaultUnknownValues(() => processFlightyFile(content, options)),
   byair: async (content, options) =>
-    withDefaultUnknownUsers(() => processByAirFile(content, options)),
+    withDefaultUnknownValues(() => processByAirFile(content, options)),
   jetlovers: async (content, options) =>
-    withDefaultUnknownUsers(() => processJetLoversFile(content, options)),
+    withDefaultUnknownValues(() => processJetLoversFile(content, options)),
   openflights: async (content, options) =>
-    withDefaultUnknownUsers(() => processOpenFlightsFile(content, options)),
+    withDefaultUnknownValues(() => processOpenFlightsFile(content, options)),
 };
 
 export const processFile = async (

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -37,8 +37,19 @@ type Processor = (
   options: PlatformOptions,
 ) => Promise<ProcessResult>;
 
+type DefaultedProcessResult = Pick<
+  ProcessResult,
+  'unknownAircraft' | 'unknownUsers' | 'exportedUsers'
+>;
+
+type ProcessResultWithDefaults = Omit<
+  ProcessResult,
+  keyof DefaultedProcessResult
+> &
+  Partial<DefaultedProcessResult>;
+
 const withDefaultUnknownValues = async (
-  fn: () => Promise<Partial<ProcessResult>>,
+  fn: () => Promise<ProcessResultWithDefaults>,
 ): Promise<ProcessResult> => {
   const res = await fn();
   return {
@@ -46,11 +57,11 @@ const withDefaultUnknownValues = async (
     unknownUsers: res.unknownUsers ?? {},
     exportedUsers: res.exportedUsers ?? [],
     unknownAircraft: res.unknownAircraft ?? {},
-  } as ProcessResult;
+  };
 };
 
 const processors: Record<PlatformValue, Processor> = {
-  airtrail: async (content, options) => 
+  airtrail: async (content, options) =>
     withDefaultUnknownValues(() => processAirTrailFile(content, options)),
   'legacy-airtrail': async (content, options) =>
     withDefaultUnknownValues(() => processLegacyAirTrailFile(content, options)),

--- a/src/lib/import/openflights.test.ts
+++ b/src/lib/import/openflights.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { processOpenFlightsFile } from './openflights';
+
+const {
+  getAirportByIata,
+  getAirportByIcao,
+  getAirlineByIata,
+  getAirlineByIcao,
+  getAirlineByName,
+  getAircraftByIcao,
+  getAircraftByName,
+} = vi.hoisted(() => ({
+  getAirportByIata: vi.fn(async (iata: string) => ({
+    id: iata,
+    iata,
+    tz: 'UTC',
+  })),
+  getAirportByIcao: vi.fn(),
+  getAirlineByIata: vi.fn(),
+  getAirlineByIcao: vi.fn(),
+  getAirlineByName: vi.fn(),
+  getAircraftByIcao: vi.fn(async () => null),
+  getAircraftByName: vi.fn(async () => null),
+}));
+
+vi.mock('$app/state', () => ({
+  page: {
+    data: {
+      user: {
+        id: 'user-1',
+      },
+    },
+  },
+}));
+
+vi.mock('$lib/utils/data/airports/cache', () => ({
+  getAirportByIata,
+  getAirportByIcao,
+}));
+
+vi.mock('$lib/utils/data/airlines', () => ({
+  getAirlineByIata,
+  getAirlineByIcao,
+  getAirlineByName,
+}));
+
+vi.mock('$lib/utils/data/aircraft', () => ({
+  getAircraftByIcao,
+  getAircraftByName,
+}));
+
+const openFlightsCsv = [
+  [
+    'Date',
+    'From',
+    'To',
+    'Flight Number',
+    'Airline',
+    'Distance',
+    'Duration',
+    'Seat',
+    'Seat Type',
+    'Class',
+    'Reason',
+    'Plane',
+    'Registration',
+    'Trip',
+    'Note',
+    'From OID',
+    'To OID',
+    'Airline OID',
+    'Plane OID',
+  ].join(','),
+  [
+    '2025-01-01',
+    'CPH',
+    'LHR',
+    '',
+    '',
+    '',
+    '02:00',
+    '',
+    '',
+    '',
+    '',
+    'Boeing 737-300 (winglets)',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '1',
+  ].join(','),
+].join('\n');
+
+describe('processOpenFlightsFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => ({
+        ok: true,
+        status: 200,
+        text: async () =>
+          url.endsWith('/planes.dat')
+            ? 'Boeing 737-300 (winglets),73C,B733'
+            : '',
+      })),
+    );
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports and applies mappings for unknown OpenFlights aircraft', async () => {
+    const options = {
+      filterOwner: false,
+      airlineFromFlightNumber: false,
+      importMode: 'personal' as const,
+    };
+
+    const unresolved = await processOpenFlightsFile(openFlightsCsv, options);
+
+    expect(unresolved.flights).toHaveLength(1);
+    expect(unresolved.flights[0]?.aircraft).toBeNull();
+    expect(unresolved.unknownAircraft).toEqual({ B733: [0] });
+
+    const mappedAircraft = {
+      id: 8,
+      name: 'Boeing 737-300',
+      icao: 'B733',
+      sourceId: 'boeing-737-300',
+    };
+    const resolved = await processOpenFlightsFile(openFlightsCsv, {
+      ...options,
+      aircraftMapping: { B733: mappedAircraft },
+    });
+
+    expect(resolved.flights[0]?.aircraft).toEqual(mappedAircraft);
+    expect(resolved.unknownAircraft).toEqual({});
+  });
+});

--- a/src/lib/import/openflights.ts
+++ b/src/lib/import/openflights.ts
@@ -363,6 +363,7 @@ const lookupAirline = async (
 const lookupAircraft = async (
   row: z.infer<typeof OpenFlightsFlight>,
   data: OpenFlightsData,
+  options: PlatformOptions,
 ) => {
   const byOid = row.plane_oid
     ? data.planesByRowNumber.get(row.plane_oid)
@@ -376,11 +377,16 @@ const lookupAircraft = async (
       : (byOid ?? byName);
   const icao = openFlightsPlane?.icao ?? null;
   const name = openFlightsPlane?.name ?? row.plane;
+  const mappingKey = icao ?? name ?? row.plane_oid ?? null;
+
+  if (mappingKey && options.aircraftMapping?.[mappingKey]) {
+    return { aircraft: options.aircraftMapping[mappingKey], mappingKey };
+  }
 
   let aircraft = icao ? await getAircraftByIcao(icao) : null;
   aircraft ??= name ? await getAircraftByName(name) : null;
 
-  return aircraft;
+  return { aircraft, mappingKey };
 };
 
 export const processOpenFlightsFile = async (
@@ -400,6 +406,7 @@ export const processOpenFlightsFile = async (
   const flights: CreateFlight[] = [];
   const unknownAirports: Record<string, number[]> = {};
   const unknownAirlines: Record<string, number[]> = {};
+  const unknownAircraft: Record<string, number[]> = {};
   let skippedInvalidRows = 0;
 
   for (const row of data) {
@@ -425,7 +432,7 @@ export const processOpenFlightsFile = async (
       openFlightsData,
       options,
     );
-    const aircraft = await lookupAircraft(row, openFlightsData);
+    const { aircraft, mappingKey: aircraftKey } = await lookupAircraft(row, openFlightsData, options);
     const duration = parseDuration(row.duration);
 
     const departure =
@@ -454,6 +461,10 @@ export const processOpenFlightsFile = async (
     if (!airline && airlineKey) {
       unknownAirlines[airlineKey] ??= [];
       unknownAirlines[airlineKey].push(flightIndex);
+    }
+    if (!aircraft && aircraftKey) {
+      unknownAircraft[aircraftKey] ??= [];
+      unknownAircraft[aircraftKey].push(flightIndex);
     }
 
     flights.push({
@@ -496,6 +507,7 @@ export const processOpenFlightsFile = async (
     flights,
     unknownAirports,
     unknownAirlines,
+    unknownAircraft,
     skippedRows: skipped.length + skippedInvalidRows,
   };
 };

--- a/src/lib/import/openflights.ts
+++ b/src/lib/import/openflights.ts
@@ -432,7 +432,11 @@ export const processOpenFlightsFile = async (
       openFlightsData,
       options,
     );
-    const { aircraft, mappingKey: aircraftKey } = await lookupAircraft(row, openFlightsData, options);
+    const { aircraft, mappingKey: aircraftKey } = await lookupAircraft(
+      row,
+      openFlightsData,
+      options,
+    );
     const duration = parseDuration(row.duration);
 
     const departure =


### PR DESCRIPTION
Fixes #630. Also lays groundwork for fixing #664.

This is a rough draft, submitting for review on the approach.

These issues could be fixed by more intelligently mapping aircraft names, but that seems dangerous to me. Instead, I matched the existing approach for airlines and airports to let the user map the incoming values:
<img width="445" height="587" alt="image" src="https://github.com/user-attachments/assets/50ef86e6-0e57-44a7-95c0-9c058966de7d" />

If you're interested in this approach, I can continue working on it. Or feel free to take it over.
Outstanding issues:
1. UI is not handling longer aircraft names well
2. If you map some of the values then import, the status bar gets out of sync (I believe this is preexisting): 
<img width="396" height="46" alt="image" src="https://github.com/user-attachments/assets/63df6e5a-838b-4da0-818c-9e996d247de4" />

3. I don't like how I handled the typing in import/index.ts with `withDefaultUnknownValues`. That was a quick workaround to get something testable
4. This only handles OpenFlights. I figured that's a good starting place for now, but it's worth reviewing other imports to see which could benefit from the same feature. Clearly Flighty can, but having no Apple devices, I can't find a way to create an import file for testing :(. Supporting other sources might also be better left for separate MRs, to keep things focused.
5. Unit tests
6. Support for creating a new Aircraft during the workflow
7. Oops, forgot prettier


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unknown aircraft mapping to Flighty and OpenFlights imports
> - The import pipeline now detects unresolved aircraft during Flighty and OpenFlights imports, reports them as `unknownAircraft` in the result, and excludes affected flights from insertion until resolved.
> - A new aircraft mapping UI in [StatusStep.svelte](https://github.com/johanohly/AirTrail/pull/669/files#diff-fc098632bd5784c8b66c06fef7d89e7a1c30851d4610fadd2385be3574b513b9) lets users pick or create aircraft for unknown entries, mirroring the existing airport/airline mapping flow.
> - [AircraftPicker.svelte](https://github.com/johanohly/AirTrail/pull/669/files#diff-35a0ee840991be0d8de44f7878aecebe034963da417a0da572e49aa5200c4d60) gains an `onCreateNew` callback that shows a "Create a new aircraft?" action when no search results are found.
> - Applied airport, airline, and aircraft mappings are now accumulated across reprocess attempts and only cleared on reset.
> - Behavioral Change: flights with unresolved aircraft are silently excluded from the inserted batch rather than inserted with a null aircraft reference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7ce499.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->