### PR TITLE
fix: reconcile flight aircraft/airline types with form input

### DIFF
--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -52,6 +52,18 @@ export type Flight = Omit<
 };
 export type FlightTrack = Selectable<flight_track>;
 type CreateFlightAirport = Partial<Airport>;
+// aircraft/airline as attached to a flight via the form or an importer: an
+// Aircraft/Airline, but with a nullable id (a not-yet-created item has none)
+// and dropping the fields the form schema leaves out/optional (sourceId, and
+// iconPath for airline). Only the id is persisted (see aircraftId/airlineId in
+// db/queries.ts), so this stays loose enough that both the form schema outputs
+// and full records assign.
+type FlightAircraftInput = Omit<Aircraft, 'id' | 'sourceId'> & {
+  id: number | null;
+};
+type FlightAirlineInput = Omit<Airline, 'id' | 'sourceId' | 'iconPath'> & {
+  id: number | null;
+};
 type FlightRecord = Omit<
   Selectable<flight>,
   'id' | 'fromId' | 'toId' | 'aircraftId' | 'airlineId'
@@ -59,8 +71,8 @@ type FlightRecord = Omit<
 export type CreateFlight = FlightRecord & {
   from: CreateFlightAirport | null;
   to: CreateFlightAirport | null;
-  aircraft: Aircraft | null;
-  airline: Airline | null;
+  aircraft: FlightAircraftInput | null;
+  airline: FlightAirlineInput | null;
   seats: Omit<Seat, 'flightId' | 'id'>[];
   track?: FlightTrackInput | null;
 };


### PR DESCRIPTION
## Error

When saving a flight, the save util (`src/lib/server/utils/flight.ts`) builds a `values` object from form data and passes it as a `CreateFlight`. TypeScript rejected that at both `saveFlightValues(values)` call sites (the partial-date and day-precision branches). The error:

```
src/lib/server/utils/flight.ts(286,35): error TS2345: Argument of type
'{ from: {...}; ... 27 more ...; track: {...} | undefined }' is not
assignable to parameter of type 'CreateFlight'.
  ...
    Types of property 'aircraft' are incompatible.
      Type '{ id: number | null; name: string; icao: string | null; } | null'
        is not assignable to type
      '{ id: number; name: string; icao: string | null; sourceId: string | null; } | null'.
        Property 'sourceId' is missing in type
        '{ id: number | null; name: string; icao: string | null; }' but required in type
        '{ id: number; name: string; icao: string | null; sourceId: string | null; }'.
```

## The issue behind it

`CreateFlight` typed its `aircraft`/`airline` as the **full DB records** (`Aircraft = Selectable<aircraft>`, `Airline = Selectable<airline>`), which require a non-null `id` and a `sourceId`. But the flight **form** produces looser objects (from `aircraftSchema` / `airlineSchema`):

- `id` is `number | null` — a not-yet-created aircraft/airline has a null id
- `aircraftSchema` has **no `sourceId`** (and `airlineSchema`'s `sourceId` / `iconPath` are optional)

The error message only names `sourceId` because TypeScript reports the first incompatible property, but there are really two gaps — the missing `sourceId` **and** the `id: number | null → number` mismatch — affecting **both** aircraft and airline.

Key facts that shaped the fix:

- The schemas **can't** be tightened (make `id` non-null), because they're shared with the
  aircraft/airline *create* forms where a null id is valid.
- Downstream, **only `.id` is ever read** off these fields (`src/lib/db/queries.ts` —
  `aircraftId` / `airlineId`); nothing uses `name` / `icao` / `sourceId`.
- Importers pass full records or `null`, so they still satisfy a loosened type.

## The fix (`src/lib/db/types.ts`)

Loosen the two `CreateFlight` fields to *"an `Aircraft`/`Airline`, but with a nullable id and without the fields the form omits"* — derived from the DB types so `name` / `icao` / `iata` stay in sync:

```ts
type FlightAircraftInput = Omit<Aircraft, 'id' | 'sourceId'> & { id: number | null };
type FlightAirlineInput  = Omit<Airline,  'id' | 'sourceId' | 'iconPath'> & { id: number | null };

export type CreateFlight = FlightRecord & {
  ...
  aircraft: FlightAircraftInput | null;   // was: Aircraft | null
  airline:  FlightAirlineInput  | null;   // was: Airline  | null
  ...
};
```

Both the form's schema outputs **and** full `Aircraft`/`Airline` records assign to these, and `.id` still types as `number | null` — a types-only change with no runtime behavior difference. (Airline also drops `iconPath` because `Omit<Airline, 'id' | 'sourceId'>` would otherwise keep it *required*, while the form has it optional.)

**Verified:** the `TS2345 … not assignable to 'CreateFlight'` errors in `flight.ts` and the importers are gone; prettier clean. Single-file change on `fix/aircraft-airline-createflight-type` (off current `origin/main`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix aircraft and airline types in `CreateFlight` to accept nullable IDs for unsaved entities
> Introduces `FlightAircraftInput` and `FlightAirlineInput` type aliases in [types.ts](https://github.com/johanohly/AirTrail/pull/674/files#diff-a97109ac8fce36242938748e3cdcd50fb220907e545e52431549ef3e40ea6384) to represent aircraft and airline data as it arrives from form input. Both types omit fields not present in form input (e.g. `sourceId`, `iconPath`) and reintroduce `id` as nullable to handle not-yet-persisted entities. The `CreateFlight` type is updated to use these input-focused types instead of the full `Aircraft` and `Airline` types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71b7523.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->