### PR TITLE
feat: add Vanguard Airlines

### DIFF
--- a/data/airlines.json
+++ b/data/airlines.json
@@ -14476,6 +14476,13 @@
     "defunct": false
   },
   {
+    "id": "vanguard-airlines",
+    "name": "Vanguard Airlines",
+    "icao": "VGD",
+    "iata": "NJ*",
+    "defunct": true
+  },
+  {
     "id": "varesh-airlines",
     "name": "Varesh Airlines",
     "icao": "VRH",

--- a/data/icons/airlines/vanguard-airlines.svg
+++ b/data/icons/airlines/vanguard-airlines.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="71"
+   height="55"
+   viewBox="0 0 71 55"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="g1">
+    <image
+       width="71"
+       height="55"
+       preserveAspectRatio="none"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEcAAAA3CAMAAABpTKfsAAAAAXNSR0IArs4c6QAAAARnQU1BAACx&#10;jwv8YQUAAAAJUExURYwxa2sASgAAAFVOFqcAAAADdFJOU///ANfKDUEAAAAJcEhZcwAADsMAAA7D&#10;AcdvqGQAAAAZdEVYdFNvZnR3YXJlAFBhaW50Lk5FVCA1LjEuMTITAUd0AAAAuGVYSWZJSSoACAAA&#10;AAUAGgEFAAEAAABKAAAAGwEFAAEAAABSAAAAKAEDAAEAAAACAAAAMQECABEAAABaAAAAaYcEAAEA&#10;AABsAAAAAAAAAGAAAAABAAAAYAAAAAEAAABQYWludC5ORVQgNS4xLjEyAAADAACQBwAEAAAAMDIz&#10;MAGgAwABAAAAAQAAAAWgBAABAAAAlgAAAAAAAAACAAEAAgAEAAAAUjk4AAIABwAEAAAAMDEwMAAA&#10;AADZp5qVybcLXwAAAOBJREFUWEfN0VsOgzAMRFHo/hddKSkFT/wY2xT1fib4JArb6542XCg2nA3C&#10;j3av+cmYwS2AcHtXDiWcZXe5L+WIw88LQLHD9ZCDOzLawQ3tTxGOmFpGRa6T6AEHV0W8syy676SP&#10;GGtOliNOV28gs5xsP3XcUJgxDvNOhGONimKHYmKHY0KHZCKHZQKHZnyHZ1wnwXhOhnGcFGM7OcZ0&#10;kozlZBnDSTO6k2dUp8BoToVRnBKzOjVmcYoMOlUGnDIjnTojnAZzdTrMxWkxp9Njvk6TOZwu83Ha&#10;zHT6zB3E6N+cN8bwGWhJOcDDAAAAAElFTkSuQmCC&#10;"
+       id="image1" />
+  </g>
+</svg>


### PR DESCRIPTION
[Vanguard Airlines ](https://en.wikipedia.org/wiki/Vanguard_Airlines) is a defunct airline that operated in the U.S. Midwest in the late 90s and early 2000s. 

Unfortunately, graphic design from that time doesn't really hold up today... The logo that Wikipedia has is far too wide to look good. I found a different version on an old version of [their site](https://web.archive.org/web/20000302205557fw_/http://www.flyvanguard.com/index.html). The red V seems to match what was on their [liveries](https://www.jetphotos.com/photo/keyword/vanguard%20airlines), so I think that's the better choice.

I made some slight modifications to the logo. I cropped to just the V, removed the white background, and converted to SVG (well, wrapped the PNG in the SVG). I tried to make no visual changes, since it's still a brand logo even though I doubt anyone actually still holds the rights to it. Not sure if it's worth including or if you'd rather just leave it off, I'm fine either way.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Vanguard Airlines to the airlines dataset
> Adds a new entry for Vanguard Airlines to [airlines.json](https://github.com/johanohly/AirTrail/pull/678/files#diff-b0b85aa79fedb02229c77350c7b9b8d2dd3b11e2e676a1729692b0c7332608e0) with ICAO code `VGD`, IATA code `NJ*`, and `defunct: true`. Also adds the corresponding SVG icon at [vanguard-airlines.svg](https://github.com/johanohly/AirTrail/pull/678/files#diff-f29aad83140651d91f0b4ad8a5911ba924516d1e29dd3aea5552080d76b23350).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c9d84a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->