### PR TITLE
feat: consider the entered origin/destination when searching aerodatabox

### DIFF
--- a/src/lib/components/modals/flight-form/FlightNumber.svelte
+++ b/src/lib/components/modals/flight-form/FlightNumber.svelte
@@ -225,10 +225,13 @@
       const tempResults = await api.flight.lookup.query({
         flightNumber: normalizedFlightNumber,
         date: $formData.departure ?? undefined,
-        // Let the server drop results that don't match the route already
-        // entered, e.g. the return leg sharing the same flight number.
-        from: $formData.from?.icao ?? undefined,
-        to: $formData.to?.icao ?? undefined,
+        preferredRoute:
+          $formData.from || $formData.to
+            ? {
+                from: $formData.from?.icao ?? undefined,
+                to: $formData.to?.icao ?? undefined,
+              }
+            : undefined,
       });
       results = tempResults.map((r) => ({
         ...r,

--- a/src/lib/components/modals/flight-form/FlightNumber.svelte
+++ b/src/lib/components/modals/flight-form/FlightNumber.svelte
@@ -225,6 +225,10 @@
       const tempResults = await api.flight.lookup.query({
         flightNumber: normalizedFlightNumber,
         date: $formData.departure ?? undefined,
+        // Let the server drop results that don't match the route already
+        // entered, e.g. the return leg sharing the same flight number.
+        from: $formData.from?.icao ?? undefined,
+        to: $formData.to?.icao ?? undefined,
       });
       results = tempResults.map((r) => ({
         ...r,
@@ -287,7 +291,7 @@
         Flight Number
         {#if appConfig.configured?.integrations.aeroDataBoxKey}
           <HelpTooltip
-            text="If you set the departure date before searching, it will be considered when searching for flights."
+            text="If you set the departure date, origin or destination before searching, they will be considered when searching for flights."
           />
         {:else}
           <HelpTooltip>

--- a/src/lib/server/routes/flight.ts
+++ b/src/lib/server/routes/flight.ts
@@ -33,14 +33,17 @@ export const flightRouter = router({
       z.object({
         flightNumber: z.string(),
         date: z.string().datetime({ offset: true }).optional(),
+        from: z.string().optional(),
+        to: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
-      const results = await getFlightRoute(
-        input.flightNumber,
+      const results = await getFlightRoute(input.flightNumber, {
         // @ts-expect-error - We know the date string is a full ISO datetime string
-        input.date ? { date: parseISO(input.date.split('T')[0]) } : undefined,
-      );
+        date: input.date ? parseISO(input.date.split('T')[0]) : undefined,
+        from: input.from,
+        to: input.to,
+      });
 
       const [onlyFlight] = results;
       if (results.length === 1 && onlyFlight?.aircraftReg) {

--- a/src/lib/server/routes/flight.ts
+++ b/src/lib/server/routes/flight.ts
@@ -33,16 +33,19 @@ export const flightRouter = router({
       z.object({
         flightNumber: z.string(),
         date: z.string().datetime({ offset: true }).optional(),
-        from: z.string().optional(),
-        to: z.string().optional(),
+        preferredRoute: z
+          .object({
+            from: z.string().optional(),
+            to: z.string().optional(),
+          })
+          .optional(),
       }),
     )
     .query(async ({ input }) => {
       const results = await getFlightRoute(input.flightNumber, {
         // @ts-expect-error - We know the date string is a full ISO datetime string
         date: input.date ? parseISO(input.date.split('T')[0]) : undefined,
-        from: input.from,
-        to: input.to,
+        preferredRoute: input.preferredRoute,
       });
 
       const [onlyFlight] = results;

--- a/src/lib/server/utils/flight-lookup/aerodatabox.ts
+++ b/src/lib/server/utils/flight-lookup/aerodatabox.ts
@@ -8,7 +8,10 @@ import {
   addDays,
 } from 'date-fns';
 
-import type { FlightLookupOptions, FlightLookupResult } from './flight-lookup';
+import type {
+  FlightLookupProviderOptions,
+  FlightLookupResult,
+} from './flight-lookup';
 
 import type { Aircraft, Airline } from '$lib/db/types';
 import { getAircraftByIcao } from '$lib/server/utils/aircraft';
@@ -33,7 +36,7 @@ function isValidDateWithin365(date: Date): boolean {
 
 export async function getFlightRoute(
   flightNumber: string,
-  opts?: FlightLookupOptions,
+  opts?: FlightLookupProviderOptions,
 ): Promise<FlightLookupResult> {
   await rateLimiter.checkRequest();
 

--- a/src/lib/server/utils/flight-lookup/flight-lookup.test.ts
+++ b/src/lib/server/utils/flight-lookup/flight-lookup.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Airport } from '$lib/db/types';
+
+import {
+  preferRouteMatches,
+  type FlightLookupResultItem,
+} from './flight-lookup';
+
+const airport = (icao: string, iata: string | null): Airport => ({
+  id: 1,
+  icao,
+  iata,
+  lat: 0,
+  lon: 0,
+  tz: 'UTC',
+  name: icao,
+  municipality: null,
+  type: 'large_airport',
+  continent: 'EU',
+  country: 'DK',
+  custom: false,
+});
+
+const flight = (from: Airport, to: Airport): FlightLookupResultItem => ({
+  from,
+  to,
+});
+
+const cph = airport('EKCH', 'CPH');
+const lhr = airport('EGLL', 'LHR');
+const jfk = airport('KJFK', 'JFK');
+const outbound = flight(cph, lhr);
+const returnLeg = flight(lhr, cph);
+const connection = flight(cph, jfk);
+const results = [outbound, returnLeg, connection];
+
+describe('preferRouteMatches', () => {
+  it('preserves results when no route is preferred', () => {
+    expect(preferRouteMatches(results)).toBe(results);
+    expect(preferRouteMatches(results, {})).toBe(results);
+  });
+
+  it('matches an origin independently and ignores code casing and whitespace', () => {
+    expect(preferRouteMatches(results, { from: ' ekch ' })).toEqual([
+      outbound,
+      connection,
+    ]);
+  });
+
+  it('matches a destination independently by IATA code', () => {
+    expect(preferRouteMatches(results, { to: 'lhr' })).toEqual([outbound]);
+  });
+
+  it('requires both preferred endpoints to match the same flight', () => {
+    expect(preferRouteMatches(results, { from: 'CPH', to: 'LHR' })).toEqual([
+      outbound,
+    ]);
+  });
+
+  it('preserves all results when the preferred route has no match', () => {
+    expect(preferRouteMatches(results, { from: 'JFK', to: 'CPH' })).toBe(
+      results,
+    );
+  });
+});

--- a/src/lib/server/utils/flight-lookup/flight-lookup.ts
+++ b/src/lib/server/utils/flight-lookup/flight-lookup.ts
@@ -8,6 +8,10 @@ import { appConfig } from '$lib/server/utils/config';
 
 export type FlightLookupOptions = {
   date?: Date;
+  /** ICAO or IATA code of the departure airport, used to narrow down results. */
+  from?: string;
+  /** ICAO or IATA code of the arrival airport, used to narrow down results. */
+  to?: string;
 };
 
 export type FlightLookupResultItem = {
@@ -50,10 +54,41 @@ async function getProvider(): Promise<FlightLookupProvider> {
   return adsbdbProvider;
 }
 
+function matchesAirport(airport: Airport, code: string | undefined): boolean {
+  const wanted = code?.trim().toUpperCase();
+  if (!wanted) return true;
+
+  return (
+    airport.icao.toUpperCase() === wanted ||
+    airport.iata?.toUpperCase() === wanted
+  );
+}
+
+/**
+ * Narrows results down to the route the user already entered. The same flight
+ * number is often used for both legs on a given date, so without this the user
+ * would be asked to pick between a flight and its reverse.
+ */
+function filterByRoute(
+  results: FlightLookupResult,
+  opts?: FlightLookupOptions,
+): FlightLookupResult {
+  if (!opts?.from && !opts?.to) return results;
+
+  const filtered = results.filter(
+    (r) => matchesAirport(r.from, opts.from) && matchesAirport(r.to, opts.to),
+  );
+
+  // If nothing matches, the entered route is likely wrong. Fall back to the
+  // full set instead of claiming the flight doesn't exist.
+  return filtered.length > 0 ? filtered : results;
+}
+
 export async function getFlightRoute(
   flightNumber: string,
   opts?: FlightLookupOptions,
 ): Promise<FlightLookupResult> {
   const provider = await getProvider();
-  return provider.getFlightRoute(flightNumber, opts);
+  const results = await provider.getFlightRoute(flightNumber, opts);
+  return filterByRoute(results, opts);
 }

--- a/src/lib/server/utils/flight-lookup/flight-lookup.ts
+++ b/src/lib/server/utils/flight-lookup/flight-lookup.ts
@@ -6,12 +6,19 @@ import { getFlightRoute as getAerodataboxFlightRoute } from './aerodatabox';
 import type { Airport, Aircraft, Airline } from '$lib/db/types';
 import { appConfig } from '$lib/server/utils/config';
 
-export type FlightLookupOptions = {
+export type FlightLookupProviderOptions = {
   date?: Date;
-  /** ICAO or IATA code of the departure airport, used to narrow down results. */
+};
+
+export type FlightRoutePreference = {
+  /** ICAO or IATA code of the preferred departure airport. */
   from?: string;
-  /** ICAO or IATA code of the arrival airport, used to narrow down results. */
+  /** ICAO or IATA code of the preferred arrival airport. */
   to?: string;
+};
+
+export type FlightLookupOptions = FlightLookupProviderOptions & {
+  preferredRoute?: FlightRoutePreference;
 };
 
 export type FlightLookupResultItem = {
@@ -35,7 +42,7 @@ export type FlightLookupResult = FlightLookupResultItem[];
 interface FlightLookupProvider {
   getFlightRoute: (
     flightNumber: string,
-    opts?: FlightLookupOptions,
+    opts?: FlightLookupProviderOptions,
   ) => Promise<FlightLookupResult>;
 }
 
@@ -64,24 +71,20 @@ function matchesAirport(airport: Airport, code: string | undefined): boolean {
   );
 }
 
-/**
- * Narrows results down to the route the user already entered. The same flight
- * number is often used for both legs on a given date, so without this the user
- * would be asked to pick between a flight and its reverse.
- */
-function filterByRoute(
+/** Prefer route matches, but preserve every result when none match. */
+export function preferRouteMatches(
   results: FlightLookupResult,
-  opts?: FlightLookupOptions,
+  preferredRoute?: FlightRoutePreference,
 ): FlightLookupResult {
-  if (!opts?.from && !opts?.to) return results;
+  if (!preferredRoute?.from && !preferredRoute?.to) return results;
 
-  const filtered = results.filter(
-    (r) => matchesAirport(r.from, opts.from) && matchesAirport(r.to, opts.to),
+  const matches = results.filter(
+    (result) =>
+      matchesAirport(result.from, preferredRoute.from) &&
+      matchesAirport(result.to, preferredRoute.to),
   );
 
-  // If nothing matches, the entered route is likely wrong. Fall back to the
-  // full set instead of claiming the flight doesn't exist.
-  return filtered.length > 0 ? filtered : results;
+  return matches.length > 0 ? matches : results;
 }
 
 export async function getFlightRoute(
@@ -89,6 +92,7 @@ export async function getFlightRoute(
   opts?: FlightLookupOptions,
 ): Promise<FlightLookupResult> {
   const provider = await getProvider();
-  const results = await provider.getFlightRoute(flightNumber, opts);
-  return filterByRoute(results, opts);
+  const providerOptions = opts?.date ? { date: opts.date } : undefined;
+  const results = await provider.getFlightRoute(flightNumber, providerOptions);
+  return preferRouteMatches(results, opts?.preferredRoute);
 }


### PR DESCRIPTION
# Problem

Searching by flight number for a date often returns both legs of a round trip, since airlines reuse the same number in each direction. The picker then asks you to choose between a route and its exact reverse — even though you had already filled in the origin and destination on the form, so the answer was never ambiguous.

<img width="591" height="850" alt="Screenshot_20260801_173318" src="https://github.com/user-attachments/assets/9a24fd97-d01f-49d7-a182-93fe84e5bff1" />

# Solution

Now, that information narrows the results before the picker appears. In the common case only one flight survives and it is applied directly, with no prompt at all.

- **Filtering lives in the shared lookup layer.** `FlightLookupOptions` gains `from`/`to`, and `getFlightRoute` filters whatever the provider returned. Doing it there rather than inside the AeroDataBox client means the adsbdb provider benefits too.
- **Codes match on either ICAO or IATA, case-insensitively,** and each side is applied independently — entering only an origin still narrows the list.
- **A route that matches nothing falls back to the unfiltered results.** If you mistyped an airport, or the flight was rerouted, you get the full list you used to get instead of a misleading "Flight not found".
- **The tooltip now mentions origin and destination** alongside the departure date.
<img width="337" height="155" alt="image" src="https://github.com/user-attachments/assets/04e99d93-b07f-4b85-96cc-6894b0c80739" />


## Why not filter at the API?

AeroDataBox cannot do this for us. Its two flight-by-number endpoints (`/flights/{searchBy}/{searchParam}/{dateLocal}` and the date-range variant) accept only `dateLocalRole`, `withAircraftImage`, `withLocation`, and `withFlightPlan` — there is no origin or destination parameter, per their [OpenAPI spec](https://doc.aerodatabox.com/docs/openapi-rapidapi-v1.json). `dateLocalRole` does not help here either, because both legs genuinely depart on the searched date. So the filtering has to happen after the fetch.

# Testing

`bun run check` reports no new errors in the touched files. Not exercised against the live AeroDataBox API — that needs a real key.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Use entered origin and destination to narrow flight-number lookups
> - Pass the form’s entered origin and destination through the flight lookup API as route preferences.
> - Filter provider results against ICAO or IATA airport codes while retaining unfiltered results when no route matches.
> - Clarify the lookup tooltip and cover route matching, partial preferences, normalization, and fallback behavior with tests.
>
> <sup>AirTrail Helper summarized a417c93 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
