### PR TITLE
fix: doublefilterbutton on map

### DIFF
--- a/src/lib/components/flight-filters/Filters.svelte
+++ b/src/lib/components/flight-filters/Filters.svelte
@@ -62,7 +62,7 @@
   import { Airlines } from '@o7/icon/material';
   import { Filter, useDataTableFilters } from 'bits-ui';
   import { createRawSnippet } from 'svelte';
-  import type { Component } from 'svelte';
+  import type { Component, Snippet } from 'svelte';
   import type { ColumnConfig, FilterIcon, FiltersState } from 'bits-ui';
 
   import './filter.css';
@@ -107,13 +107,20 @@
     hasTempFilters = false,
     layout = 'default',
     presentation = 'default',
+    leading,
   }: {
     flights: FlightData[];
     filters: FlightFilters;
     tempFilters?: TempFilters;
     hasTempFilters?: boolean;
     layout?: 'default' | 'stacked';
-    presentation?: 'default' | 'map-popover';
+    /**
+     * `map-control` renders the filter menu as a MapLibre control button with
+     * the active filters listed underneath it, instead of a toolbar.
+     */
+    presentation?: 'default' | 'map-control';
+    /** Rendered before the filter trigger. Only used by `map-control`. */
+    leading?: Snippet;
   } = $props();
 
   type OptionSource = {
@@ -479,6 +486,20 @@
   });
 
   const providerColumns = $derived(filterState.columns);
+
+  // Filters on a hidden column (the airport columns while a map selection is
+  // active) never render an item, so they must not open the list either.
+  const visibleFilterCount = $derived(
+    filterState.filters.filter((filter) =>
+      filterState.columns.some(
+        (column) => column.id === filter.columnId && !column.hidden,
+      ),
+    ).length,
+  );
+  const showMenuLabel = $derived(
+    presentation !== 'map-control' &&
+      (filterState.filters.length === 0 || layout === 'stacked'),
+  );
 </script>
 
 <Filter.Provider
@@ -494,7 +515,18 @@
     data-filter-layout={layout}
     data-filter-presentation={presentation}
   >
-    {#if layout === 'stacked'}
+    {#if presentation === 'map-control'}
+      <!-- `title` sits on the group because bits-ui owns the trigger element
+           and does not forward attributes to it; the leading control button
+           carries its own title, so each button keeps its own tooltip. -->
+      <div class="maplibregl-ctrl-group" title="Filter flights">
+        {@render leading?.()}
+        {@render filterMenu()}
+      </div>
+      {#if visibleFilterCount > 0}
+        {@render filterList()}
+      {/if}
+    {:else if layout === 'stacked'}
       <div class="airtrail-filter-toolbar">
         {@render filterMenu()}
         {@render filterActions()}
@@ -513,7 +545,7 @@
 {#snippet filterMenu()}
   <Filter.Menu>
     <Funnel size={16} aria-hidden="true" />
-    {#if filterState.filters.length === 0 || layout === 'stacked'}
+    {#if showMenuLabel}
       <span>Filter</span>
     {:else}
       <span class="sr-only">Filter</span>

--- a/src/lib/components/flight-filters/filter.css
+++ b/src/lib/components/flight-filters/filter.css
@@ -39,14 +39,49 @@
     padding: 0 0.75rem;
   }
 
-  .airtrail-filter-root[data-filter-presentation='map-popover']
-    [data-filter-actions] {
-    height: 2rem;
-    border: 1px solid var(--border);
-    background: var(--background);
-    padding: 0 0.75rem;
-    box-shadow: var(--filter-shadow-xs);
-    font-weight: 500;
+  /* Sits inside a MapLibre control slot: a control group holding the filter
+     trigger, with the active filters stacked underneath it. */
+  .airtrail-filter-root[data-filter-presentation='map-control'] {
+    width: auto;
+    flex-direction: column;
+    align-items: flex-end;
+    /* matches MapLibre's spacing between control groups */
+    gap: 10px;
+  }
+
+  .airtrail-filter-root[data-filter-presentation='map-control']
+    [data-filter-trigger] {
+    /* app.css sizes and colors every button inside a control group */
+    border-radius: 4px;
+  }
+
+  .airtrail-filter-root[data-filter-presentation='map-control']
+    [data-filter-trigger]
+    svg {
+    color: inherit;
+  }
+
+  .airtrail-filter-root[data-filter-presentation='map-control']
+    [data-filter-trigger][data-menu-state='open'] {
+    background-color: var(--accent) !important;
+  }
+
+  .airtrail-filter-root[data-filter-presentation='map-control']
+    [data-filter-list] {
+    max-width: min(20rem, calc(100vw - 5rem));
+    max-height: calc(100vh - 18rem);
+    overflow-y: auto;
+    border-radius: 4px;
+    background: hsl(var(--ml-bg));
+    padding: 0.375rem;
+  }
+
+  /* app.css dims map control buttons on hover; the filter items brought their
+     own hover states along. */
+  .airtrail-filter-root[data-filter-presentation='map-control']
+    [data-filter-item]
+    button:hover {
+    filter: none !important;
   }
 
   .airtrail-filter-root[data-filter-layout='stacked'] [data-filter-list] {

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -37,7 +37,6 @@
     type Route,
     type TempFilters,
   } from '$lib/components/flight-filters/types';
-  import * as Popover from '$lib/components/ui/popover';
   import {
     getDefaultAppMapStyleUrl,
     getAppMapImages,
@@ -591,41 +590,21 @@
     </Control>
     {#if flights.length}
       <Control position="top-right">
-        <ControlGroup>
-          <ControlButton onclick={fitFlights} title="Show all flights">
-            <Fullscreen size={20} />
-          </ControlButton>
-          {#if filters}
-            {#if $isMediumScreen}
-              <Popover.Root>
-                <Popover.Trigger>
-                  <ControlButton title="Filter flights">
-                    <span class="relative inline-flex">
-                      <Funnel size={18} />
-                      {#if showClear || hasTempFilters}
-                        <span
-                          aria-hidden="true"
-                          data-map-filter-dot
-                          class="absolute -right-1 -top-1 size-2.5 rounded-full bg-blue-500 ring-2 ring-background"
-                        ></span>
-                      {/if}
-                    </span>
-                  </ControlButton>
-                </Popover.Trigger>
-                <Popover.Content
-                  side="left"
-                  class="flex w-fit grow-0 flex-col gap-2 p-3"
-                >
-                  <Filters
-                    bind:flights
-                    bind:filters
-                    bind:tempFilters
-                    layout="stacked"
-                    presentation="map-popover"
-                  />
-                </Popover.Content>
-              </Popover.Root>
-            {:else}
+        {#if filters && $isMediumScreen}
+          <!-- The trigger opens the filter menu itself, so adding a filter
+               stays a single click; active filters are listed below it. -->
+          <Filters
+            bind:flights
+            bind:filters
+            bind:tempFilters
+            layout="stacked"
+            presentation="map-control"
+            leading={fitFlightsButton}
+          />
+        {:else}
+          <ControlGroup>
+            {@render fitFlightsButton()}
+            {#if filters}
               <ControlButton
                 onclick={() => (filterDrawerOpen = true)}
                 title="Filter flights"
@@ -642,8 +621,8 @@
                 </span>
               </ControlButton>
             {/if}
-          {/if}
-        </ControlGroup>
+          </ControlGroup>
+        {/if}
       </Control>
       <Control position="top-right">
         {#if showClear}
@@ -713,6 +692,12 @@
 {:else}
   <MapFallback {flights} {filteredFlights} />
 {/if}
+
+{#snippet fitFlightsButton()}
+  <ControlButton onclick={fitFlights} title="Show all flights">
+    <Fullscreen size={20} />
+  </ControlButton>
+{/snippet}
 
 <style>
   /* The compass is dead weight while rotation is locked (globe mode):


### PR DESCRIPTION
### Context
Since #607, filtering on the map took two clicks. 

### Fix
The funnel button in the map controls is the filter menu trigger now — one click opens the column menu. The popover is gone, and the filters you've applied are listed as chips directly under the button instead of being hidden behind it.


Before : 
<img width="442" height="449" alt="image" src="https://github.com/user-attachments/assets/1109f10d-cfe6-4537-b27a-312d78c0ccf2" />


After : 
<img width="375" height="422" alt="image" src="https://github.com/user-attachments/assets/d07c999e-d772-4d21-b229-fca9e9089551" />

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Open map filters directly from the funnel control
> The map funnel now opens the filter menu in one click and displays active filter chips beneath the combined fit-and-filter control group. The shared filter component adds a dedicated map-control presentation with matching responsive styling.
>
> <sup>AirTrail Helper summarized 5d2a602 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
