### PR TITLE
fix: import flights with unknown airlines

### DIFF
--- a/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
@@ -20,6 +20,7 @@
   import {
     createEmptyImportMappings,
     createEmptyImportUnknowns,
+    getOutstandingUnknowns,
     getPendingFlights,
     mergeImportMappings,
     type ImportMappings,
@@ -42,6 +43,7 @@
 
   let importing = $state(false);
   let importedCount = $state(0);
+  let updatedCount = $state(0);
   let skippedRows = $state(0);
   let importFailures = $state<ImportFailure[]>([]);
   let unknowns = $state<ImportUnknowns>(createEmptyImportUnknowns());
@@ -119,10 +121,12 @@
     batch: IndexedFlight[],
   ): Promise<{
     inserted: number;
+    updated: number;
     attached: number;
     failures: ImportFailure[];
   }> => {
-    if (!batch.length) return { inserted: 0, attached: 0, failures: [] };
+    if (!batch.length)
+      return { inserted: 0, updated: 0, attached: 0, failures: [] };
 
     try {
       const stats = await $createMany.mutateAsync({
@@ -133,6 +137,7 @@
 
       return {
         inserted: stats?.insertedFlights ?? 0,
+        updated: stats?.updatedFlights ?? 0,
         attached: stats?.attachedPassengers ?? 0,
         failures: [],
       };
@@ -140,6 +145,7 @@
       if (batch.length === 1) {
         return {
           inserted: 0,
+          updated: 0,
           attached: 0,
           failures: [
             {
@@ -156,6 +162,7 @@
 
       return {
         inserted: first.inserted + second.inserted,
+        updated: first.updated + second.updated,
         attached: first.attached + second.attached,
         failures: [...first.failures, ...second.failures],
       };
@@ -165,6 +172,7 @@
   const executeImport = async (mapping?: {
     mappings?: ImportMappings;
     userMapping?: Record<string, string>;
+    allowUnmappedOptional?: boolean;
   }) => {
     if (!originalFile) return;
 
@@ -193,25 +201,30 @@
       return;
     }
 
-    // Exclude flights with unknown airports/airlines/aircraft so they aren't
-    // inserted with null references (which would cause duplicates when
-    // the user maps the unknowns and re-imports).
+    // Keep unresolved flights pending for review. Once the user continues,
+    // airlines and aircraft may remain empty, but airports still block import.
     const nextUnknowns = result.unknowns;
     const flightsToImport = getPendingFlights(
       flights,
       nextUnknowns,
       handledFlightIndices,
+      {
+        allowUnknownAirlines: mapping?.allowUnmappedOptional,
+        allowUnknownAircraft: mapping?.allowUnmappedOptional,
+      },
     );
 
     // Send flights in batches to avoid exceeding the server body size limit
     const BATCH_SIZE = 50;
     let inserted = 0;
+    let updated = 0;
     let attached = 0;
     const failures: ImportFailure[] = [];
     for (let i = 0; i < flightsToImport.length; i += BATCH_SIZE) {
       const batch = flightsToImport.slice(i, i + BATCH_SIZE);
       const result = await importBatch(batch);
       inserted += result.inserted;
+      updated += result.updated;
       attached += result.attached;
       failures.push(...result.failures);
       const failedIndices = new Set(
@@ -221,19 +234,24 @@
         if (!failedIndices.has(index)) handledFlightIndices.add(index);
       }
     }
-    if (inserted > 0 || attached > 0) {
+    if (inserted > 0 || updated > 0 || attached > 0) {
       await refreshImportedFlights();
     }
 
-    unknowns = nextUnknowns;
+    unknowns = getOutstandingUnknowns(nextUnknowns, handledFlightIndices);
     exportedUsers = result.exportedUsers;
     skippedRows = result.skippedRows ?? 0;
     importFailures = failures;
 
     importedCount = mapping ? importedCount + inserted : inserted;
+    updatedCount = mapping ? updatedCount + updated : updated;
     if (inserted > 0) {
       toast.success(`Imported ${inserted} ${pluralize(inserted, 'flight')}`);
-    } else if (failures.length === 0) {
+    }
+    if (updated > 0) {
+      toast.success(`Updated ${updated} ${pluralize(updated, 'flight')}`);
+    }
+    if (inserted === 0 && updated === 0 && failures.length === 0) {
       toast.info('No new flights to import');
     }
     if (skippedRows > 0) {
@@ -309,7 +327,7 @@
     }
   };
 
-  const handleReprocess = async (
+  const handleImportRemaining = async (
     pendingMappings: ImportMappings,
   ): Promise<boolean> => {
     if (!originalFile) return false;
@@ -320,11 +338,14 @@
       await executeImport({
         mappings: nextMappings,
         userMapping,
+        allowUnmappedOptional: true,
       });
       appliedMappings = nextMappings;
       return true;
     } catch (error) {
-      toast.error(getImportErrorMessage(error, 'Failed to reprocess file'));
+      toast.error(
+        getImportErrorMessage(error, 'Failed to import remaining flights'),
+      );
       console.error(error);
       return false;
     } finally {
@@ -339,6 +360,7 @@
     appliedMappings = createEmptyImportMappings();
     handledFlightIndices.clear();
     importedCount = 0;
+    updatedCount = 0;
     skippedRows = 0;
     importFailures = [];
     files = null;
@@ -455,11 +477,12 @@
   {:else}
     <StatusStep
       {importedCount}
+      {updatedCount}
       {skippedRows}
       {importFailures}
       {unknowns}
       busy={importing}
-      onreprocess={handleReprocess}
+      onimportremaining={handleImportRemaining}
       onclose={closeAndReset}
     />
   {/if}

--- a/src/lib/components/modals/settings/pages/import-page/StatusStep.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/StatusStep.svelte
@@ -27,19 +27,21 @@
 
   let {
     importedCount = 0,
+    updatedCount = 0,
     skippedRows = 0,
     importFailures = [],
     unknowns = createEmptyImportUnknowns(),
     busy = false,
-    onreprocess,
+    onimportremaining,
     onclose,
   }: {
     importedCount?: number;
+    updatedCount?: number;
     skippedRows?: number;
     importFailures?: ImportFailure[];
     unknowns?: ImportUnknowns;
     busy?: boolean;
-    onreprocess?: (mappings: ImportMappings) => Promise<boolean>;
+    onimportremaining?: (mappings: ImportMappings) => Promise<boolean>;
     onclose?: () => void;
   } = $props();
 
@@ -72,7 +74,20 @@
   const unmatchedCount = $derived(
     mappingSections.reduce((count, section) => count + section.unknownCount, 0),
   );
-  const canReprocess = $derived(mappedCount > 0 && !busy);
+  const optionalOnlyFlightCount = $derived.by(() => {
+    const airportIndices = new Set(Object.values(unknowns.airports).flat());
+    const allIndices = new Set([
+      ...airportIndices,
+      ...Object.values(unknowns.airlines).flat(),
+      ...Object.values(unknowns.aircraft).flat(),
+    ]);
+    return [...allIndices].filter((index) => !airportIndices.has(index)).length;
+  });
+  const canImportRemaining = $derived(
+    !busy &&
+      (optionalOnlyFlightCount > 0 ||
+        Object.keys(mappings.airports).length > 0),
+  );
   const mappingSummary = $derived.by(() => {
     return mappingSections
       .filter((section) => section.mappedCount > 0)
@@ -116,8 +131,8 @@
     }
   };
 
-  const handleReprocess = async () => {
-    const succeeded = await onreprocess?.(mappings);
+  const handleImportRemaining = async () => {
+    const succeeded = await onimportremaining?.(mappings);
     if (!succeeded) return;
 
     mappings = createEmptyImportMappings();
@@ -142,12 +157,18 @@
       {/if}
       <div class="flex-1">
         <p class="font-medium text-sm">
-          {unmatchedCount > 0 ? 'Import Needs Mapping' : 'Import Complete'}
+          {unmatchedCount > 0 ? 'Review Unmatched Items' : 'Import Complete'}
         </p>
         <p class="text-sm text-muted-foreground mt-0.5">
           {#if importedCount > 0}
             Successfully imported {importedCount}
             {pluralize(importedCount, 'flight')}
+            {#if updatedCount > 0}
+              and updated {updatedCount} {pluralize(updatedCount, 'flight')}
+            {/if}
+          {:else if updatedCount > 0}
+            Successfully updated {updatedCount}
+            {pluralize(updatedCount, 'flight')}
           {:else if unmatchedCount > 0}
             No flights were imported yet.
           {:else}
@@ -216,7 +237,11 @@
             {unmatchedCount} Unmatched {pluralize(unmatchedCount, 'Item')}
           </p>
           <p class="text-sm text-muted-foreground mt-0.5">
-            Choose a match for each item you recognize, then re-import.
+            Map any items you recognize. Unmapped airlines and aircraft will be
+            left blank.
+            {#if unknownAirportCodes.length > 0}
+              Airports must be mapped before their flights can be imported.
+            {/if}
           </p>
         </div>
       </div>
@@ -280,11 +305,11 @@
 
       <div class="mt-4 flex flex-wrap gap-2">
         <Button
-          onclick={handleReprocess}
-          disabled={!canReprocess}
+          onclick={handleImportRemaining}
+          disabled={!canImportRemaining}
           class="flex-1 sm:flex-none"
         >
-          Apply Mapping & Re-import
+          Import Remaining Flights
         </Button>
         {#if unknownAirportCodes.length}
           <Button
@@ -298,7 +323,7 @@
           </Button>
         {/if}
         <Button variant="ghost" onclick={() => onclose?.()} class="ml-auto">
-          Close
+          Leave Remaining Unimported
         </Button>
       </div>
     {:else}

--- a/src/lib/import/fr24.test.ts
+++ b/src/lib/import/fr24.test.ts
@@ -9,7 +9,12 @@ const { getAirportByIcao, getAirlineByIcao, getAircraftByIcao } = vi.hoisted(
       icao,
       tz: 'UTC',
     })),
-    getAirlineByIcao: vi.fn(async (icao: string) => ({ id: icao, icao })),
+    getAirlineByIcao: vi.fn(
+      async (icao: string): Promise<{ id: string; icao: string } | null> => ({
+        id: icao,
+        icao,
+      }),
+    ),
     getAircraftByIcao: vi.fn(async (icao: string) => ({ id: icao, icao })),
   }),
 );
@@ -141,5 +146,37 @@ describe('processFR24File', () => {
 
     expect(result.flights).toHaveLength(1);
     expect(getAirlineByIcao).toHaveBeenCalledWith('LFH');
+  });
+
+  it('reports and applies mappings for defunct airline codes', async () => {
+    const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note\n1999-07-15,NW687,Minneapolis (MSP/KMSP),Seattle (SEA/KSEA),10:00:00,11:30:00,03:30:00,Northwest Airlines (NW/NWA),Boeing 757-200 (B752),N687NW,12A,1,1,1,Issue 687 unknown airline test`;
+    getAirlineByIcao.mockResolvedValueOnce(null);
+
+    const unresolved = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+    });
+
+    expect(unresolved.flights[0]?.airline).toBeNull();
+    expect(unresolved.unknowns.airlines).toEqual({ NWA: [0] });
+
+    const northwest = {
+      id: 687,
+      name: 'Northwest Airlines',
+      iata: 'NW',
+      icao: 'NWA',
+      sourceId: null,
+      iconPath: null,
+    };
+    const resolved = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+      airlineMapping: { NWA: northwest },
+    });
+
+    expect(resolved.flights[0]?.airline).toEqual(northwest);
+    expect(resolved.unknowns.airlines).toEqual({});
   });
 });

--- a/src/lib/import/model.test.ts
+++ b/src/lib/import/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createEmptyImportMappings,
+  getOutstandingUnknowns,
   getPendingFlights,
   mergeImportMappings,
 } from './model';
@@ -44,5 +45,46 @@ describe('import mapping model', () => {
     );
 
     expect(pending.map(({ index }) => index)).toEqual([2]);
+  });
+
+  it('allows unknown optional references while still blocking unknown airports', () => {
+    const flights = [
+      flight('2026-01-01'),
+      flight('2026-01-02'),
+      flight('2026-01-03'),
+    ];
+
+    const pending = getPendingFlights(
+      flights,
+      {
+        airports: { CPH: [0] },
+        airlines: { NWA: [1] },
+        aircraft: { B733: [2] },
+      },
+      new Set(),
+      {
+        allowUnknownAirlines: true,
+        allowUnknownAircraft: true,
+      },
+    );
+
+    expect(pending.map(({ index }) => index)).toEqual([1, 2]);
+  });
+
+  it('removes unknown values after their flights are handled', () => {
+    const outstanding = getOutstandingUnknowns(
+      {
+        airports: { CPH: [0] },
+        airlines: { NWA: [1, 2], JAI: [2] },
+        aircraft: {},
+      },
+      new Set([1, 2]),
+    );
+
+    expect(outstanding).toEqual({
+      airports: { CPH: [0] },
+      airlines: {},
+      aircraft: {},
+    });
   });
 });

--- a/src/lib/import/model.ts
+++ b/src/lib/import/model.ts
@@ -43,6 +43,11 @@ export type IndexedFlight = {
   index: number;
 };
 
+export type PendingFlightOptions = {
+  allowUnknownAirlines?: boolean;
+  allowUnknownAircraft?: boolean;
+};
+
 export const createEmptyImportMappings = (): ImportMappings => ({
   airports: {},
   airlines: {},
@@ -67,11 +72,16 @@ export const getPendingFlights = (
   flights: CreateFlight[],
   unknowns: ImportUnknowns,
   handledIndices: ReadonlySet<number>,
+  options: PendingFlightOptions = {},
 ): IndexedFlight[] => {
   const unknownIndices = new Set([
     ...Object.values(unknowns.airports).flat(),
-    ...Object.values(unknowns.airlines).flat(),
-    ...Object.values(unknowns.aircraft).flat(),
+    ...(options.allowUnknownAirlines
+      ? []
+      : Object.values(unknowns.airlines).flat()),
+    ...(options.allowUnknownAircraft
+      ? []
+      : Object.values(unknowns.aircraft).flat()),
   ]);
 
   return flights
@@ -79,4 +89,24 @@ export const getPendingFlights = (
     .filter(
       ({ index }) => !unknownIndices.has(index) && !handledIndices.has(index),
     );
+};
+
+export const getOutstandingUnknowns = (
+  unknowns: ImportUnknowns,
+  handledIndices: ReadonlySet<number>,
+): ImportUnknowns => {
+  const filterHandledIndices = (values: UnknownImportValues) => {
+    const outstanding: UnknownImportValues = {};
+    for (const [code, indices] of Object.entries(values)) {
+      const remaining = indices.filter((index) => !handledIndices.has(index));
+      if (remaining.length) outstanding[code] = remaining;
+    }
+    return outstanding;
+  };
+
+  return {
+    airports: filterHandledIndices(unknowns.airports),
+    airlines: filterHandledIndices(unknowns.airlines),
+    aircraft: filterHandledIndices(unknowns.aircraft),
+  };
 };

--- a/src/lib/server/utils/flight-import.test.ts
+++ b/src/lib/server/utils/flight-import.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { CreateFlight, User } from '$lib/db/types';
 
 import {
+  getMissingFlightReferenceUpdate,
   getMissingImportPassengers,
   validateFlightImportPermissions,
 } from './flight-import';
@@ -75,6 +76,38 @@ describe('getMissingImportPassengers', () => {
     expect(getMissingImportPassengers([], [userSeat, userSeat])).toEqual([
       userSeat,
     ]);
+  });
+});
+
+describe('getMissingFlightReferenceUpdate', () => {
+  it('fills missing airline and aircraft references', () => {
+    expect(
+      getMissingFlightReferenceUpdate(
+        { airline: null, aircraft: null },
+        { airline: { id: 12 }, aircraft: { id: 34 } },
+      ),
+    ).toEqual({ airlineId: 12, aircraftId: 34 });
+  });
+
+  it('does not replace existing references', () => {
+    expect(
+      getMissingFlightReferenceUpdate(
+        {
+          airline: { id: 1 },
+          aircraft: { id: 2 },
+        } as Parameters<typeof getMissingFlightReferenceUpdate>[0],
+        { airline: { id: 12 }, aircraft: { id: 34 } },
+      ),
+    ).toBeNull();
+  });
+
+  it('ignores unresolved incoming references', () => {
+    expect(
+      getMissingFlightReferenceUpdate(
+        { airline: null, aircraft: null },
+        { airline: null, aircraft: null },
+      ),
+    ).toBeNull();
   });
 });
 

--- a/src/lib/server/utils/flight-import.ts
+++ b/src/lib/server/utils/flight-import.ts
@@ -1,6 +1,27 @@
-import type { CreateFlight, User } from '$lib/db/types';
+import type { CreateFlight, Flight, User } from '$lib/db/types';
 
 export type FlightImportMode = 'personal' | 'restore';
+
+export type MissingFlightReferenceUpdate = {
+  airlineId?: number;
+  aircraftId?: number;
+};
+
+export const getMissingFlightReferenceUpdate = (
+  existing: Pick<Flight, 'airline' | 'aircraft'>,
+  incoming: Pick<CreateFlight, 'airline' | 'aircraft'>,
+): MissingFlightReferenceUpdate | null => {
+  const update: MissingFlightReferenceUpdate = {};
+
+  if (!existing.airline && incoming.airline?.id != null) {
+    update.airlineId = incoming.airline.id;
+  }
+  if (!existing.aircraft && incoming.aircraft?.id != null) {
+    update.aircraftId = incoming.aircraft.id;
+  }
+
+  return Object.keys(update).length ? update : null;
+};
 
 type FlightImportPassenger = Pick<
   CreateFlight['passengers'][number],

--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -23,7 +23,9 @@ import {
   persistEntityCustomFields,
 } from '$lib/server/utils/custom-fields';
 import {
+  getMissingFlightReferenceUpdate,
   getMissingImportPassengers,
+  type MissingFlightReferenceUpdate,
   type FlightImportMode,
 } from '$lib/server/utils/flight-import';
 import { distanceBetween } from '$lib/utils';
@@ -503,7 +505,11 @@ export const createManyFlights = async (
   userId: string,
   dedupe = true,
   mode: FlightImportMode = 'personal',
-): Promise<{ insertedFlights: number; attachedPassengers: number }> => {
+): Promise<{
+  insertedFlights: number;
+  updatedFlights: number;
+  attachedPassengers: number;
+}> => {
   if (!dedupe) {
     const insertedFlights = data.length;
     const attachedPassengers = data.reduce(
@@ -511,7 +517,7 @@ export const createManyFlights = async (
       0,
     );
     await createManyFlightsPrimitive(db, data);
-    return { insertedFlights, attachedPassengers };
+    return { insertedFlights, updatedFlights: 0, attachedPassengers };
   }
 
   // Deduplicate within incoming data
@@ -523,7 +529,7 @@ export const createManyFlights = async (
   const uniqueFlights = Array.from(uniqueMap.values());
 
   if (uniqueFlights.length === 0)
-    return { insertedFlights: 0, attachedPassengers: 0 };
+    return { insertedFlights: 0, updatedFlights: 0, attachedPassengers: 0 };
 
   // Gather candidate filters
   const dates = new Set(uniqueFlights.map((f) => f.date));
@@ -547,10 +553,10 @@ export const createManyFlights = async (
       .execute();
   }
 
-  const existingBySig = new Map<string, number>();
+  const existingBySig = new Map<string, Flight>();
   for (const ef of existingFlights) {
     const key = signature(ef);
-    if (!existingBySig.has(key)) existingBySig.set(key, ef.id);
+    if (!existingBySig.has(key)) existingBySig.set(key, ef);
   }
 
   const userPassengerByFlight = new Set<number>();
@@ -572,13 +578,28 @@ export const createManyFlights = async (
     flightId: number;
     track: NonNullable<CreateFlight['track']>;
   }> = [];
+  const referenceUpdates: Array<{
+    flightId: number;
+    update: MissingFlightReferenceUpdate;
+  }> = [];
 
   for (const f of uniqueFlights) {
     const key = signature(f);
-    const existingId = existingBySig.get(key);
-    if (existingId) {
+    const existingFlight = existingBySig.get(key);
+    if (existingFlight) {
+      const existingId = existingFlight.id;
       if (f.track) {
         tracksToUpsert.push({ flightId: existingId, track: f.track });
+      }
+      const referenceUpdate = getMissingFlightReferenceUpdate(
+        existingFlight,
+        f,
+      );
+      if (referenceUpdate) {
+        referenceUpdates.push({
+          flightId: existingId,
+          update: referenceUpdate,
+        });
       }
 
       // Personal imports only deduplicate flights already owned by the importer.
@@ -613,10 +634,34 @@ export const createManyFlights = async (
     insertedFlights = flightsToInsert.length;
   }
 
-  // Attach passengers to existing flights.
+  // Enrich and attach data to existing flights.
+  const updatedFlights = referenceUpdates.length;
   let attachedPassengers = 0;
-  if (passengersToAttach.length || tracksToUpsert.length) {
+  if (
+    referenceUpdates.length ||
+    passengersToAttach.length ||
+    tracksToUpsert.length
+  ) {
     await db.transaction().execute(async (trx) => {
+      for (const { flightId, update } of referenceUpdates) {
+        if (update.airlineId != null) {
+          await trx
+            .updateTable('flight')
+            .set({ airlineId: update.airlineId })
+            .where('id', '=', flightId)
+            .where('airlineId', 'is', null)
+            .execute();
+        }
+        if (update.aircraftId != null) {
+          await trx
+            .updateTable('flight')
+            .set({ aircraftId: update.aircraftId })
+            .where('id', '=', flightId)
+            .where('aircraftId', 'is', null)
+            .execute();
+        }
+      }
+
       for (const { flightId, track } of tracksToUpsert) {
         await upsertFlightTrackPrimitiveWithConnection(trx, flightId, track);
       }
@@ -631,5 +676,5 @@ export const createManyFlights = async (
     });
   }
 
-  return { insertedFlights, attachedPassengers };
+  return { insertedFlights, updatedFlights, attachedPassengers };
 };

--- a/tests/manual/issue-687-unknown-airlines.csv
+++ b/tests/manual/issue-687-unknown-airlines.csv
@@ -1,0 +1,4 @@
+Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note
+1999-07-15,NW687,Minneapolis (MSP/KMSP),Seattle (SEA/KSEA),10:00:00,11:30:00,03:30:00,Northwest Airlines (NW/NWA),Boeing 757-200 (B752),N687NW,12A,1,1,1,Issue 687 unknown airline test
+2008-04-20,9W687,Mumbai (BOM/VABB),Delhi (DEL/VIDP),09:00:00,11:10:00,02:10:00,Jet Airways (9W/JAI),Boeing 737-800 (B738),VT-JAT,14F,1,1,1,Issue 687 unknown airline test
+2025-01-15,DL687,Atlanta (ATL/KATL),New York (JFK/KJFK),08:00:00,10:15:00,02:15:00,Delta Air Lines (DL/DAL),Airbus A320 (A320),N687DL,8A,1,1,1,Issue 687 known airline control


### PR DESCRIPTION
<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
### Import flights with unknown airlines and aircraft
- Allows flights with unresolved airlines or aircraft to be imported while continuing to require airport mappings.
- Adds an import-status workflow for mapping recognized references and importing remaining flights.
- Enriches matching existing flights with newly resolved airline and aircraft references and reports updated-flight counts.

<sup>AirTrail Helper summarized 87ee6f5 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
