### PR TITLE
fix: path traversal in airline icon upload

### DIFF
--- a/src/routes/api/airline/icon/+server.ts
+++ b/src/routes/api/airline/icon/+server.ts
@@ -50,7 +50,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
   // Get file extension from mime type
   const ext = ALLOWED_IMAGE_EXTENSIONS[typeIndex] || '.png';
-  const relativePath = `airlines/${airlineId}${ext}`;
+  const relativePath = `airlines/${airlineIdNum}${ext}`;
 
   // Delete old icon if it exists with a different extension
   const existingAirline = await db


### PR DESCRIPTION
The airline icon upload builds the save path from the raw `airlineId` form field but only validates it with `parseInt(...)` for NaN. Since `parseInt('5/../../foo', 10)` returns `5`, a value like `5/../../../../some/path` slips through, and `uploadManager.saveFile` just does `path.join(uploadLocation, relativePath)` with no containment check, so the uploaded bytes get written outside the uploads directory. Any logged-in non-`user` account can use it to drop attacker-controlled png/jpg/svg/webp content at arbitrary paths on the host. I switched the path to use the already-parsed integer `airlineIdNum` instead of the raw string, so only digits ever reach the filesystem. One-line change, behavior for normal uploads is unchanged.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Build airline icon paths from the parsed numeric airline ID
> The upload handler now uses the parsed numeric airline ID when constructing an icon path, preventing raw form input from traversing outside the airline uploads directory.
>
> <sup>AirTrail Helper summarized 95949c6 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
