### PR TITLE
feat: group layovers and separate upcoming from past flights

### DIFF
--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -13,7 +13,12 @@
 
   import DeleteFlightModal from './DeleteFlightModal.svelte';
   import EmptyFlightsState from './EmptyFlightsState.svelte';
+  import {
+    buildFlightListYears,
+    sortByDepartureDesc,
+  } from './flight-list-groups';
   import MobileFlightList from './MobileFlightList.svelte';
+  import PastFlightsDivider from './PastFlightsDivider.svelte';
   import Toolbar from './Toolbar.svelte';
 
   import { page as appPage } from '$app/state';
@@ -87,8 +92,8 @@
     const data = filteredFlights;
     if (!data) return [];
 
-    return data
-      .map((f) => {
+    return sortByDepartureDesc(
+      data.map((f) => {
         const depDate = f.departure;
         const arrDate = f.arrival;
 
@@ -135,16 +140,8 @@
             ? getFlightPassengerLabels(f)
             : [],
         };
-      })
-      .sort((a, b) => {
-        if (a.departure && b.departure) {
-          return isBefore(a.departure, b.departure) ? 1 : -1;
-        } else if (a.dateStart && b.dateStart) {
-          return isBefore(a.dateStart, b.dateStart) ? 1 : -1;
-        } else {
-          return 0;
-        }
-      });
+      }),
+    );
   });
 
   const flightsPerPage = 20;
@@ -156,22 +153,9 @@
     );
   });
 
-  const flightsByYear = $derived.by(() => {
-    const raw = paginatedFlights.reduce(
-      (acc, f) => {
-        const year = f.date?.getFullYear() ?? 0;
-        if (!acc[year]) acc[year] = [];
-        acc[year].push(f);
-        return acc;
-      },
-      {} as Record<number, typeof formattedFlights>,
-    );
-    return Object.entries(raw)
-      .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))
-      .map(([year, flights]) => {
-        return { year, flights };
-      });
-  });
+  const flightsByYear = $derived.by(() =>
+    buildFlightListYears(paginatedFlights, new Date()),
+  );
 
   let selecting = $state(false);
   let selectedFlights = $state<number[]>([]);
@@ -471,8 +455,11 @@
           )}
           use:autoAnimate
         >
-          {#each flightsByYear as { year, flights } (year)}
-            {#if year !== '0'}
+          {#each flightsByYear as { year, groups } (year)}
+            {#if groups[0]?.startsPastSection}
+              <PastFlightsDivider class="col-span-full" />
+            {/if}
+            {#if year !== 0}
               <LabelledSeparator class="col-span-full mt-4">
                 <h3
                   class="border px-4 py-1 rounded-full border-dashed text-sm font-medium leading-7"
@@ -481,98 +468,118 @@
                 </h3>
               </LabelledSeparator>
             {/if}
-            {#each flights as flight (flight.id)}
-              <div
-                id="flight-list-row-{flight.id}"
-                class="relative col-span-full grid grid-cols-subgrid scroll-mt-24 rounded-lg"
-              >
-                {#if showPassengerDetails && flight.passengerLabels.length}
-                  {@render passengerBadge(flight.passengerLabels)}
-                {/if}
-                <Card
-                  onclick={() => {
-                    if (!readonly && selecting) {
-                      if (selectedFlights.includes(flight.id)) {
-                        selectedFlights = selectedFlights.filter(
-                          (id) => id !== flight.id,
-                        );
-                      } else {
-                        selectedFlights = [...selectedFlights, flight.id];
-                      }
-                    }
-                  }}
-                  level="2"
-                  class={cn(
-                    'col-span-full grid grid-cols-subgrid items-center p-3',
-                    {
-                      'cursor-pointer border-zinc-600 border-dotted border-2':
-                        !readonly && selecting,
-                      'border-destructive border-solid':
-                        !readonly &&
-                        selecting &&
-                        selectedFlights.includes(flight.id),
-                    },
-                  )}
-                >
-                  {#if flight.hasDateDisplay}
-                    <div class="flex min-w-max items-center">
-                      <div class="flex w-11 shrink-0 justify-center">
-                        <AirlineIcon
-                          airline={flight.airline}
-                          size={36}
-                          fallback="plane"
-                        />
-                      </div>
-                      <Separator orientation="vertical" class="mx-3 h-10" />
-                      <div
-                        class="flex min-w-max shrink-0 flex-col whitespace-nowrap"
-                      >
-                        {@render flightTimes(flight)}
-                      </div>
-                    </div>
-                  {:else}
-                    <div aria-hidden="true"></div>
-                  {/if}
-                  <div aria-hidden="true"></div>
-                  <div class="hidden min-w-0 flex-col lg:flex">
-                    {@render seatAndAirline(flight)}
-                  </div>
-                  <div class="hidden lg:block" aria-hidden="true"></div>
-                  <div class="hidden min-w-0 flex-col xl:flex">
-                    {@render flightAndTailNumber(flight)}
-                  </div>
-                  <div class="hidden xl:block" aria-hidden="true"></div>
-                  <div class="flex min-w-0 px-8 xl:px-12">
-                    <div class="w-full grid grid-cols-[auto_1fr_auto] gap-3">
-                      {@render airport(flight.from)}
-                      <div class="h-full flex flex-col justify-center">
-                        <div class="relative">
+            {#each groups as group, groupIndex (group.key)}
+              {#if group.startsPastSection && groupIndex > 0}
+                <PastFlightsDivider class="col-span-full" />
+              {/if}
+              <!-- Legs connected by a layover share one block: the grid gap and
+                   the borders between them are dropped. -->
+              <div class="col-span-full grid grid-cols-subgrid gap-y-0">
+                {#each group.flights as flight, legIndex (flight.id)}
+                  {@const continuesAbove = legIndex > 0}
+                  {@const continuesBelow = legIndex < group.flights.length - 1}
+                  {@const outlined = !readonly && selecting}
+                  <div
+                    id="flight-list-row-{flight.id}"
+                    class="relative col-span-full grid grid-cols-subgrid scroll-mt-24 rounded-lg"
+                  >
+                    {#if showPassengerDetails && flight.passengerLabels.length}
+                      {@render passengerBadge(flight.passengerLabels)}
+                    {/if}
+                    <Card
+                      onclick={() => {
+                        if (!readonly && selecting) {
+                          if (selectedFlights.includes(flight.id)) {
+                            selectedFlights = selectedFlights.filter(
+                              (id) => id !== flight.id,
+                            );
+                          } else {
+                            selectedFlights = [...selectedFlights, flight.id];
+                          }
+                        }
+                      }}
+                      level="2"
+                      class={cn(
+                        'col-span-full grid grid-cols-subgrid items-center p-3',
+                        {
+                          'rounded-t-none': continuesAbove,
+                          'rounded-b-none': continuesBelow,
+                          // Legs of one trip drop the borders that would sit
+                          // between them, and the block keeps a single drop
+                          // shadow cast by its bottom-most leg. While selecting,
+                          // every card keeps its own outline instead.
+                          'border-t-0': continuesAbove && !outlined,
+                          'border-b-0 shadow-none': continuesBelow && !outlined,
+                          'cursor-pointer border-zinc-600 border-dotted border-2':
+                            outlined,
+                          'border-destructive border-solid':
+                            outlined && selectedFlights.includes(flight.id),
+                        },
+                      )}
+                    >
+                      {#if flight.hasDateDisplay}
+                        <div class="flex min-w-max items-center">
+                          <div class="flex w-11 shrink-0 justify-center">
+                            <AirlineIcon
+                              airline={flight.airline}
+                              size={36}
+                              fallback="plane"
+                            />
+                          </div>
+                          <Separator orientation="vertical" class="mx-3 h-10" />
                           <div
-                            class="relative w-full h-px border-b border-dashed border-dark-2 dark:border-zinc-500"
+                            class="flex min-w-max shrink-0 flex-col whitespace-nowrap"
                           >
-                            <div
-                              class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-1 bg-card dark:bg-dark-2 text-dark-2 dark:text-zinc-500"
-                            >
-                              <div class="flex flex-col items-center">
-                                <Plane size="20" />
-                                <span class="text-xs"
-                                  >{flight.durationDisplay}</span
+                            {@render flightTimes(flight)}
+                          </div>
+                        </div>
+                      {:else}
+                        <div aria-hidden="true"></div>
+                      {/if}
+                      <div aria-hidden="true"></div>
+                      <div class="hidden min-w-0 flex-col lg:flex">
+                        {@render seatAndAirline(flight)}
+                      </div>
+                      <div class="hidden lg:block" aria-hidden="true"></div>
+                      <div class="hidden min-w-0 flex-col xl:flex">
+                        {@render flightAndTailNumber(flight)}
+                      </div>
+                      <div class="hidden xl:block" aria-hidden="true"></div>
+                      <div class="flex min-w-0 px-8 xl:px-12">
+                        <div
+                          class="w-full grid grid-cols-[auto_1fr_auto] gap-3"
+                        >
+                          {@render airport(flight.from)}
+                          <div class="h-full flex flex-col justify-center">
+                            <div class="relative">
+                              <div
+                                class="relative w-full h-px border-b border-dashed border-dark-2 dark:border-zinc-500"
+                              >
+                                <div
+                                  class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-1 bg-card dark:bg-dark-2 text-dark-2 dark:text-zinc-500"
                                 >
+                                  <div class="flex flex-col items-center">
+                                    <Plane size="20" />
+                                    <span class="text-xs"
+                                      >{flight.durationDisplay}</span
+                                    >
+                                  </div>
+                                </div>
                               </div>
                             </div>
                           </div>
+                          {@render airport(flight.to)}
                         </div>
                       </div>
-                      {@render airport(flight.to)}
-                    </div>
+                      {#if !readonly}
+                        <div aria-hidden="true"></div>
+                        <div class="hidden md:flex">
+                          {@render actions(flight)}
+                        </div>
+                      {/if}
+                    </Card>
                   </div>
-                  {#if !readonly}
-                    <div aria-hidden="true"></div>
-                    <div class="hidden md:flex">
-                      {@render actions(flight)}
-                    </div>
-                  {/if}
-                </Card>
+                {/each}
               </div>
             {/each}
           {/each}

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -15,6 +15,7 @@
   import EmptyFlightsState from './EmptyFlightsState.svelte';
   import {
     buildFlightListYears,
+    paginateFlightListYears,
     sortByDepartureDesc,
   } from './flight-list-groups';
   import MobileFlightList from './MobileFlightList.svelte';
@@ -146,15 +147,29 @@
 
   const flightsPerPage = 20;
   let page = $state(1);
-  const paginatedFlights = $derived.by(() => {
-    return formattedFlights.slice(
-      (page - 1) * flightsPerPage,
-      page * flightsPerPage,
-    );
+  let flightListReferenceTime = $state(new Date());
+
+  $effect(() => {
+    if (open) flightListReferenceTime = new Date();
   });
 
-  const flightsByYear = $derived.by(() =>
-    buildFlightListYears(paginatedFlights, new Date()),
+  const flightListPages = $derived.by(() => {
+    const years = buildFlightListYears(
+      formattedFlights,
+      flightListReferenceTime,
+    );
+    return paginateFlightListYears(years, flightsPerPage);
+  });
+  const currentFlightListPage = $derived(flightListPages[page - 1]);
+  const flightsByYear = $derived(currentFlightListPage?.years ?? []);
+  const showingFrom = $derived(
+    currentFlightListPage ? currentFlightListPage.firstFlightIndex + 1 : 0,
+  );
+  const showingTo = $derived(
+    currentFlightListPage
+      ? currentFlightListPage.firstFlightIndex +
+          currentFlightListPage.flights.length
+      : 0,
   );
 
   let selecting = $state(false);
@@ -188,10 +203,10 @@
       timers.add(timer);
     };
 
-    const index = formattedFlights.findIndex(
-      (flight) => flight.id === flightId,
+    const targetPage = flightListPages.findIndex((candidate) =>
+      candidate.flights.some((flight) => flight.id === flightId),
     );
-    if (index >= 0) page = Math.floor(index / flightsPerPage) + 1;
+    if (targetPage >= 0) page = targetPage + 1;
 
     // Poll until the row is mounted (on mobile the list opens in a drawer that
     // animates in, so it isn't in the DOM for the first few frames), then scroll
@@ -406,7 +421,9 @@
           bind:selecting
           bind:selectedFlights
           bind:page
-          {flightsPerPage}
+          pageCount={flightListPages.length}
+          {showingFrom}
+          {showingTo}
           {hasTempFilters}
           numOfFlights={filteredFlights.length}
           modalOpen={open &&

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -2,7 +2,9 @@
   import autoAnimate from '@formkit/auto-animate';
   import { AirplanemodeInactive } from '@o7/icon/material';
 
+  import type { FlightListYear } from './flight-list-groups';
   import FlightCard from './FlightCard.svelte';
+  import PastFlightsDivider from './PastFlightsDivider.svelte';
   import SwipeableFlightRow from './SwipeableFlightRow.svelte';
 
   import type { FlightData } from '$lib/utils';
@@ -11,11 +13,6 @@
   type Flight = FlightData & {
     month?: string | null;
     passengerLabels?: string[];
-  };
-
-  type YearGroup = {
-    year: string;
-    flights: Flight[];
   };
 
   let {
@@ -27,7 +24,7 @@
     onShowOnMap,
     readonly = false,
   }: {
-    flightsByYear: YearGroup[];
+    flightsByYear: FlightListYear<Flight>[];
     selecting?: boolean;
     selectedFlights?: number[];
     onEdit?: (flight: FlightData) => void;
@@ -61,53 +58,58 @@
   </div>
 {:else}
   <div class="flex flex-col" use:autoAnimate>
-    {#each flightsByYear as { year, flights }, yearIndex (year)}
-      {@const isLastYear = yearIndex === flightsByYear.length - 1}
+    {#each flightsByYear as { year, groups }, yearIndex (year)}
       <div use:autoAnimate>
-        {#each flights as flight, index (flight.id)}
-          {@const isLastFlight = index === flights.length - 1}
-          {@const isSelected =
-            !readonly && selecting && selectedFlights.includes(flight.id)}
-          <div id="flight-list-row-{flight.id}" class="isolate scroll-mt-24">
-            <SwipeableFlightRow
-              bind:this={swipeableRefs[flight.id]}
-              disabled={selecting || readonly}
-              onEdit={readonly ? undefined : () => onEdit?.(flight)}
-              onDelete={readonly ? undefined : () => onDelete?.(flight)}
-              onShowOnMap={readonly ||
-              !onShowOnMap ||
-              !flight.from ||
-              !flight.to
-                ? undefined
-                : () => onShowOnMap?.(flight)}
-            >
-              {#snippet children({ isInteracting })}
-                <button
-                  type="button"
-                  class={cn(
-                    'w-full px-4 py-4 transition-colors',
-                    isSelected
-                      ? 'bg-destructive/10 hover:bg-destructive/15'
-                      : !isInteracting && 'hover:bg-hover active:bg-hover',
-                  )}
-                  onclick={() => {
-                    if (!readonly && selecting) {
-                      toggleSelection(flight.id);
-                    }
-                  }}
-                >
-                  <FlightCard
-                    {flight}
-                    passengerLabels={flight.passengerLabels}
-                  />
-                </button>
-              {/snippet}
-            </SwipeableFlightRow>
-            <!-- Separator outside swipeable content with its own stacking context -->
-            {#if !(isLastFlight && isLastYear)}
-              <div class="relative z-10 h-px bg-border"></div>
-            {/if}
-          </div>
+        {#each groups as group, groupIndex (group.key)}
+          {@const isFirstGroup = yearIndex === 0 && groupIndex === 0}
+          <!-- Separators sit between groups, outside the swipeable rows so they
+               keep their own stacking context. Legs connected by a layover are
+               not separated at all. -->
+          {#if group.startsPastSection}
+            <PastFlightsDivider />
+          {:else if !isFirstGroup}
+            <div class="relative z-10 h-px bg-border"></div>
+          {/if}
+          {#each group.flights as flight (flight.id)}
+            {@const isSelected =
+              !readonly && selecting && selectedFlights.includes(flight.id)}
+            <div id="flight-list-row-{flight.id}" class="isolate scroll-mt-24">
+              <SwipeableFlightRow
+                bind:this={swipeableRefs[flight.id]}
+                disabled={selecting || readonly}
+                onEdit={readonly ? undefined : () => onEdit?.(flight)}
+                onDelete={readonly ? undefined : () => onDelete?.(flight)}
+                onShowOnMap={readonly ||
+                !onShowOnMap ||
+                !flight.from ||
+                !flight.to
+                  ? undefined
+                  : () => onShowOnMap?.(flight)}
+              >
+                {#snippet children({ isInteracting })}
+                  <button
+                    type="button"
+                    class={cn(
+                      'w-full px-4 py-4 transition-colors',
+                      isSelected
+                        ? 'bg-destructive/10 hover:bg-destructive/15'
+                        : !isInteracting && 'hover:bg-hover active:bg-hover',
+                    )}
+                    onclick={() => {
+                      if (!readonly && selecting) {
+                        toggleSelection(flight.id);
+                      }
+                    }}
+                  >
+                    <FlightCard
+                      {flight}
+                      passengerLabels={flight.passengerLabels}
+                    />
+                  </button>
+                {/snippet}
+              </SwipeableFlightRow>
+            </div>
+          {/each}
         {/each}
       </div>
     {/each}

--- a/src/lib/components/modals/list-flights/PastFlightsDivider.svelte
+++ b/src/lib/components/modals/list-flights/PastFlightsDivider.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Separator } from '$lib/components/ui/separator';
+  import { cn } from '$lib/utils';
+
+  // Marks the point in the list where upcoming flights end and flown ones begin.
+  let { class: className }: { class?: string } = $props();
+</script>
+
+<Separator
+  class={cn('my-4 bg-muted-foreground/40', className)}
+  data-testid="past-flights-divider"
+/>

--- a/src/lib/components/modals/list-flights/Toolbar.svelte
+++ b/src/lib/components/modals/list-flights/Toolbar.svelte
@@ -39,7 +39,9 @@
     filters = $bindable(),
     tempFilters = $bindable(),
     page = $bindable(),
-    flightsPerPage,
+    pageCount,
+    showingFrom,
+    showingTo,
     numOfFlights,
     selecting = $bindable(),
     selectedFlights = $bindable(),
@@ -51,7 +53,9 @@
     filters: FlightFilters;
     tempFilters?: TempFilters;
     page: number;
-    flightsPerPage: number;
+    pageCount: number;
+    showingFrom: number;
+    showingTo: number;
     numOfFlights: number;
     selecting: boolean;
     selectedFlights: number[];
@@ -88,20 +92,10 @@
     return 'Mine';
   });
 
-  let pages = $derived.by(() => {
-    return Math.ceil(numOfFlights / flightsPerPage);
-  });
-  let showingFrom = $derived.by(() => {
-    return numOfFlights === 0 ? 0 : (page - 1) * flightsPerPage + 1;
-  });
-  let showingTo = $derived.by(() => {
-    return Math.min(page * flightsPerPage, numOfFlights);
-  });
-
   // Ensure page is within bounds even after filtering
   $effect(() => {
-    if (page > pages && pages !== 0) {
-      page = pages;
+    if (page > pageCount && pageCount !== 0) {
+      page = pageCount;
     }
   });
 
@@ -281,9 +275,9 @@
                     </Button>
                     <Button
                       onclick={() => {
-                        page = Math.min(pages, page + 1);
+                        page = Math.min(pageCount, page + 1);
                       }}
-                      disabled={page === pages || pages === 0}
+                      disabled={page === pageCount || pageCount === 0}
                       variant="outline"
                       size="sm"
                     >

--- a/src/lib/components/modals/list-flights/flight-list-groups.test.ts
+++ b/src/lib/components/modals/list-flights/flight-list-groups.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildFlightListYears,
+  paginateFlightListYears,
   sortByDepartureDesc,
 } from './flight-list-groups';
 
@@ -49,6 +50,18 @@ const build = (flights: Flight[], now: string) =>
 const groupedIds = (years: ReturnType<typeof build>) =>
   years.flatMap((year) =>
     year.groups.map((group) => group.flights.map((f) => f.id)),
+  );
+
+const unrelatedFlights = (count: number, date: string) =>
+  Array.from({ length: count }, (_, index) =>
+    flight({
+      id: 100 + index,
+      from: LHR,
+      to: SYD,
+      date,
+      departure: `${date}T05:00:00.000Z`,
+      arrival: `${date}T18:00:00.000Z`,
+    }),
   );
 
 // LHR -> DXB -> SYD, connecting in Dubai after a 3h stop.
@@ -165,6 +178,25 @@ describe('buildFlightListYears', () => {
     ]);
   });
 
+  it('keeps a scheduled flight upcoming until its effective arrival', () => {
+    const [onward, inbound] = dubaiConnection;
+    const scheduledOnward = {
+      ...onward!,
+      departure: null,
+      arrival: null,
+      departureScheduled: onward!.departure,
+      arrivalScheduled: onward!.arrival,
+    } as Flight;
+
+    const years = build([scheduledOnward, inbound!], '2024-03-02T10:00:00Z');
+
+    expect(groupedIds(years)).toEqual([[2], [1]]);
+    expect(years[0]!.groups.map((group) => group.startsPastSection)).toEqual([
+      false,
+      true,
+    ]);
+  });
+
   it('marks the boundary on the first group of an older year', () => {
     const [onward] = dubaiConnection;
     const upcoming = {
@@ -205,5 +237,33 @@ describe('buildFlightListYears', () => {
 
     expect(years.map((year) => year.year)).toEqual([2024, 0]);
     expect(groupedIds(years)).toEqual([[2, 1], [4]]);
+  });
+});
+
+describe('paginateFlightListYears', () => {
+  it('moves a layover group intact to the next page', () => {
+    const years = build(
+      [...unrelatedFlights(19, '2024-03-03'), ...dubaiConnection],
+      '2024-06-01T00:00:00Z',
+    );
+
+    const pages = paginateFlightListYears(years, 20);
+
+    expect(pages.map((page) => page.flights.length)).toEqual([19, 2]);
+    expect(pages.map((page) => page.firstFlightIndex)).toEqual([0, 19]);
+    expect(groupedIds(pages[1]!.years)).toEqual([[2, 1]]);
+  });
+
+  it('keeps the past divider on a new page', () => {
+    const [, pastFlight] = dubaiConnection;
+    const years = build(
+      [...unrelatedFlights(20, '2025-03-03'), pastFlight!],
+      '2024-06-01T00:00:00Z',
+    );
+
+    const pages = paginateFlightListYears(years, 20);
+
+    expect(pages.map((page) => page.flights.length)).toEqual([20, 1]);
+    expect(pages[1]!.years[0]!.groups[0]!.startsPastSection).toBe(true);
   });
 });

--- a/src/lib/components/modals/list-flights/flight-list-groups.test.ts
+++ b/src/lib/components/modals/list-flights/flight-list-groups.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildFlightListYears,
+  sortByDepartureDesc,
+} from './flight-list-groups';
+
+import type { Airport, Flight } from '$lib/db/types';
+import { prepareFlightData } from '$lib/utils';
+
+const airport = (id: number, tz: string): Airport =>
+  ({ id, tz, lon: 0, lat: 0 }) as Airport;
+
+const LHR = airport(1, 'Europe/London');
+const DXB = airport(2, 'Asia/Dubai');
+const SYD = airport(3, 'Australia/Sydney');
+
+type FlightInput = {
+  id: number;
+  from: Airport;
+  to: Airport;
+  date: string;
+  departure: string;
+  arrival: string;
+};
+
+const flight = ({ id, from, to, date, departure, arrival }: FlightInput) =>
+  ({
+    id,
+    from,
+    to,
+    date,
+    datePrecision: 'day',
+    departure,
+    arrival,
+    duration: null,
+    departureScheduled: null,
+    arrivalScheduled: null,
+    takeoffScheduled: null,
+    takeoffActual: null,
+    landingScheduled: null,
+    landingActual: null,
+  }) as Flight;
+
+/** Flights are handed to the list newest first. */
+const build = (flights: Flight[], now: string) =>
+  buildFlightListYears(prepareFlightData(flights), new Date(now));
+
+const groupedIds = (years: ReturnType<typeof build>) =>
+  years.flatMap((year) =>
+    year.groups.map((group) => group.flights.map((f) => f.id)),
+  );
+
+// LHR -> DXB -> SYD, connecting in Dubai after a 3h stop.
+const dubaiConnection = [
+  flight({
+    id: 2,
+    from: DXB,
+    to: SYD,
+    date: '2024-03-02',
+    departure: '2024-03-02T05:00:00.000Z',
+    arrival: '2024-03-02T18:00:00.000Z',
+  }),
+  flight({
+    id: 1,
+    from: LHR,
+    to: DXB,
+    date: '2024-03-01',
+    departure: '2024-03-01T20:00:00.000Z',
+    arrival: '2024-03-02T02:00:00.000Z',
+  }),
+];
+
+describe('sortByDepartureDesc', () => {
+  const order = (flights: Flight[]) =>
+    sortByDepartureDesc(prepareFlightData(flights)).map((f) => f.id);
+
+  it('orders same-day flights on their scheduled time when none has flown', () => {
+    // Upcoming flights only carry scheduled times, so ordering them on the
+    // start of their day leaves same-day departures tied.
+    const [onward, inbound] = dubaiConnection.map(
+      (f) =>
+        ({
+          ...f,
+          departure: null,
+          arrival: null,
+          departureScheduled: f.departure,
+          arrivalScheduled: f.arrival,
+          date: '2024-03-02',
+        }) as Flight,
+    );
+
+    expect(order([inbound!, onward!])).toEqual([2, 1]);
+    expect(order([onward!, inbound!])).toEqual([2, 1]);
+  });
+
+  it('orders flown flights on their recorded time', () => {
+    const [onward, inbound] = dubaiConnection;
+
+    expect(order([inbound!, onward!])).toEqual([2, 1]);
+  });
+
+  it('puts flights without a usable date last', () => {
+    const undated = {
+      ...dubaiConnection[0]!,
+      id: 4,
+      date: '',
+      departure: null,
+      arrival: null,
+    } as Flight;
+
+    expect(order([undated, ...dubaiConnection])).toEqual([2, 1, 4]);
+  });
+});
+
+describe('buildFlightListYears', () => {
+  it('groups legs connected by a layover', () => {
+    expect(groupedIds(build(dubaiConnection, '2024-06-01T00:00:00Z'))).toEqual([
+      [2, 1],
+    ]);
+  });
+
+  it('keeps legs apart when the stop is longer than 12 hours', () => {
+    const [onward, inbound] = dubaiConnection;
+    const later = {
+      ...onward!,
+      departure: '2024-03-02T15:00:00.000Z',
+      arrival: '2024-03-03T04:00:00.000Z',
+    } as Flight;
+
+    expect(
+      groupedIds(build([later, inbound!], '2024-06-01T00:00:00Z')),
+    ).toEqual([[2], [1]]);
+  });
+
+  it('keeps legs apart when the second one starts somewhere else', () => {
+    const [onward, inbound] = dubaiConnection;
+    const elsewhere = { ...onward!, from: SYD, to: DXB } as Flight;
+
+    expect(
+      groupedIds(build([elsewhere, inbound!], '2024-06-01T00:00:00Z')),
+    ).toEqual([[2], [1]]);
+  });
+
+  it('does not group flights that have no times to compare', () => {
+    const untimed = dubaiConnection.map(
+      (f) => ({ ...f, departure: null, arrival: null }) as Flight,
+    );
+
+    expect(groupedIds(build(untimed, '2024-06-01T00:00:00Z'))).toEqual([
+      [2],
+      [1],
+    ]);
+  });
+
+  it('marks the first flown flight below the upcoming ones', () => {
+    const years = build(dubaiConnection, '2024-03-02T10:00:00Z');
+
+    // The Dubai stop is over, so the onward leg is still upcoming while the
+    // inbound one has landed: the run is cut at the boundary.
+    expect(groupedIds(years)).toEqual([[2], [1]]);
+    expect(years[0]!.groups.map((group) => group.startsPastSection)).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  it('marks the boundary on the first group of an older year', () => {
+    const [onward] = dubaiConnection;
+    const upcoming = {
+      ...onward!,
+      id: 3,
+      date: '2025-01-10',
+      departure: '2025-01-10T05:00:00.000Z',
+      arrival: '2025-01-10T18:00:00.000Z',
+    } as Flight;
+
+    const years = build([upcoming, ...dubaiConnection], '2024-06-01T00:00:00Z');
+
+    expect(years.map((year) => year.year)).toEqual([2025, 2024]);
+    expect(years[0]!.groups[0]!.startsPastSection).toBe(false);
+    expect(years[1]!.groups[0]!.startsPastSection).toBe(true);
+  });
+
+  it('leaves the boundary unmarked when every flight has been flown', () => {
+    const years = build(dubaiConnection, '2024-06-01T00:00:00Z');
+
+    expect(
+      years.flatMap((year) =>
+        year.groups.map((group) => group.startsPastSection),
+      ),
+    ).toEqual([false]);
+  });
+
+  it('sorts undated flights into their own trailing year', () => {
+    const undated = {
+      ...dubaiConnection[0]!,
+      id: 4,
+      date: '',
+      departure: null,
+      arrival: null,
+    } as Flight;
+
+    const years = build([...dubaiConnection, undated], '2024-06-01T00:00:00Z');
+
+    expect(years.map((year) => year.year)).toEqual([2024, 0]);
+    expect(groupedIds(years)).toEqual([[2, 1], [4]]);
+  });
+});

--- a/src/lib/components/modals/list-flights/flight-list-groups.ts
+++ b/src/lib/components/modals/list-flights/flight-list-groups.ts
@@ -1,6 +1,8 @@
-import { isCompletedFlight } from '$lib/stats/summary';
 import type { FlightData } from '$lib/utils';
-import { resolveFlightTimeline } from '$lib/utils/data/flight-timeline';
+import {
+  isCompletedFlight,
+  resolveFlightTimeline,
+} from '$lib/utils/data/flight-timeline';
 
 /** Ground time under which two legs still read as one trip rather than two. */
 export const MAX_LAYOVER_HOURS = 12;
@@ -22,6 +24,13 @@ export type FlightListYear<T> = {
   /** `UNDATED_YEAR` for flights without a date. */
   year: number;
   groups: LayoverGroup<T>[];
+};
+
+export type FlightListPage<T> = {
+  /** Zero-based index of the first flight in the complete sorted list. */
+  firstFlightIndex: number;
+  flights: T[];
+  years: FlightListYear<T>[];
 };
 
 /**
@@ -145,4 +154,55 @@ export const buildFlightListYears = <T extends FlightData>(
     year,
     groups: groupByLayover(yearFlights, pastSectionStart),
   }));
+};
+
+/** Packs complete layover groups into pages without losing divider metadata. */
+export const paginateFlightListYears = <T>(
+  years: FlightListYear<T>[],
+  pageSize: number,
+): FlightListPage<T>[] => {
+  if (!Number.isInteger(pageSize) || pageSize < 1) {
+    throw new RangeError('pageSize must be a positive integer');
+  }
+
+  const pages: FlightListPage<T>[] = [];
+  let currentPage: FlightListPage<T> | null = null;
+  let flightsBeforePage = 0;
+
+  const finishPage = () => {
+    if (!currentPage) return;
+    pages.push(currentPage);
+    flightsBeforePage += currentPage.flights.length;
+    currentPage = null;
+  };
+
+  for (const year of years) {
+    for (const group of year.groups) {
+      if (
+        currentPage &&
+        currentPage.flights.length > 0 &&
+        currentPage.flights.length + group.flights.length > pageSize
+      ) {
+        finishPage();
+      }
+
+      currentPage ??= {
+        firstFlightIndex: flightsBeforePage,
+        flights: [],
+        years: [],
+      };
+
+      let pageYear = currentPage.years.at(-1);
+      if (!pageYear || pageYear.year !== year.year) {
+        pageYear = { year: year.year, groups: [] };
+        currentPage.years.push(pageYear);
+      }
+
+      pageYear.groups.push(group);
+      currentPage.flights.push(...group.flights);
+    }
+  }
+
+  finishPage();
+  return pages;
 };

--- a/src/lib/components/modals/list-flights/flight-list-groups.ts
+++ b/src/lib/components/modals/list-flights/flight-list-groups.ts
@@ -1,0 +1,148 @@
+import { isCompletedFlight } from '$lib/stats/summary';
+import type { FlightData } from '$lib/utils';
+import { resolveFlightTimeline } from '$lib/utils/data/flight-timeline';
+
+/** Ground time under which two legs still read as one trip rather than two. */
+export const MAX_LAYOVER_HOURS = 12;
+
+const MAX_LAYOVER_MS = MAX_LAYOVER_HOURS * 60 * 60 * 1000;
+
+/** Bucket for flights that only have a placeholder date. */
+const UNDATED_YEAR = 0;
+
+/** A run of legs connected by a layover, drawn as one uninterrupted block. */
+export type LayoverGroup<T> = {
+  key: string;
+  /** The last upcoming flight sits directly above this group. */
+  startsPastSection: boolean;
+  flights: T[];
+};
+
+export type FlightListYear<T> = {
+  /** `UNDATED_YEAR` for flights without a date. */
+  year: number;
+  groups: LayoverGroup<T>[];
+};
+
+/**
+ * Sorts newest first on the best known departure time. Actual times are only
+ * recorded once a flight has been flown, so upcoming ones have to be ordered on
+ * their scheduled time rather than on the start of their day. Flights without
+ * any usable date sink to the bottom, where their year bucket renders.
+ */
+export const sortByDepartureDesc = <T extends FlightData>(flights: T[]): T[] =>
+  flights
+    .map((flight) => ({
+      flight,
+      at:
+        (
+          resolveFlightTimeline(flight.raw).effectiveDeparture ??
+          flight.dateStart
+        )?.getTime() ?? null,
+    }))
+    .sort((a, b) => {
+      if (a.at === null || b.at === null) {
+        return (a.at === null ? 1 : 0) - (b.at === null ? 1 : 0);
+      }
+      return b.at - a.at;
+    })
+    .map(({ flight }) => flight);
+
+/**
+ * True when `later` leaves from where `earlier` landed, soon enough to be a
+ * layover. Both times must be known: a same-day pair without times is just as
+ * likely to be two unrelated flights.
+ */
+const isLayover = (earlier: FlightData, later: FlightData) => {
+  if (!earlier.to || !later.from || earlier.to.id !== later.from.id) {
+    return false;
+  }
+
+  const { effectiveArrival } = resolveFlightTimeline(earlier.raw);
+  const { effectiveDeparture } = resolveFlightTimeline(later.raw);
+  if (!effectiveArrival || !effectiveDeparture) return false;
+
+  const gap = effectiveDeparture.getTime() - effectiveArrival.getTime();
+  return gap >= 0 && gap < MAX_LAYOVER_MS;
+};
+
+/** Id of the first flight that has already happened, if upcoming ones precede it. */
+const findPastSectionStart = (flights: FlightData[], now: Date) => {
+  let seenUpcoming = false;
+
+  for (const flight of flights) {
+    if (!isCompletedFlight(flight.raw, now)) {
+      seenUpcoming = true;
+    } else if (seenUpcoming) {
+      return flight.id;
+    }
+  }
+
+  return null;
+};
+
+const groupByLayover = <T extends FlightData>(
+  flights: T[],
+  pastSectionStart: number | null,
+): LayoverGroup<T>[] => {
+  const groups: LayoverGroup<T>[] = [];
+
+  for (const flight of flights) {
+    const startsPastSection = flight.id === pastSectionStart;
+    const openGroup = groups.at(-1);
+    // Newest first, so the flight already in the group is the later leg.
+    const laterLeg = openGroup?.flights.at(-1);
+
+    // The upcoming/past boundary always breaks the run, so that a group never
+    // straddles the divider drawn between the two sections.
+    if (
+      openGroup &&
+      laterLeg &&
+      !startsPastSection &&
+      isLayover(flight, laterLeg)
+    ) {
+      openGroup.flights.push(flight);
+      continue;
+    }
+
+    groups.push({
+      key: `layover-group-${flight.id}`,
+      startsPastSection,
+      flights: [flight],
+    });
+  }
+
+  return groups;
+};
+
+/**
+ * Render model for the flight list: years newest first, each split into layover
+ * groups, with the upcoming/past boundary marked on the group that follows it.
+ * `flights` must already be sorted newest first.
+ */
+export const buildFlightListYears = <T extends FlightData>(
+  flights: T[],
+  now: Date,
+): FlightListYear<T>[] => {
+  const byYear = new Map<number, T[]>();
+
+  for (const flight of flights) {
+    const year = flight.date?.getFullYear() ?? UNDATED_YEAR;
+    const bucket = byYear.get(year);
+    if (bucket) bucket.push(flight);
+    else byYear.set(year, [flight]);
+  }
+
+  const years = [...byYear.entries()].sort(([a], [b]) => b - a);
+  // Undated flights sink to the bottom, so the boundary has to be resolved on
+  // the rendered order instead of the incoming one.
+  const pastSectionStart = findPastSectionStart(
+    years.flatMap(([, yearFlights]) => yearFlights),
+    now,
+  );
+
+  return years.map(([year, yearFlights]) => ({
+    year,
+    groups: groupByLayover(yearFlights, pastSectionStart),
+  }));
+};

--- a/src/lib/stats/summary.ts
+++ b/src/lib/stats/summary.ts
@@ -1,8 +1,8 @@
-import { isBefore } from 'date-fns';
-
 import type { Flight } from '$lib/db/types';
 import { distanceBetween } from '$lib/utils';
-import { getFlightDateRange, parseLocalizeISO } from '$lib/utils/datetime';
+import { isCompletedFlight } from '$lib/utils/data/flight-timeline';
+
+export { isCompletedFlight };
 
 type TopKeyResult = {
   best: string | null;
@@ -71,30 +71,6 @@ const topKey = (
   }
 
   return { best, count };
-};
-
-export const isCompletedFlight = (
-  flight: Flight,
-  now: Date = new Date(),
-): boolean => {
-  if (!flight.date) return true;
-
-  const hasExactDateTime = flight.datePrecision === 'day';
-  const arrival =
-    hasExactDateTime && flight.arrival
-      ? parseLocalizeISO(flight.arrival, flight.to?.tz ?? 'UTC')
-      : null;
-  const { start, end } = getFlightDateRange(
-    flight.date,
-    flight.datePrecision,
-    flight.from?.tz ?? 'UTC',
-  );
-
-  const fallbackDate = flight.datePrecision === 'day' ? start : (end ?? start);
-  const comparisonDate = arrival ?? fallbackDate;
-  if (!comparisonDate) return true;
-
-  return isBefore(comparisonDate, now);
 };
 
 export const completedFlights = (

--- a/src/lib/stats/summary.ts
+++ b/src/lib/stats/summary.ts
@@ -2,11 +2,7 @@ import { isBefore } from 'date-fns';
 
 import type { Flight } from '$lib/db/types';
 import { distanceBetween } from '$lib/utils';
-import {
-  getFlightDateRange,
-  nowIn,
-  parseLocalizeISO,
-} from '$lib/utils/datetime';
+import { getFlightDateRange, parseLocalizeISO } from '$lib/utils/datetime';
 
 type TopKeyResult = {
   best: string | null;
@@ -77,7 +73,10 @@ const topKey = (
   return { best, count };
 };
 
-export const isCompletedFlight = (flight: Flight): boolean => {
+export const isCompletedFlight = (
+  flight: Flight,
+  now: Date = new Date(),
+): boolean => {
   if (!flight.date) return true;
 
   const hasExactDateTime = flight.datePrecision === 'day';
@@ -95,11 +94,13 @@ export const isCompletedFlight = (flight: Flight): boolean => {
   const comparisonDate = arrival ?? fallbackDate;
   if (!comparisonDate) return true;
 
-  return isBefore(comparisonDate, nowIn(flight.to?.tz ?? 'UTC'));
+  return isBefore(comparisonDate, now);
 };
 
-export const completedFlights = (flights: Flight[]): Flight[] =>
-  flights.filter(isCompletedFlight);
+export const completedFlights = (
+  flights: Flight[],
+  now: Date = new Date(),
+): Flight[] => flights.filter((flight) => isCompletedFlight(flight, now));
 
 export const computeFlightStatsSummary = (
   flights: Flight[],

--- a/src/lib/utils/data/flight-timeline.ts
+++ b/src/lib/utils/data/flight-timeline.ts
@@ -1,4 +1,5 @@
 import { TZDate } from '@date-fns/tz';
+import { isBefore } from 'date-fns';
 
 import type { Flight, FlightDatePrecision } from '$lib/db/types';
 import { getFlightDateRange, parseLocalizeISO } from '$lib/utils/datetime';
@@ -65,6 +66,21 @@ export const resolveFlightTimeline = (flight: Flight): FlightTimeline => {
     effectiveDeparture,
     effectiveArrival,
   };
+};
+
+export const isCompletedFlight = (
+  flight: Flight,
+  now: Date = new Date(),
+): boolean => {
+  const timeline = resolveFlightTimeline(flight);
+  const fallbackDate =
+    timeline.precision === 'day'
+      ? timeline.dateStart
+      : (timeline.dateEnd ?? timeline.dateStart);
+  const comparisonDate =
+    timeline.effectiveArrival ?? timeline.effectiveDeparture ?? fallbackDate;
+
+  return comparisonDate ? isBefore(comparisonDate, now) : true;
 };
 
 export const getFlightTimelineWindow = (

--- a/src/routes/api/airline/icon/+server.ts
+++ b/src/routes/api/airline/icon/+server.ts
@@ -50,7 +50,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
   // Get file extension from mime type
   const ext = ALLOWED_IMAGE_EXTENSIONS[typeIndex] || '.png';
-  const relativePath = `airlines/${airlineId}${ext}`;
+  const relativePath = `airlines/${airlineIdNum}${ext}`;
 
   // Delete old icon if it exists with a different extension
   const existingAirline = await db


### PR DESCRIPTION
### Description
Improves the flight list, grouping layovers, and separating upcomming flights
<img width="979" height="263" alt="image" src="https://github.com/user-attachments/assets/aa504061-bfa4-4fb8-9075-e55fd073cd5f" />


### Change details

- Consecutive legs of one trip (same connecting airport, 0–12h apart, both times
  known) render as a single block
- A divider marks where upcoming flights end and flown ones begin. 
- Fixes same-day ordering of upcoming flights.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Group connecting flights and separate upcoming trips from flown history
> - Groups consecutive connecting legs into unified desktop and mobile flight-list blocks.
> - Sorts flights by effective departure time and marks the transition from upcoming to completed flights.
> - Paginates complete layover groups while preserving year and past-divider metadata.
> - Centralizes flight-completion logic and normalizes airline icon filenames to validated numeric IDs.
>
> <sup>AirTrail Helper summarized a19aa4c · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
