### PR TITLE
fix: derive FR24 arrival times left empty in the export

### DIFF
--- a/src/lib/import/fr24.test.ts
+++ b/src/lib/import/fr24.test.ts
@@ -148,6 +148,50 @@ describe('processFR24File', () => {
     expect(getAirlineByIcao).toHaveBeenCalledWith('LFH');
   });
 
+  it('derives the arrival from the duration when the arrival time is the 00:00:00 placeholder', async () => {
+    const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note\n2015-03-10,SK537,Stockholm / Arlanda (ARN/ESSA),Copenhagen / Kastrup (CPH/EKCH),07:25:00,00:00:00,01:15:00,Scandinavian Airlines (SK/SAS),Boeing 737-800 (B738),,,1,1,1,`;
+
+    const result = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+    });
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0]?.departure).toBe('2015-03-10T07:25:00.000+00:00');
+    expect(result.flights[0]?.arrival).toBe('2015-03-10T08:40:00.000+00:00');
+    expect(result.flights[0]?.duration).toBe(4500);
+  });
+
+  it('keeps an explicit overnight arrival on the next day', async () => {
+    const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note\n2015-03-10,SK537,Stockholm / Arlanda (ARN/ESSA),Copenhagen / Kastrup (CPH/EKCH),22:00:00,01:10:00,03:10:00,Scandinavian Airlines (SK/SAS),Boeing 737-800 (B738),,,1,1,1,`;
+
+    const result = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+    });
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0]?.departure).toBe('2015-03-10T22:00:00.000+00:00');
+    expect(result.flights[0]?.arrival).toBe('2015-03-11T01:10:00.000+00:00');
+  });
+
+  it('leaves both times empty when neither is known', async () => {
+    const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note\n2015-03-10,SK537,Stockholm / Arlanda (ARN/ESSA),Copenhagen / Kastrup (CPH/EKCH),00:00:00,00:00:00,01:15:00,Scandinavian Airlines (SK/SAS),Boeing 737-800 (B738),,,1,1,1,`;
+
+    const result = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+    });
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0]?.departure).toBeNull();
+    expect(result.flights[0]?.arrival).toBeNull();
+    expect(result.flights[0]?.duration).toBe(4500);
+  });
+
   it('reports and applies mappings for defunct airline codes', async () => {
     const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note\n1999-07-15,NW687,Minneapolis (MSP/KMSP),Seattle (SEA/KSEA),10:00:00,11:30:00,03:30:00,Northwest Airlines (NW/NWA),Boeing 757-200 (B752),N687NW,12A,1,1,1,Issue 687 unknown airline test`;
     getAirlineByIcao.mockResolvedValueOnce(null);

--- a/src/lib/import/fr24.ts
+++ b/src/lib/import/fr24.ts
@@ -1,5 +1,5 @@
 import { tz } from '@date-fns/tz/tz';
-import { addDays, isBefore } from 'date-fns';
+import { addDays, addSeconds, isBefore } from 'date-fns';
 import { z } from 'zod';
 
 import { page } from '$app/state';
@@ -178,6 +178,13 @@ export const processFR24File = async (
       row.arr_time = null;
     }
 
+    const duration = row.duration
+      .split(':')
+      .reduce(
+        (acc, val, idx) => acc + parseInt(val) * Math.pow(60, 2 - idx),
+        0,
+      );
+
     const departure = row.dep_time
       ? toUtc(
           parseLocalISO(
@@ -186,25 +193,25 @@ export const processFR24File = async (
           ),
         )
       : null;
-    let arrival = row.arr_time
-      ? toUtc(
-          parseLocalISO(
-            `${normalizedDate.date}T${row.arr_time}`,
-            to?.tz || 'UTC',
-          ),
-        )
-      : null;
+    // FR24 exports an arrival time left empty as 00:00:00, so a lone
+    // midnight arrival is derived from the duration instead of being
+    // taken literally
+    let arrival =
+      row.arr_time && row.arr_time !== '00:00:00'
+        ? toUtc(
+            parseLocalISO(
+              `${normalizedDate.date}T${row.arr_time}`,
+              to?.tz || 'UTC',
+            ),
+          )
+        : null;
+    if (!arrival && departure && duration > 0) {
+      arrival = addSeconds(departure, duration, { in: tz('UTC') });
+    }
     while (departure && arrival && isBefore(arrival, departure)) {
       // arrival is before departure in UTC, so it must be on a later day
       arrival = addDays(arrival, 1, { in: tz('UTC') });
     }
-
-    const duration = row.duration
-      .split(':')
-      .reduce(
-        (acc, val, idx) => acc + parseInt(val) * Math.pow(60, 2 - idx),
-        0,
-      );
 
     const seatType = FR24_SEAT_TYPE_MAP?.[row.seat_type ?? 'noop'] ?? null;
     const seatClass =


### PR DESCRIPTION
Fixes #697. MyFlightradar24 writes 00:00:00 in the Arr time column when the arrival time was left empty, and the importer took that midnight literally, so the day roll-forward gave every such flight an arrival at 00:00 the day after departure. The export always carries a duration, so a lone midnight arrival is now derived as departure plus duration instead, an explicit overnight arrival still rolls over to the next day, and a placeholder arrival without a known departure stays empty.

Verified with the 127 flight export from the issue, imported through the UI on a dev instance: all 121 flights with a known departure time came out with arrival matching departure plus duration to the second, the 6 without times stayed empty, and the airport timezone conversion held up. Unit tests cover the derived arrival, an explicit overnight arrival and the fully unknown case.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Derive missing FR24 arrivals from departure time and duration
> The importer now treats a lone midnight arrival as missing, derives it from departure plus duration, and preserves explicit overnight rollover behavior, with focused regression coverage.
>
> <sup>AirTrail Helper summarized fc98d70 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
