### PR TITLE
fix: count dropped FR24 rows and surface unknown aircraft

### DIFF
--- a/src/lib/import/fr24.test.ts
+++ b/src/lib/import/fr24.test.ts
@@ -15,7 +15,12 @@ const { getAirportByIcao, getAirlineByIcao, getAircraftByIcao } = vi.hoisted(
         icao,
       }),
     ),
-    getAircraftByIcao: vi.fn(async (icao: string) => ({ id: icao, icao })),
+    getAircraftByIcao: vi.fn(
+      async (icao: string): Promise<{ id: string; icao: string } | null> => ({
+        id: icao,
+        icao,
+      }),
+    ),
   }),
 );
 
@@ -178,5 +183,45 @@ describe('processFR24File', () => {
 
     expect(resolved.flights[0]?.airline).toEqual(northwest);
     expect(resolved.unknowns.airlines).toEqual({});
+  });
+
+  it('counts rows with unparseable airport cells as skipped', async () => {
+    const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note
+2006-02-01,,Dunedin / Momona (DUD/NZDN),Christchurch / Christchurch (CHC/NZCH),00:00:00,00:00:00,00:41:00,Air New Zealand (NZ/ANZ),ATR 72-200 (AT72),,,0,1,1,
+2006-02-02,,Some Heliport,Christchurch / Christchurch (CHC/NZCH),00:00:00,00:00:00,00:41:00,Air New Zealand (NZ/ANZ),ATR 72-200 (AT72),,,0,1,1,`;
+
+    const result = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+    });
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.skippedRows).toBe(1);
+  });
+
+  it('reports and applies mappings for unknown aircraft codes', async () => {
+    const content = `Date,Flight number,From,To,Dep time,Arr time,Duration,Airline,Aircraft,Registration,Seat number,Seat type,Flight class,Flight reason,Note\n2006-02-01,,Dunedin / Momona (DUD/NZDN),Christchurch / Christchurch (CHC/NZCH),00:00:00,00:00:00,00:41:00,Air New Zealand (NZ/ANZ),ATR 72-200 (AT72),,,0,1,1,`;
+    getAircraftByIcao.mockResolvedValueOnce(null);
+
+    const unresolved = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+    });
+
+    expect(unresolved.flights[0]?.aircraft).toBeNull();
+    expect(unresolved.unknowns.aircraft).toEqual({ AT72: [0] });
+
+    const atr = { id: 72, name: 'ATR 72-200', icao: 'AT72', sourceId: null };
+    const resolved = await processFR24File(content, {
+      filterOwner: false,
+      airlineFromFlightNumber: true,
+      importMode: 'personal',
+      aircraftMapping: { AT72: atr },
+    });
+
+    expect(resolved.flights[0]?.aircraft).toEqual(atr);
+    expect(resolved.unknowns.aircraft).toEqual({});
   });
 });

--- a/src/lib/import/fr24.ts
+++ b/src/lib/import/fr24.ts
@@ -157,11 +157,14 @@ export const processFR24File = async (
   const flights: CreateFlight[] = [];
   const unknownAirports: Record<string, number[]> = {};
   const unknownAirlines: Record<string, number[]> = {};
+  const unknownAircraft: Record<string, number[]> = {};
+  let droppedRows = 0;
   for (const row of data) {
     const normalizedDate = normalizeFR24Date(row.date);
     const fromCode = extractAirportICAO(row.from);
     const toCode = extractAirportICAO(row.to);
     if (!fromCode || !toCode) {
+      droppedRows++;
       continue;
     }
 
@@ -221,10 +224,12 @@ export const processFR24File = async (
       (rawAirline ? (await getAirlineByIcao(rawAirline)) || null : null);
 
     const rawAircraft = row.aircraft ? extractAircraftICAO(row.aircraft) : null;
-    const aircraft = rawAircraft ? await getAircraftByIcao(rawAircraft) : null;
-    if (!aircraft && rawAircraft) {
-      console.warn(`Unknown aircraft ICAO code: ${rawAircraft}`);
-    }
+    const mappedAircraft = rawAircraft
+      ? options.aircraftMapping?.[rawAircraft]
+      : undefined;
+    const aircraft =
+      mappedAircraft ||
+      (rawAircraft ? (await getAircraftByIcao(rawAircraft)) || null : null);
 
     const flightIndex = flights.length;
 
@@ -239,6 +244,10 @@ export const processFR24File = async (
     if (!airline && rawAirline) {
       if (!unknownAirlines[rawAirline]) unknownAirlines[rawAirline] = [];
       unknownAirlines[rawAirline].push(flightIndex);
+    }
+    if (!aircraft && rawAircraft) {
+      if (!unknownAircraft[rawAircraft]) unknownAircraft[rawAircraft] = [];
+      unknownAircraft[rawAircraft].push(flightIndex);
     }
 
     flights.push({
@@ -282,9 +291,9 @@ export const processFR24File = async (
     unknowns: {
       airports: unknownAirports,
       airlines: unknownAirlines,
-      aircraft: {},
+      aircraft: unknownAircraft,
     },
     exportedUsers: [],
-    skippedRows: skipped.length,
+    skippedRows: skipped.length + droppedRows,
   };
 };


### PR DESCRIPTION
Fixes #700 and fixes #701. Rows whose airport cells do not match the (IATA/ICAO) shape now count toward the skipped rows the dialog reports instead of vanishing silently, unknown aircraft codes end up in unknowns.aircraft so the mapping step offers them just like unknown airports and airlines, and the importer honors an aircraft mapping on the re-run the same way the Flighty importer does. Unit tests cover the skipped count and the mapping round trip.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Count dropped FR24 rows and map unknown aircraft
> - Counts FR24 rows with unparseable airport cells in the reported skipped-row total.
> - Surfaces unresolved aircraft ICAO codes and applies user-selected aircraft mappings on re-import.
> - Adds coverage for skipped-row counting and aircraft mapping round trips.
>
> <sup>AirTrail Helper summarized 6472972 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
