### PR TITLE
fix: treat an empty METAR response body as no data

### DIFF
--- a/src/lib/server/utils/metar.test.ts
+++ b/src/lib/server/utils/metar.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getParsedMetar } from './metar';
+
+describe('getParsedMetar', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('treats an empty response body as no metar', async () => {
+    const errorSpy = vi.spyOn(console, 'error');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 200 })),
+    );
+
+    const result = await getParsedMetar('EDDT');
+
+    expect(result).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('parses a normal metar response', async () => {
+    const payload = [
+      {
+        rawOb: 'EKCH 091350Z 24010KT 9999 FEW030 17/09 Q1013',
+        obsTime: 1754747400,
+        icaoId: 'EKCH',
+      },
+    ];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json(payload)),
+    );
+
+    const result = await getParsedMetar('EKCH');
+
+    expect(result?.raw).toBe('EKCH 091350Z 24010KT 9999 FEW030 17/09 Q1013');
+  });
+});

--- a/src/lib/server/utils/metar.ts
+++ b/src/lib/server/utils/metar.ts
@@ -88,7 +88,10 @@ async function fetchMetar(
     if (!resp.ok) {
       throw new Error(`METAR fetch ${resp.status} ${resp.statusText}`);
     }
-    const data = (await resp.json()) as AwcMetar[];
+    // decommissioned stations come back as an empty body rather than []
+    const body = await resp.text();
+    if (!body.trim()) return null;
+    const data = JSON.parse(body) as AwcMetar[];
     if (!Array.isArray(data) || data.length === 0) return null;
     // API returns newest first, but be defensive.
     const latest = [...data]


### PR DESCRIPTION
Fixes #702. aviationweather.gov returns an empty body rather than an empty array for stations that no longer report, so every visit to a closed airport like EDDT logged a JSON parse stack trace from the weather card. An empty body now simply means there is no METAR, with unit tests for the empty and the normal case.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Treat empty METAR responses as no weather data
> The METAR fetcher now reads the response body as text and returns no data when it is empty or whitespace-only, while preserving normal JSON parsing. Unit tests cover both empty and populated responses.
>
> <sup>AirTrail Helper summarized 1ebe291 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
