### PR TITLE
fix: align arc endpoints at high zoom

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "openid-client": "^6.8.2",
         "postcss": "^8.5.6",
         "postcss-load-config": "^6.0.1",
-        "prettier": "^3.7.4",
+        "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^3.4.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "prisma": "^6.19.1",
@@ -2054,7 +2054,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "openid-client": "^6.8.2",
     "postcss": "^8.5.6",
     "postcss-load-config": "^6.0.1",
-    "prettier": "^3.7.4",
+    "prettier": "^3.9.6",
     "prettier-plugin-svelte": "^3.4.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "prisma": "^6.19.1",

--- a/src/lib/components/display/TimeDisplayHost.svelte
+++ b/src/lib/components/display/TimeDisplayHost.svelte
@@ -82,8 +82,7 @@
     getContentZIndex: () =>
       (
         timeDisplayTether.state.registry.activePayload as
-          | TimeDisplayPayload
-          | undefined
+          TimeDisplayPayload | undefined
       )?.zIndex,
   };
   setContext(ModalContextKey, hostModalContext);

--- a/src/lib/components/flight-filters/MobileDateFilterScreen.svelte
+++ b/src/lib/components/flight-filters/MobileDateFilterScreen.svelte
@@ -87,8 +87,7 @@
 
   function handleDateRangeChange(
     value:
-      | { start: DateValue | undefined; end: DateValue | undefined }
-      | undefined,
+      { start: DateValue | undefined; end: DateValue | undefined } | undefined,
   ) {
     const start = value?.start as CalendarDate | undefined;
     const end = value?.end as CalendarDate | undefined;

--- a/src/lib/components/form-fields/DateRangeField.svelte
+++ b/src/lib/components/form-fields/DateRangeField.svelte
@@ -64,8 +64,7 @@
   // Handle date range changes from the DateRangePicker
   function handleValueChange(
     value:
-      | { start: DateValue | undefined; end: DateValue | undefined }
-      | undefined,
+      { start: DateValue | undefined; end: DateValue | undefined } | undefined,
   ) {
     if (!value) {
       dateRange = { start: undefined, end: undefined };

--- a/src/lib/components/form-fields/DateTimeField.svelte
+++ b/src/lib/components/form-fields/DateTimeField.svelte
@@ -55,8 +55,7 @@
   const timeKey = `${field}Time` as 'departureTime' | 'arrivalTime';
   const counterpartField = field === 'departure' ? 'arrival' : 'departure';
   const counterpartTimeKey = `${counterpartField}Time` as
-    | 'departureTime'
-    | 'arrivalTime';
+    'departureTime' | 'arrivalTime';
 
   const airportTz = $derived(
     (field === 'departure' ? $formData.from?.tz : $formData.to?.tz) ??

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -52,6 +52,7 @@
     type DeckPointerEvent,
   } from '$lib/map/map-popup-position';
   import { mapPreferences } from '$lib/map/map-preferences.svelte';
+  import { PreciseArcEndpointsExtension } from '$lib/map/precise-arc-endpoints';
   import {
     closeMapDetails,
     mapDetailsState,
@@ -98,6 +99,7 @@
     depthWriteEnabled: false,
   } as const;
   const globeOcclusion = new GlobeOcclusionExtension();
+  const preciseArcEndpoints = new PreciseArcEndpointsExtension();
   const isDarkMode = $derived(mode.current === 'dark');
 
   const interpolateColor = (
@@ -193,8 +195,7 @@
 
   const getProjectionType = () => {
     const projection = map?.getProjection?.() as
-      | { type?: string; name?: string }
-      | undefined;
+      { type?: string; name?: string } | undefined;
     return projection?.type ?? projection?.name ?? 'unknown';
   };
 
@@ -558,7 +559,7 @@
   const arcOptions = $derived.by(() => ({
     id: 'arc-layer',
     parameters: isGlobe ? GLOBE_ARC_PARAMETERS : MERCATOR_ROUTE_PARAMETERS,
-    extensions: [globeOcclusion],
+    extensions: [preciseArcEndpoints, globeOcclusion],
     data: visibleFlightArcs,
     getSourcePosition: (data: FlightArc): Position => [
       data.from.lon,
@@ -607,7 +608,7 @@
   const ghostArcOptions = $derived({
     id: 'ghost-arc',
     parameters: isGlobe ? GLOBE_ARC_PARAMETERS : MERCATOR_ROUTE_PARAMETERS,
-    extensions: [globeOcclusion],
+    extensions: [preciseArcEndpoints, globeOcclusion],
     data: visibleFlightArcs,
     getSourcePosition: (data: FlightArc): Position => [
       data.from.lon,

--- a/src/lib/components/modals/flight-form/PassengerPicker.svelte
+++ b/src/lib/components/modals/flight-form/PassengerPicker.svelte
@@ -53,8 +53,7 @@
     | { type: 'create'; name: string };
 
   const buildSelectedOption = ():
-    | { label: string; value: SelectionValue }
-    | undefined => {
+    { label: string; value: SelectionValue } | undefined => {
     if (userId) {
       const users = getUsers();
       const user = users.find((u) => u.id === userId);

--- a/src/lib/components/modals/statistics/StatisticsModal.svelte
+++ b/src/lib/components/modals/statistics/StatisticsModal.svelte
@@ -145,8 +145,7 @@
 
   const restoreDrilldown = (state: unknown) => {
     const drilldown = state as
-      | { activeChart?: unknown; activeContinent?: unknown }
-      | undefined;
+      { activeChart?: unknown; activeContinent?: unknown } | undefined;
     const chart = drilldown?.activeChart;
     activeChart =
       typeof chart === 'string' &&

--- a/src/lib/components/ui/modal/modal-history.ts
+++ b/src/lib/components/ui/modal/modal-history.ts
@@ -37,9 +37,7 @@ type QueuedModalHistoryEntry = ModalHistoryEntryBase & {
 };
 
 type ModalHistoryEntry =
-  | ActiveModalHistoryEntry
-  | ClosingModalHistoryEntry
-  | QueuedModalHistoryEntry;
+  ActiveModalHistoryEntry | ClosingModalHistoryEntry | QueuedModalHistoryEntry;
 
 type ModalHistoryOptions = {
   closeOnEscape?: boolean;
@@ -336,8 +334,7 @@ export const createModalHistoryController = (adapter: HistoryAdapter) => {
 };
 
 let browserController:
-  | ReturnType<typeof createModalHistoryController>
-  | undefined;
+  ReturnType<typeof createModalHistoryController> | undefined;
 
 const getBrowserController = () => {
   if (typeof window === 'undefined') return undefined;

--- a/src/lib/map/openaip.ts
+++ b/src/lib/map/openaip.ts
@@ -74,9 +74,7 @@ type OpenAipSymbolLayer = OpenAipLayerBase & {
 };
 
 export type OpenAipOverlayLayer =
-  | OpenAipFillLayer
-  | OpenAipLineLayer
-  | OpenAipSymbolLayer;
+  OpenAipFillLayer | OpenAipLineLayer | OpenAipSymbolLayer;
 
 export type OpenAipTheme = 'light' | 'dark';
 

--- a/src/lib/map/precise-arc-endpoints.ts
+++ b/src/lib/map/precise-arc-endpoints.ts
@@ -1,0 +1,41 @@
+import { LayerExtension } from '@deck.gl/core';
+
+/**
+ * Keeps ArcLayer's first and last great-circle vertices on their exact input
+ * coordinates.
+ *
+ * ArcLayer normally reconstructs every great-circle vertex with fp32
+ * trigonometry. At extreme zoom levels, the reconstructed endpoint can land
+ * several pixels away from another layer that projects the original fp64
+ * coordinate directly. This correction shifts the completed endpoint vertices
+ * onto the exact projected coordinates, so the route shape and styling stay
+ * unchanged.
+ *
+ * This shader injection relies on ArcLayer's vertex shader variables and must
+ * only be attached to ArcLayer instances.
+ */
+export class PreciseArcEndpointsExtension extends LayerExtension {
+  static extensionName = 'PreciseArcEndpointsExtension';
+
+  getShaders() {
+    return {
+      inject: {
+        'vs:#main-end': /* glsl */ `
+          if (segmentIndex == 0.0) {
+            gl_Position += project_position_to_clipspace(
+              instanceSourcePositions,
+              instanceSourcePositions64Low,
+              vec3(0.0)
+            ) - curr;
+          } else if (segmentIndex == arc.numSegments - 1.0) {
+            gl_Position += project_position_to_clipspace(
+              instanceTargetPositions,
+              instanceTargetPositions64Low,
+              vec3(0.0)
+            ) - curr;
+          }
+        `,
+      },
+    };
+  }
+}


### PR DESCRIPTION
Closes #690

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Align flight arc endpoints precisely at high zoom
> - Adds a Deck.gl extension that snaps great-circle endpoints to their exact projected airport coordinates.
> - Applies precise endpoint alignment to both visible and ghost flight arcs.
> - Updates Prettier and reformats affected TypeScript and Svelte declarations.
>
> <sup>AirTrail Helper summarized cd7bd8f · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
