### PR TITLE
fix: preserve flight list scroll after edit

### DIFF
--- a/src/lib/components/modals/list-flights/EditFlightAction.svelte
+++ b/src/lib/components/modals/list-flights/EditFlightAction.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { SquarePen } from '@o7/icon/lucide';
+
+  import EditFlightModal from '../edit-flight/EditFlightModal.svelte';
+
+  import { Button } from '$lib/components/ui/button';
+  import type { FlightData } from '$lib/utils';
+
+  let {
+    flight,
+    triggerDisabled = false,
+  }: {
+    flight: FlightData;
+    triggerDisabled?: boolean;
+  } = $props();
+
+  let open = $state(false);
+</script>
+
+<Button
+  variant="outline"
+  size="icon"
+  onclick={() => (open = true)}
+  disabled={triggerDisabled}
+  aria-label="Edit flight"
+  title="Edit flight"
+  data-testid="edit-flight-button"
+>
+  <SquarePen size={16} />
+</Button>
+
+{#key flight}
+  <EditFlightModal {flight} bind:open showTrigger={false} />
+{/key}

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -12,6 +12,7 @@
   import { tick } from 'svelte';
 
   import DeleteFlightModal from './DeleteFlightModal.svelte';
+  import EditFlightAction from './EditFlightAction.svelte';
   import EmptyFlightsState from './EmptyFlightsState.svelte';
   import {
     buildFlightListYears,
@@ -719,9 +720,7 @@
         <MapPin size="20" />
       </Button>
     {/if}
-    {#key flight}
-      <EditFlightModal {flight} triggerDisabled={selecting} />
-    {/key}
+    <EditFlightAction {flight} triggerDisabled={selecting} />
     <Button
       variant="outline"
       size="icon"

--- a/tests/e2e/helpers/flight-form.ts
+++ b/tests/e2e/helpers/flight-form.ts
@@ -66,11 +66,7 @@ export const submitFlightForm = async (page: Page, modal: Locator) => {
 export const openEditFlightModal = async (page: Page): Promise<Locator> => {
   await page.getByTestId('list-flights-button').click();
   await expect(page.getByText(/all flights/i)).toBeVisible({ timeout: 5000 });
-  // `ListFlightsModal` wraps the edit trigger in `{#key flight}` and remaps
-  // flight objects every derivation, so the button detaches+reattaches on
-  // any upstream tick — Playwright's actionability wait never sees stability.
-  // Dispatch the click event directly to bypass pointer simulation.
-  await page.getByTestId('edit-flight-button').first().dispatchEvent('click');
+  await page.getByTestId('edit-flight-button').first().click();
   const modal = page.getByRole('dialog').filter({ hasText: /edit flight/i });
   await expect(modal).toBeVisible();
   return modal;

--- a/tests/e2e/tests/flights/edit-flight.spec.ts
+++ b/tests/e2e/tests/flights/edit-flight.spec.ts
@@ -1,0 +1,111 @@
+import { airportsFactory } from '@test/factories/airports';
+import { flightsFactory } from '@test/factories/flights';
+import { usersFactory } from '@test/factories/users';
+import { login } from '@test/helpers/auth';
+import { expect, test } from '@test/index';
+
+test.describe('Edit Flight', () => {
+  test('keeps the list position and edit focus after saving', async ({
+    page,
+  }) => {
+    const { user } = await usersFactory.create();
+    await login(page, user);
+
+    const { airport: fromAirport } = await airportsFactory.getOrCreate({
+      icao: 'EKCH',
+      name: 'Copenhagen Airport',
+      municipality: 'Copenhagen',
+      lat: 55.618,
+      lon: 12.656,
+      country: 'DK',
+      continent: 'EU',
+      tz: 'Europe/Copenhagen',
+      type: 'large_airport',
+      iata: 'CPH',
+    });
+    const { airport: toAirport } = await airportsFactory.getOrCreate({
+      icao: 'ESSA',
+      name: 'Stockholm Arlanda Airport',
+      municipality: 'Stockholm',
+      lat: 59.652,
+      lon: 17.919,
+      country: 'SE',
+      continent: 'EU',
+      tz: 'Europe/Stockholm',
+      type: 'large_airport',
+      iata: 'ARN',
+    });
+
+    const flights = [];
+    for (let day = 1; day <= 20; day += 1) {
+      flights.push(
+        await flightsFactory.create({
+          userId: user.id,
+          date: `2025-01-${String(day).padStart(2, '0')}`,
+          fromId: fromAirport.id,
+          toId: toAirport.id,
+          departure: `2025-01-${String(day).padStart(2, '0')}T10:00:00.000Z`,
+          arrival: `2025-01-${String(day).padStart(2, '0')}T11:15:00.000Z`,
+          duration: 4500,
+          flightNumber: `AT${String(day).padStart(3, '0')}`,
+        }),
+      );
+    }
+    await page.goto('/');
+    await page.getByTestId('list-flights-button').click();
+
+    const listModal = page
+      .getByRole('dialog')
+      .filter({ hasText: 'All Flights' });
+    await expect(listModal).toBeVisible();
+    await expect
+      .poll(() =>
+        listModal.evaluate(
+          (element) => element.scrollHeight > element.clientHeight,
+        ),
+      )
+      .toBe(true);
+
+    const targetRow = listModal.locator(
+      `#flight-list-row-${flights[0]!.flight.id}`,
+    );
+    await targetRow.scrollIntoViewIfNeeded();
+    const editButton = targetRow.getByRole('button', {
+      name: 'Edit flight',
+    });
+    await expect(editButton).toBeVisible();
+    await expect
+      .poll(() => listModal.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+
+    await editButton.click();
+    const editModal = page
+      .getByRole('dialog')
+      .filter({ hasText: 'Edit flight' });
+    await expect(editModal).toBeVisible();
+    const scrollBeforeSave = await listModal.evaluate(
+      (element) => element.scrollTop,
+    );
+
+    await editModal
+      .getByRole('textbox', { name: 'Flight Number' })
+      .fill('AT693');
+    await editModal.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Flight updated successfully')).toBeVisible();
+    await expect(editModal).not.toBeVisible();
+    await expect(targetRow.getByText('AT693')).toBeVisible();
+    await expect(editButton).toBeFocused();
+
+    const scrollAfterSave = await listModal.evaluate(
+      (element) => element.scrollTop,
+    );
+    expect(scrollAfterSave).toBe(scrollBeforeSave);
+
+    await editButton.click();
+    await expect(editModal).toBeVisible();
+    await expect(
+      editModal.getByRole('textbox', { name: 'Flight Number' }),
+    ).toHaveValue('AT693');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,7 +152,7 @@ const pwaOptions = {
 
 export default defineConfig({
   resolve: {
-    dedupe: ['maplibre-gl'],
+    dedupe: ['@internationalized/date', 'maplibre-gl'],
   },
   plugins: [o7Icon(), tailwindcss(), sveltekit(), VitePWA(pwaOptions)],
 });


### PR DESCRIPTION
Closes #693

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Preserve flight list position and focus after editing a flight
> - Moves each desktop edit trigger outside the keyed modal lifecycle so list rows and trigger focus remain stable when flight data refreshes.
> - Adds end-to-end coverage for retaining the list scroll position, restoring edit-button focus, and reopening with updated flight data.
> - Deduplicates the internationalized date dependency in Vite to keep date values consistent across form components.
>
> <sup>AirTrail Helper summarized dd6de33 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
