### PR TITLE
fix: close date picker after selection

### DIFF
--- a/src/lib/components/form-fields/DateField.svelte
+++ b/src/lib/components/form-fields/DateField.svelte
@@ -37,6 +37,7 @@
   let dateValue: DateValue | undefined = $state(
     $fieldValue ? parseDate($fieldValue) : undefined,
   );
+  let calendarOpen = $state(false);
 
   $effect(() => {
     if ($fieldValue) {
@@ -94,7 +95,7 @@
                   {/if}
                 </div>
               {/each}
-              <Popover.Root>
+              <Popover.Root bind:open={calendarOpen}>
                 <Popover.Trigger
                   {...props}
                   class="ml-auto inline-flex items-center justify-center text-muted-foreground transition-all hover:text-foreground active:text-foreground"
@@ -105,7 +106,10 @@
                   <Calendar
                     type="single"
                     value={dateValue}
-                    onValueChange={setDateValue}
+                    onValueChange={(value) => {
+                      setDateValue(value);
+                      if (value) calendarOpen = false;
+                    }}
                   />
                 </Popover.Content>
               </Popover.Root>

--- a/src/lib/components/form-fields/DateTimeField.svelte
+++ b/src/lib/components/form-fields/DateTimeField.svelte
@@ -148,6 +148,7 @@
   let dateValue: DateValue | undefined = $state(
     $formData[field] ? dateValueFromISO($formData[field]) : undefined,
   );
+  let calendarOpen = $state(false);
 
   let partialYear = $state('');
   let partialMonth = $state('');
@@ -370,7 +371,7 @@
                       {/if}
                     </div>
                   {/each}
-                  <Popover.Root>
+                  <Popover.Root bind:open={calendarOpen}>
                     <Popover.Trigger
                       {...props}
                       class="ml-auto inline-flex items-center justify-center text-muted-foreground transition-all hover:text-foreground active:text-foreground"
@@ -394,6 +395,7 @@
                             dateValue?.toDate('UTC').toISOString() ?? null,
                           );
                           validate(field);
+                          calendarOpen = false;
                         }}
                       />
                     </Popover.Content>

--- a/src/lib/components/modals/flight-form/TimetableDateTimeCell.svelte
+++ b/src/lib/components/modals/flight-form/TimetableDateTimeCell.svelte
@@ -188,6 +188,7 @@
   });
 
   let open = $state(false);
+  let calendarOpen = $state(false);
   let nativeInput = $state<HTMLInputElement | null>(null);
 
   let dateValue: DateValue | undefined = $state(
@@ -445,7 +446,7 @@
                               {/if}
                             </div>
                           {/each}
-                          <Popover.Root>
+                          <Popover.Root bind:open={calendarOpen}>
                             <Popover.Trigger
                               {...props}
                               class="ml-auto inline-flex items-center justify-center text-muted-foreground transition-all hover:text-foreground active:text-foreground"
@@ -470,6 +471,7 @@
                                       null,
                                   );
                                   validateField(dateField);
+                                  calendarOpen = false;
                                 }}
                               />
                             </Popover.Content>


### PR DESCRIPTION
<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
### Close date pickers after selecting a date
- Date-only fields now dismiss their calendar popover after a valid date selection.
- Date-time fields and timetable cells now close their calendar popovers after applying the selected date.

<sup>AirTrail Helper summarized 0e61ec3 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
