### PR TITLE
feat: add indicator icons for tracks, time, notes

### DIFF
--- a/src/lib/components/modals/list-flights/FlightCard.svelte
+++ b/src/lib/components/modals/list-flights/FlightCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TZDate } from '@date-fns/tz';
+  import type { Snippet } from 'svelte';
 
   import { page } from '$app/state';
   import { AirlineIcon, RouteArrow } from '$lib/components/display';
@@ -20,10 +21,12 @@
     flight,
     passengerLabels = [],
     showMeta = true,
+    indicators,
   }: {
     flight: Flight;
     passengerLabels?: string[];
     showMeta?: boolean;
+    indicators?: Snippet;
   } = $props();
 
   const prefs = $derived(getPreferences(page.data.user));
@@ -87,6 +90,7 @@
             {getFlightNumber(flight)}
           </span>
         {/if}
+        {@render indicators?.()}
       </div>
     {/if}
   </div>

--- a/src/lib/components/modals/list-flights/FlightIndicators.svelte
+++ b/src/lib/components/modals/list-flights/FlightIndicators.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { Clock, Route, StickyNote } from '@o7/icon/lucide';
+
+  import {
+    buildFlightIndicators,
+    type FlightIndicatorKey,
+  } from './flight-indicators';
+
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import { cn, type FlightData } from '$lib/utils';
+
+  let {
+    flight,
+    hasTrack = false,
+    size = 16,
+    tooltips = true,
+    class: className,
+  }: {
+    flight: FlightData;
+    hasTrack?: boolean;
+    size?: number;
+    tooltips?: boolean;
+    class?: string;
+  } = $props();
+
+  const icons: Record<FlightIndicatorKey, typeof Route> = {
+    track: Route,
+    actualTimes: Clock,
+    note: StickyNote,
+  };
+
+  const indicators = $derived(buildFlightIndicators(flight, { hasTrack }));
+</script>
+
+{#if indicators.length}
+  <div
+    class={cn('flex items-center gap-1.5 text-muted-foreground', className)}
+    data-testid="flight-indicators"
+  >
+    {#each indicators as indicator (indicator.key)}
+      {@const Icon = icons[indicator.key]}
+      {#if tooltips}
+        <Tooltip.TextTooltip content={indicator.label}>
+          <Icon {size} data-indicator={indicator.key} />
+        </Tooltip.TextTooltip>
+      {:else}
+        <Icon
+          {size}
+          role="img"
+          aria-label={indicator.label}
+          data-indicator={indicator.key}
+        />
+      {/if}
+    {/each}
+  </div>
+{/if}

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -14,6 +14,7 @@
   import DeleteFlightModal from './DeleteFlightModal.svelte';
   import EditFlightAction from './EditFlightAction.svelte';
   import EmptyFlightsState from './EmptyFlightsState.svelte';
+  import FlightIndicators from './FlightIndicators.svelte';
   import {
     buildFlightListYears,
     paginateFlightListYears,
@@ -73,6 +74,7 @@
     readonly = false,
     seatUserId,
     showPassengerDetails = false,
+    trackedFlightIds,
     onNavigate,
   }: {
     open?: boolean;
@@ -85,6 +87,7 @@
     readonly?: boolean;
     seatUserId?: string;
     showPassengerDetails?: boolean;
+    trackedFlightIds?: Set<number>;
     onNavigate?: NavigateFlights;
   } = $props();
 
@@ -459,6 +462,7 @@
         onEdit={readonly ? undefined : handleMobileEdit}
         onDelete={readonly ? undefined : handleDelete}
         onShowOnMap={readonly || !onNavigate ? undefined : showFlightOnMap}
+        {trackedFlightIds}
         {readonly}
       />
       <div class="h-[130px] sm:h-[90px]"></div>
@@ -589,12 +593,18 @@
                           {@render airport(flight.to)}
                         </div>
                       </div>
-                      {#if !readonly}
-                        <div aria-hidden="true"></div>
-                        <div class="hidden md:flex">
+                      <div aria-hidden="true"></div>
+                      <div
+                        class="hidden items-center justify-end gap-3 md:flex"
+                      >
+                        <FlightIndicators
+                          {flight}
+                          hasTrack={trackedFlightIds?.has(flight.id) ?? false}
+                        />
+                        {#if !readonly}
                           {@render actions(flight)}
-                        </div>
-                      {/if}
+                        {/if}
+                      </div>
                     </Card>
                   </div>
                 {/each}

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -4,6 +4,7 @@
 
   import type { FlightListYear } from './flight-list-groups';
   import FlightCard from './FlightCard.svelte';
+  import FlightIndicators from './FlightIndicators.svelte';
   import PastFlightsDivider from './PastFlightsDivider.svelte';
   import SwipeableFlightRow from './SwipeableFlightRow.svelte';
 
@@ -22,6 +23,7 @@
     onEdit,
     onDelete,
     onShowOnMap,
+    trackedFlightIds,
     readonly = false,
   }: {
     flightsByYear: FlightListYear<Flight>[];
@@ -30,6 +32,7 @@
     onEdit?: (flight: FlightData) => void;
     onDelete?: (flight: FlightData) => void;
     onShowOnMap?: (flight: FlightData) => void;
+    trackedFlightIds?: Set<number>;
     readonly?: boolean;
   } = $props();
 
@@ -104,7 +107,16 @@
                     <FlightCard
                       {flight}
                       passengerLabels={flight.passengerLabels}
-                    />
+                    >
+                      {#snippet indicators()}
+                        <FlightIndicators
+                          {flight}
+                          hasTrack={trackedFlightIds?.has(flight.id) ?? false}
+                          size={15}
+                          tooltips={false}
+                        />
+                      {/snippet}
+                    </FlightCard>
                   </button>
                 {/snippet}
               </SwipeableFlightRow>

--- a/src/lib/components/modals/list-flights/flight-indicators.test.ts
+++ b/src/lib/components/modals/list-flights/flight-indicators.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFlightIndicators } from './flight-indicators';
+
+import type { Airport, Flight } from '$lib/db/types';
+import { prepareFlightData } from '$lib/utils';
+
+const airport = (id: number): Airport =>
+  ({ id, tz: 'UTC', lon: 0, lat: 0 }) as Airport;
+
+const CDG = airport(1);
+const JFK = airport(2);
+
+const flight = (overrides: Partial<Flight> = {}) =>
+  prepareFlightData([
+    {
+      id: 1,
+      from: CDG,
+      to: JFK,
+      date: '2026-03-12',
+      datePrecision: 'day',
+      departure: null,
+      arrival: null,
+      duration: null,
+      departureScheduled: null,
+      arrivalScheduled: null,
+      takeoffScheduled: null,
+      takeoffActual: null,
+      landingScheduled: null,
+      landingActual: null,
+      note: null,
+      ...overrides,
+    } as Flight,
+  ])[0]!;
+
+const keys = (...args: Parameters<typeof buildFlightIndicators>) =>
+  buildFlightIndicators(...args).map((indicator) => indicator.key);
+
+const labelFor = (
+  key: string,
+  ...args: Parameters<typeof buildFlightIndicators>
+) => buildFlightIndicators(...args).find((i) => i.key === key)?.label;
+
+describe('buildFlightIndicators', () => {
+  it('returns nothing for a flight with only a date', () => {
+    expect(keys(flight())).toEqual([]);
+  });
+
+  it('flags a recorded track only when the flight has one', () => {
+    expect(keys(flight(), { hasTrack: true })).toEqual(['track']);
+    expect(keys(flight(), { hasTrack: false })).toEqual([]);
+  });
+
+  it('ignores scheduled-only times', () => {
+    const scheduled = flight({
+      departureScheduled: '2026-03-12T10:00:00.000Z',
+      arrivalScheduled: '2026-03-12T18:00:00.000Z',
+    });
+    expect(keys(scheduled)).toEqual([]);
+  });
+
+  it('describes which actual times are recorded', () => {
+    expect(
+      labelFor(
+        'actualTimes',
+        flight({ departure: '2026-03-12T10:04:00.000Z' }),
+      ),
+    ).toBe('Actual departure time recorded');
+    expect(
+      labelFor(
+        'actualTimes',
+        flight({ landingActual: '2026-03-12T18:12:00.000Z' }),
+      ),
+    ).toBe('Actual arrival time recorded');
+    expect(
+      labelFor(
+        'actualTimes',
+        flight({
+          departure: '2026-03-12T10:04:00.000Z',
+          arrival: '2026-03-12T18:12:00.000Z',
+        }),
+      ),
+    ).toBe('Actual departure and arrival times recorded');
+  });
+
+  it('previews the note and truncates long ones', () => {
+    expect(labelFor('note', flight({ note: '  Upgraded to J  ' }))).toBe(
+      'Note: Upgraded to J',
+    );
+    expect(labelFor('note', flight({ note: '   ' }))).toBeUndefined();
+
+    const long = 'a'.repeat(200);
+    const label = labelFor('note', flight({ note: long }))!;
+    expect(label).toBe(`Note: ${'a'.repeat(160)}…`);
+  });
+
+  it('keeps a stable order across all indicators', () => {
+    const full = flight({
+      departure: '2026-03-12T10:04:00.000Z',
+      note: 'Window seat',
+    });
+    expect(keys(full, { hasTrack: true })).toEqual([
+      'track',
+      'actualTimes',
+      'note',
+    ]);
+  });
+});

--- a/src/lib/components/modals/list-flights/flight-indicators.ts
+++ b/src/lib/components/modals/list-flights/flight-indicators.ts
@@ -1,0 +1,46 @@
+import type { FlightData } from '$lib/utils';
+
+export type FlightIndicatorKey = 'track' | 'actualTimes' | 'note';
+
+export type FlightIndicator = {
+  key: FlightIndicatorKey;
+  label: string;
+};
+
+const NOTE_PREVIEW_LENGTH = 160;
+
+export const buildFlightIndicators = (
+  flight: FlightData,
+  { hasTrack = false }: { hasTrack?: boolean } = {},
+): FlightIndicator[] => {
+  const indicators: FlightIndicator[] = [];
+
+  if (hasTrack) {
+    indicators.push({ key: 'track', label: 'Flight track recorded' });
+  }
+
+  const hasActualDeparture = Boolean(
+    flight.departure ?? flight.raw.takeoffActual,
+  );
+  const hasActualArrival = Boolean(flight.arrival ?? flight.raw.landingActual);
+  if (hasActualDeparture || hasActualArrival) {
+    const what =
+      hasActualDeparture && hasActualArrival
+        ? 'departure and arrival times'
+        : hasActualDeparture
+          ? 'departure time'
+          : 'arrival time';
+    indicators.push({ key: 'actualTimes', label: `Actual ${what} recorded` });
+  }
+
+  const note = flight.note?.trim();
+  if (note) {
+    const preview =
+      note.length > NOTE_PREVIEW_LENGTH
+        ? `${note.slice(0, NOTE_PREVIEW_LENGTH).trimEnd()}…`
+        : note;
+    indicators.push({ key: 'note', label: `Note: ${preview}` });
+  }
+
+  return indicators;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,6 +83,10 @@
     return data;
   });
 
+  const trackedFlightIds = $derived(
+    new Set(flightTracks.map((track) => track.flightId)),
+  );
+
   let filters: FlightFilters = $state(createDefaultFilters());
   let tempFilters: TempFilters = $state(createDefaultTempFilters());
 
@@ -194,6 +198,7 @@
   {deleteFlight}
   seatUserId={effectiveSeatUserId}
   {showPassengerDetails}
+  {trackedFlightIds}
   onNavigate={navigateFlights}
 />
 <StatisticsModal

--- a/src/routes/share/[slug]/+page.svelte
+++ b/src/routes/share/[slug]/+page.svelte
@@ -85,6 +85,10 @@
     );
   });
 
+  const trackedFlightIds = $derived(
+    new Set(flightTracks.map((track) => track.flightId)),
+  );
+
   let showFlightList = $state(false);
   let showStatistics = $state(false);
   let filters: FlightFilters = $state(createDefaultFilters());
@@ -175,6 +179,7 @@
       bind:open={showFlightList}
       {flights}
       filteredFlights={flights}
+      {trackedFlightIds}
       readonly={true}
     />
   {/if}


### PR DESCRIPTION
### Description

This adds 3 possible icons on the flight list : 
- Track icon: the flight as a recorded flight track
- Clock icon: the flight as the actual flight times recorded
- Note icon: a note is recorded; additionally on mouseover, the note is displayed

<img width="443" height="238" alt="image" src="https://github.com/user-attachments/assets/1a2643ee-09e7-4ff2-8ee7-58aa96a46542" />

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Show track, actual-time, and note indicators in flight lists
> - Adds indicators for recorded tracks, actual departure or arrival times, and saved notes with desktop note previews.
> - Displays indicators in desktop and mobile flight lists across personal and shared views.
> - Derives tracked flight IDs from loaded flight-track data and passes them through the flight-list components.
>
> <sup>AirTrail Helper summarized 2b1d3cb · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
