### PR TITLE
feat: Propose existing guests passanger in passenger detail

### DIFF
--- a/src/lib/components/modals/add-flight/AddFlightModal.svelte
+++ b/src/lib/components/modals/add-flight/AddFlightModal.svelte
@@ -67,6 +67,7 @@
         if (form.message) {
           if (form.message.type === 'success') {
             trpc.flight.list.utils.invalidate();
+            trpc.flight.guests.utils.invalidate();
             trpc.flightTrack.list.utils.invalidate();
             open = false;
             customFieldValues = {};

--- a/src/lib/components/modals/edit-flight/EditFlightModal.svelte
+++ b/src/lib/components/modals/edit-flight/EditFlightModal.svelte
@@ -243,6 +243,7 @@
         if (form.message) {
           if (form.message.type === 'success') {
             trpc.flight.list.utils.invalidate();
+            trpc.flight.guests.utils.invalidate();
             trpc.flightTrack.list.utils.invalidate();
             toast.success(form.message.text);
             open = false;

--- a/src/lib/components/modals/flight-form/PassengerInformation.svelte
+++ b/src/lib/components/modals/flight-form/PassengerInformation.svelte
@@ -63,6 +63,13 @@
       .map((s) => s.userId)
       .filter((id): id is string => id !== null);
   };
+
+  const getExcludedGuestNames = (currentIndex: number): string[] => {
+    return $formData.passengers
+      .filter((_, i) => i !== currentIndex)
+      .map((s) => s.guestName)
+      .filter((name): name is string => !!name);
+  };
 </script>
 
 <section>
@@ -79,6 +86,7 @@
                   bind:userId={$formData.passengers[index].userId}
                   bind:guestName={$formData.passengers[index].guestName}
                   excludeUserIds={getExcludedUserIds(index)}
+                  excludeGuestNames={getExcludedGuestNames(index)}
                   placeholderError={!!$errors?.passengers?.[index]?.userId
                     ?.length}
                 />

--- a/src/lib/components/modals/flight-form/PassengerPicker.svelte
+++ b/src/lib/components/modals/flight-form/PassengerPicker.svelte
@@ -1,26 +1,33 @@
 <script lang="ts">
   import autoAnimate from '@formkit/auto-animate';
   import { createCombobox, melt } from '@melt-ui/svelte';
-  import { User, UserPlus, UserRoundPlus } from '@o7/icon/lucide';
+  import { User, UserPlus, UserRound, UserRoundPlus } from '@o7/icon/lucide';
   import { writable } from 'svelte/store';
   import { fly } from 'svelte/transition';
 
   import { page } from '$app/state';
   import UserModal from '$lib/components/modals/settings/pages/users-page/UserModal.svelte';
   import type { PublicUser } from '$lib/db/types';
+  import { trpc } from '$lib/trpc';
   import { cn } from '$lib/utils';
 
   let {
     userId = $bindable<string | null>(null),
     guestName = $bindable<string | null>(null),
     excludeUserIds = [],
+    excludeGuestNames = [],
     placeholderError = false,
   }: {
     userId?: string | null;
     guestName?: string | null;
     excludeUserIds?: string[];
+    excludeGuestNames?: string[];
     placeholderError?: boolean;
   } = $props();
+
+  const knownGuests = trpc.flight.guests.query(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
 
   let createUser = $state(false);
   let pendingDisplayName = $state('');
@@ -136,8 +143,32 @@
     );
   });
 
-  const showGuestOption = $derived($inputValue.trim().length > 0);
+  const availableGuests = $derived.by(() => {
+    const excluded = new Set(
+      excludeGuestNames.map((name) => name.toLowerCase()),
+    );
+    return ($knownGuests.data ?? []).filter(
+      (guest) =>
+        guest.name === guestName || !excluded.has(guest.name.toLowerCase()),
+    );
+  });
+
+  const filteredGuests = $derived.by(() => {
+    if (!$inputValue) return availableGuests;
+    const search = $inputValue.toLowerCase();
+    return availableGuests.filter((guest) =>
+      guest.name.toLowerCase().includes(search),
+    );
+  });
+
   const trimmedInput = $derived($inputValue.trim());
+  const hasInput = $derived(trimmedInput.length > 0);
+  const showNewGuestOption = $derived(
+    hasInput &&
+      !filteredGuests.some(
+        (guest) => guest.name.toLowerCase() === trimmedInput.toLowerCase(),
+      ),
+  );
 
   const handleUserCreated = (username: string) => {
     // Find the newly created user by username and auto-select them
@@ -209,32 +240,65 @@
               </li>
             {/each}
           </div>
-        {:else if !showGuestOption}
+        {:else if !hasInput && filteredGuests.length === 0}
           <div class="px-3 py-3 text-sm text-muted-foreground">
             Start typing to search...
           </div>
         {/if}
 
-        {#if showGuestOption}
-          <div class="border-t bg-muted/50 p-1">
-            <li
-              use:melt={$option({
-                value: { type: 'guest', name: trimmedInput },
-                label: trimmedInput,
-              })}
-              class="cursor-pointer rounded-md px-2.5 py-2 flex items-center gap-2.5 data-highlighted:bg-background data-selected:ring-2 data-selected:ring-primary transition-colors"
+        {#if filteredGuests.length > 0}
+          <div class={cn('p-1', filteredUsers.length > 0 && 'border-t')}>
+            <div
+              class="px-2.5 py-1 text-xs font-medium text-muted-foreground uppercase"
             >
-              <div
-                class="size-7 rounded-full bg-muted flex items-center justify-center shrink-0"
+              Guests
+            </div>
+            {#each filteredGuests as guest (guest.name)}
+              <li
+                use:melt={$option({
+                  value: { type: 'guest', name: guest.name },
+                  label: guest.name,
+                })}
+                class="cursor-pointer rounded-md px-2.5 py-2 flex items-center gap-2.5 data-highlighted:bg-accent data-selected:ring-2 data-selected:ring-primary transition-colors"
               >
-                <UserPlus size={14} class="text-muted-foreground" />
-              </div>
-              <span class="text-sm text-muted-foreground">
-                Use "<span class="font-medium text-foreground"
-                  >{trimmedInput}</span
-                >" as guest
-              </span>
-            </li>
+                <div
+                  class="size-7 rounded-full bg-muted flex items-center justify-center shrink-0"
+                >
+                  <UserRound size={14} class="text-muted-foreground" />
+                </div>
+                <div class="flex flex-col min-w-0">
+                  <span class="truncate text-sm font-medium">{guest.name}</span>
+                  <span class="truncate text-xs text-muted-foreground">
+                    {guest.count} flight{guest.count === 1 ? '' : 's'}
+                  </span>
+                </div>
+              </li>
+            {/each}
+          </div>
+        {/if}
+
+        {#if hasInput}
+          <div class="border-t bg-muted/50 p-1">
+            {#if showNewGuestOption}
+              <li
+                use:melt={$option({
+                  value: { type: 'guest', name: trimmedInput },
+                  label: trimmedInput,
+                })}
+                class="cursor-pointer rounded-md px-2.5 py-2 flex items-center gap-2.5 data-highlighted:bg-background data-selected:ring-2 data-selected:ring-primary transition-colors"
+              >
+                <div
+                  class="size-7 rounded-full bg-muted flex items-center justify-center shrink-0"
+                >
+                  <UserPlus size={14} class="text-muted-foreground" />
+                </div>
+                <span class="text-sm text-muted-foreground">
+                  Use "<span class="font-medium text-foreground"
+                    >{trimmedInput}</span
+                  >" as guest
+                </span>
+              </li>
+            {/if}
             {#if canCreateUser}
               <li
                 use:melt={$option({

--- a/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
+++ b/src/lib/components/modals/settings/pages/import-page/ImportPage.svelte
@@ -112,6 +112,7 @@
   const refreshImportedFlights = async () => {
     await Promise.all([
       trpc.flight.list.utils.invalidate(),
+      trpc.flight.guests.utils.invalidate(),
       trpc.flightTrack.list.utils.invalidate(),
     ]);
     flightAddedState.added = true;

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -158,6 +158,34 @@ export const listAllFlightsPrimitive = async (db: Kysely<DB>) => {
   return await listFlightBaseQuery(db).execute();
 };
 
+export const listGuestNamesPrimitive = async (
+  db: Kysely<DB>,
+  userId: string,
+) => {
+  const rows = await db
+    .selectFrom('flightPassenger as guest')
+    .select(['guest.guestName as name'])
+    .select((eb) => eb.fn.countAll().as('count'))
+    .where('guest.guestName', 'is not', null)
+    .where((eb) =>
+      eb.exists(
+        eb
+          .selectFrom('flightPassenger as owner')
+          .select('owner.id')
+          .whereRef('owner.flightId', '=', 'guest.flightId')
+          .where('owner.userId', '=', userId),
+      ),
+    )
+    .groupBy('guest.guestName')
+    .execute();
+
+  return rows
+    .flatMap(({ name, count }) =>
+      name ? [{ name, count: Number(count) }] : [],
+    )
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+};
+
 export const getFlightPrimitive = async (db: Kysely<DB>, id: number) => {
   return await db
     .selectFrom('flight')

--- a/src/lib/server/routes/flight.ts
+++ b/src/lib/server/routes/flight.ts
@@ -12,6 +12,7 @@ import {
   createManyFlights,
   deleteFlight,
   listFlights,
+  listGuestNames,
   validateFlightDates,
 } from '$lib/server/utils/flight';
 import { getAircraftFromReg } from '$lib/server/utils/flight-lookup/aerodatabox';
@@ -99,6 +100,9 @@ export const flightRouter = router({
 
       return await listAllFlights();
     }),
+  guests: authedProcedure.query(async ({ ctx: { user } }) => {
+    return await listGuestNames(user.id);
+  }),
   delete: authedProcedure
     .input(z.number())
     .mutation(async ({ ctx: { user }, input }) => {

--- a/src/lib/server/utils/flight.ts
+++ b/src/lib/server/utils/flight.ts
@@ -12,6 +12,7 @@ import {
   listAllFlightsPrimitive,
   listFlightBaseQuery,
   listFlightPrimitive,
+  listGuestNamesPrimitive,
   updateFlightPrimitive,
   updateFlightPrimitiveWithConnection,
   upsertFlightTrackPrimitiveWithConnection,
@@ -91,6 +92,10 @@ export const listFlights = async (userId: string) => {
 
 export const listAllFlights = async () => {
   return await listAllFlightsPrimitive(db);
+};
+
+export const listGuestNames = async (userId: string) => {
+  return await listGuestNamesPrimitive(db, userId);
 };
 
 export const getFlight = async (id: number) => {


### PR DESCRIPTION
Description
Like on the stats / filters, propose a list of previously created "Guest" Passanger, in the passanger edit box.

<img width="414" height="340" alt="image" src="https://github.com/user-attachments/assets/353a8b5b-29e0-4005-ba2c-49e4af0c61e0" />

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Suggest previously used guests in passenger forms
> - Adds an authenticated guest-history query that ranks guest names by flight count.
> - Shows matching existing guests in passenger pickers while excluding guests already selected on the form.
> - Refreshes guest suggestions after flight creation, editing, and import operations.
>
> <sup>AirTrail Helper summarized 0a7c371 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
