### PR TITLE
fix: resync map overlay after backgrounding to fix misalignment

### DIFF
--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -338,6 +338,95 @@
     };
   });
 
+  $effect(() => {
+    if (!map) return;
+    const m = map;
+
+    const forceDeckResync = () => {
+      layer?.setProps({ onClick: handleMapClick, layers: buildLayers() });
+    };
+
+    const CANVAS_SIZE_TOLERANCE_PX = 2;
+    const isDeckCanvasMisaligned = () => {
+      if (isGlobe) return false;
+      const deckCanvas = layer?.getCanvas();
+      const baseCanvas = m.getCanvas();
+      if (!deckCanvas || !baseCanvas) return false;
+      return (
+        Math.abs(deckCanvas.width - baseCanvas.width) >
+          CANVAS_SIZE_TOLERANCE_PX ||
+        Math.abs(deckCanvas.height - baseCanvas.height) >
+          CANVAS_SIZE_TOLERANCE_PX
+      );
+    };
+
+    const VERIFY_DELAY_MS = 300;
+    const MAX_RESYNC_ATTEMPTS = 2;
+    let pendingVerifyTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearPendingVerify = () => {
+      if (pendingVerifyTimer !== null) {
+        clearTimeout(pendingVerifyTimer);
+        pendingVerifyTimer = null;
+      }
+    };
+
+    const verifyAlignment = (attempt = 1) => {
+      pendingVerifyTimer = null;
+      if (!isDeckCanvasMisaligned()) return;
+      if (attempt >= MAX_RESYNC_ATTEMPTS) {
+        window.location.reload();
+        return;
+      }
+      m.resize();
+      forceDeckResync();
+      pendingVerifyTimer = setTimeout(
+        () => verifyAlignment(attempt + 1),
+        VERIFY_DELAY_MS,
+      );
+    };
+
+    const resyncSize = () => {
+      clearPendingVerify();
+      m.resize();
+      forceDeckResync();
+      pendingVerifyTimer = setTimeout(() => verifyAlignment(), VERIFY_DELAY_MS);
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      resyncSize();
+    };
+    const onPageShow = () => resyncSize();
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pageshow', onPageShow);
+
+    let lastObservedSize = '';
+    const container = m.getContainer();
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      const key = `${width}x${height}`;
+      if (key === lastObservedSize) return;
+      lastObservedSize = key;
+      m.resize();
+      forceDeckResync();
+    });
+    resizeObserver.observe(container);
+
+    const onResume = () => resyncSize();
+    document.addEventListener('resume', onResume);
+
+    return () => {
+      clearPendingVerify();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pageshow', onPageShow);
+      document.removeEventListener('resume', onResume);
+      resizeObserver.disconnect();
+    };
+  });
+
   const selectedAirportId = $derived.by(() => {
     const selection = mapDetailsState.selection;
     return selection?.type === 'airport' ? selection.airportId : null;

--- a/src/lib/components/map/AirportsArcsLayer.svelte
+++ b/src/lib/components/map/AirportsArcsLayer.svelte
@@ -370,11 +370,28 @@
       }
     };
 
+    // If the two canvases never actually converge (e.g. their WebGL contexts
+    // clamp device-pixel-ratio or max texture size differently), a reload
+    // just recreates the same structural mismatch — reloading again would
+    // loop forever. Only reload once per cooldown window, then leave the map
+    // as-is until either it self-resolves or enough time has passed to
+    // justify trying again.
+    const RELOAD_LOOP_GUARD_MS = 60_000;
+    const RELOAD_LOOP_GUARD_KEY = 'airtrail:map-misalignment-reload-at';
+    const reloadForMisalignment = () => {
+      const lastReloadAt = Number(
+        sessionStorage.getItem(RELOAD_LOOP_GUARD_KEY) ?? 0,
+      );
+      if (Date.now() - lastReloadAt < RELOAD_LOOP_GUARD_MS) return;
+      sessionStorage.setItem(RELOAD_LOOP_GUARD_KEY, String(Date.now()));
+      window.location.reload();
+    };
+
     const verifyAlignment = (attempt = 1) => {
       pendingVerifyTimer = null;
       if (!isDeckCanvasMisaligned()) return;
       if (attempt >= MAX_RESYNC_ATTEMPTS) {
-        window.location.reload();
+        reloadForMisalignment();
         return;
       }
       m.resize();

--- a/src/lib/map/camera-controller.test.ts
+++ b/src/lib/map/camera-controller.test.ts
@@ -88,8 +88,8 @@ const createFakeMap = () => {
       currentPadding = next;
       return fake;
     },
-    cameraForBounds() {
-      calls.push({ name: 'cameraForBounds' });
+    cameraForBounds(bounds: unknown) {
+      calls.push({ name: 'cameraForBounds', options: { bounds } });
       if (cameraForBoundsError) throw cameraForBoundsError;
       return { center: [4, 5] as [number, number], zoom: 6 };
     },
@@ -98,6 +98,13 @@ const createFakeMap = () => {
       eventData?: Record<string, unknown>,
     ) {
       recordTransition('flyTo', options, eventData);
+      return fake;
+    },
+    jumpTo(
+      options: Record<string, unknown>,
+      eventData?: Record<string, unknown>,
+    ) {
+      recordTransition('jumpTo', options, eventData);
       return fake;
     },
     easeTo(
@@ -295,7 +302,10 @@ describe('map camera controller', () => {
 
     expect(fake.calls.map((call) => call.name)).toEqual([
       'setPadding',
-      'fitBounds',
+      'cameraForBounds',
+      'setPadding',
+      'setPadding',
+      'jumpTo',
     ]);
   });
 
@@ -312,7 +322,10 @@ describe('map camera controller', () => {
 
     expect(fake.calls.map((call) => call.name)).toEqual([
       'setPadding',
-      'fitBounds',
+      'cameraForBounds',
+      'setPadding',
+      'setPadding',
+      'jumpTo',
     ]);
   });
 
@@ -339,7 +352,42 @@ describe('map camera controller', () => {
 
     expect(fake.calls.map((call) => call.name)).toEqual([
       'setPadding',
-      'fitBounds',
+      'cameraForBounds',
+      'setPadding',
+      'setPadding',
+      'jumpTo',
+    ]);
+  });
+
+  it("does not restore an interrupted fit's padding over a newer fit", () => {
+    const fake = createFakeMap();
+    const frames = createFrameScheduler();
+    const controller = createMapCameraController(fake.map, {
+      frameScheduler: frames.scheduler,
+    });
+
+    controller.fit([arc], { projection: 'mercator', padding: padding() });
+    frames.flush();
+    const firstEventData = fake.calls.at(-1)?.eventData;
+
+    controller.fit([updatedArc], {
+      projection: 'mercator',
+      padding: padding(10, 10, 10, 10),
+    });
+    frames.flush();
+    const secondEventData = fake.calls.at(-1)?.eventData;
+    fake.calls.length = 0;
+
+    // MapLibre's own flyTo/jumpTo call _stop() first, which synchronously
+    // completes an in-flight ease and fires its moveend — so the first
+    // fit's moveend can land carrying the first fit's own eventData even
+    // though a second, newer fit has already started.
+    fake.emit('moveend', firstEventData);
+    expect(fake.calls).toEqual([]);
+
+    fake.emit('moveend', secondEventData);
+    expect(fake.calls).toEqual([
+      { name: 'setPadding', options: padding(10, 10, 10, 10) },
     ]);
   });
 
@@ -530,7 +578,10 @@ describe('map camera controller', () => {
 
     expect(fake.calls.map((call) => call.name)).toEqual([
       'setPadding',
-      'fitBounds',
+      'cameraForBounds',
+      'setPadding',
+      'setPadding',
+      'jumpTo',
     ]);
     expect(fake.calls[1]?.options?.bounds).toEqual([
       [3, 1],

--- a/src/lib/map/camera-controller.ts
+++ b/src/lib/map/camera-controller.ts
@@ -201,26 +201,43 @@ export const createMapCameraController = (
 
   const executeFit = (intent: FitIntent) => {
     const padding = addPadding(intent.padding, 60);
+    const jump = intent.source === 'automatic';
     if (intent.projection === 'globe') {
       const target = targetForArcs(intent.arcs, intent.projection, padding);
       if (!target) return;
       map.setPadding(padding);
-      map.flyTo(
-        {
-          center: target.center,
-          zoom: target.zoom,
-          essential: true,
-        },
-        beginProgrammaticMove(),
-      );
+      const transition = {
+        center: target.center,
+        zoom: target.zoom,
+        essential: true,
+      };
+      const eventData = beginProgrammaticMove();
+      if (jump) {
+        map.jumpTo(transition, eventData);
+      } else {
+        map.flyTo(transition, eventData);
+      }
       cameraMode = intent.resultMode;
       return;
     }
 
-    const bounds = calculateBounds(intent.arcs);
-    if (!bounds) return;
+    const target = targetForArcs(intent.arcs, intent.projection, padding);
+    if (!target) return;
+    const MIN_OVERVIEW_ZOOM = 1;
+    const appliedZoom = Math.max(target.zoom, MIN_OVERVIEW_ZOOM);
     map.setPadding(padding);
-    map.fitBounds(bounds, undefined, beginProgrammaticMove());
+    map.once('moveend', () => map.setPadding(intent.padding));
+    const transition = {
+      center: target.center,
+      zoom: appliedZoom,
+      essential: true,
+    };
+    const eventData = beginProgrammaticMove();
+    if (jump) {
+      map.jumpTo(transition, eventData);
+    } else {
+      map.flyTo(transition, eventData);
+    }
     cameraMode = intent.resultMode;
   };
 

--- a/src/lib/map/camera-controller.ts
+++ b/src/lib/map/camera-controller.ts
@@ -147,7 +147,7 @@ export const createMapCameraController = (
     };
   };
 
-  const beginProgrammaticMove = () => {
+  const beginProgrammaticMove = (onComplete?: () => void) => {
     const generation = ++movementGeneration;
     const eventData = { [cameraEventGenerationKey]: generation };
     const handleMoveEnd = (event: unknown) => {
@@ -158,6 +158,13 @@ export const createMapCameraController = (
 
       map.off('moveend', handleMoveEnd);
       moveEndHandlers.delete(handleMoveEnd);
+      // A moveend carrying this generation fires both when the move finishes
+      // naturally and when a newer move interrupts it (MapLibre's internal
+      // _stop() completes the interrupted ease synchronously before starting
+      // the new one). Only run onComplete for a natural finish — if a newer
+      // generation has since started, this one was interrupted, and its
+      // side effects (e.g. restoring padding) would stomp on the newer move.
+      if (generation === movementGeneration) onComplete?.();
     };
     moveEndHandlers.add(handleMoveEnd);
     map.on('moveend', handleMoveEnd);
@@ -226,13 +233,14 @@ export const createMapCameraController = (
     const MIN_OVERVIEW_ZOOM = 1;
     const appliedZoom = Math.max(target.zoom, MIN_OVERVIEW_ZOOM);
     map.setPadding(padding);
-    map.once('moveend', () => map.setPadding(intent.padding));
+    const eventData = beginProgrammaticMove(() =>
+      map.setPadding(intent.padding),
+    );
     const transition = {
       center: target.center,
       zoom: appliedZoom,
       essential: true,
     };
-    const eventData = beginProgrammaticMove();
     if (jump) {
       map.jumpTo(transition, eventData);
     } else {


### PR DESCRIPTION
Fixes #712 

@johanohly - Full disclosure, this code was completely vibe coded. I debugged this issue for a while with Claude and I am more opening this PR to show what actually ended up fixing the issue for me and hopefully make it easier for you to write a real fix if this code is not sufficient.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Resync the map overlay after resume and stabilize overview camera fits
> - Resizes MapLibre and rebuilds Deck layers after visibility, page-show, resume, and container-size changes, then verifies canvas alignment.
> - Calculates arc-fit camera targets explicitly, jumps automatic fits, animates manual fits, and prevents interrupted moves from restoring stale padding.
> - Updates camera-controller coverage for the new fit transitions and overlapping-fit behavior.
>
> <sup>AirTrail Helper summarized cf10d46 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
