### PR TITLE
feat: add indicator icons for tracks, time, passengers, notes

### DIFF
--- a/src/lib/components/modals/list-flights/FlightCard.svelte
+++ b/src/lib/components/modals/list-flights/FlightCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TZDate } from '@date-fns/tz';
+  import type { Snippet } from 'svelte';
 
   import { page } from '$app/state';
   import { AirlineIcon, RouteArrow } from '$lib/components/display';
@@ -20,10 +21,12 @@
     flight,
     passengerLabels = [],
     showMeta = true,
+    indicators,
   }: {
     flight: Flight;
     passengerLabels?: string[];
     showMeta?: boolean;
+    indicators?: Snippet;
   } = $props();
 
   const prefs = $derived(getPreferences(page.data.user));
@@ -87,6 +90,7 @@
             {getFlightNumber(flight)}
           </span>
         {/if}
+        {@render indicators?.()}
       </div>
     {/if}
   </div>

--- a/src/lib/components/modals/list-flights/FlightIndicators.svelte
+++ b/src/lib/components/modals/list-flights/FlightIndicators.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { Clock, Route, StickyNote } from '@o7/icon/lucide';
+
+  import {
+    buildFlightIndicators,
+    type FlightIndicatorKey,
+  } from './flight-indicators';
+
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import { cn, type FlightData } from '$lib/utils';
+
+  let {
+    flight,
+    hasTrack = false,
+    size = 16,
+    tooltips = true,
+    class: className,
+  }: {
+    flight: FlightData;
+    hasTrack?: boolean;
+    size?: number;
+    tooltips?: boolean;
+    class?: string;
+  } = $props();
+
+  const icons: Record<FlightIndicatorKey, typeof Route> = {
+    track: Route,
+    actualTimes: Clock,
+    note: StickyNote,
+  };
+
+  const indicators = $derived(buildFlightIndicators(flight, { hasTrack }));
+</script>
+
+{#if indicators.length}
+  <div
+    class={cn('flex items-center gap-1.5 text-muted-foreground', className)}
+    data-testid="flight-indicators"
+  >
+    {#each indicators as indicator (indicator.key)}
+      {@const Icon = icons[indicator.key]}
+      {#if tooltips}
+        <Tooltip.TextTooltip content={indicator.label}>
+          <Icon {size} data-indicator={indicator.key} />
+        </Tooltip.TextTooltip>
+      {:else}
+        <Icon
+          {size}
+          role="img"
+          aria-label={indicator.label}
+          data-indicator={indicator.key}
+        />
+      {/if}
+    {/each}
+  </div>
+{/if}

--- a/src/lib/components/modals/list-flights/FlightIndicators.svelte
+++ b/src/lib/components/modals/list-flights/FlightIndicators.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Clock, Route, StickyNote } from '@o7/icon/lucide';
+  import { Clock, Route, StickyNote, Users } from '@o7/icon/lucide';
 
   import {
     buildFlightIndicators,
@@ -12,12 +12,14 @@
   let {
     flight,
     hasTrack = false,
+    viewerId = null,
     size = 16,
     tooltips = true,
     class: className,
   }: {
     flight: FlightData;
     hasTrack?: boolean;
+    viewerId?: string | null;
     size?: number;
     tooltips?: boolean;
     class?: string;
@@ -26,10 +28,13 @@
   const icons: Record<FlightIndicatorKey, typeof Route> = {
     track: Route,
     actualTimes: Clock,
+    passengers: Users,
     note: StickyNote,
   };
 
-  const indicators = $derived(buildFlightIndicators(flight, { hasTrack }));
+  const indicators = $derived(
+    buildFlightIndicators(flight, { hasTrack, viewerId }),
+  );
 </script>
 
 {#if indicators.length}

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -463,6 +463,7 @@
         onDelete={readonly ? undefined : handleDelete}
         onShowOnMap={readonly || !onNavigate ? undefined : showFlightOnMap}
         {trackedFlightIds}
+        viewerId={seatUserId ?? null}
         {readonly}
       />
       <div class="h-[130px] sm:h-[90px]"></div>
@@ -600,6 +601,7 @@
                         <FlightIndicators
                           {flight}
                           hasTrack={trackedFlightIds?.has(flight.id) ?? false}
+                          viewerId={seatUserId ?? null}
                         />
                         {#if !readonly}
                           {@render actions(flight)}

--- a/src/lib/components/modals/list-flights/ListFlightsModal.svelte
+++ b/src/lib/components/modals/list-flights/ListFlightsModal.svelte
@@ -14,6 +14,7 @@
   import DeleteFlightModal from './DeleteFlightModal.svelte';
   import EditFlightAction from './EditFlightAction.svelte';
   import EmptyFlightsState from './EmptyFlightsState.svelte';
+  import FlightIndicators from './FlightIndicators.svelte';
   import {
     buildFlightListYears,
     paginateFlightListYears,
@@ -73,6 +74,7 @@
     readonly = false,
     seatUserId,
     showPassengerDetails = false,
+    trackedFlightIds,
     onNavigate,
   }: {
     open?: boolean;
@@ -85,6 +87,7 @@
     readonly?: boolean;
     seatUserId?: string;
     showPassengerDetails?: boolean;
+    trackedFlightIds?: Set<number>;
     onNavigate?: NavigateFlights;
   } = $props();
 
@@ -459,6 +462,7 @@
         onEdit={readonly ? undefined : handleMobileEdit}
         onDelete={readonly ? undefined : handleDelete}
         onShowOnMap={readonly || !onNavigate ? undefined : showFlightOnMap}
+        {trackedFlightIds}
         {readonly}
       />
       <div class="h-[130px] sm:h-[90px]"></div>
@@ -589,12 +593,18 @@
                           {@render airport(flight.to)}
                         </div>
                       </div>
-                      {#if !readonly}
-                        <div aria-hidden="true"></div>
-                        <div class="hidden md:flex">
+                      <div aria-hidden="true"></div>
+                      <div
+                        class="hidden items-center justify-end gap-3 md:flex"
+                      >
+                        <FlightIndicators
+                          {flight}
+                          hasTrack={trackedFlightIds?.has(flight.id) ?? false}
+                        />
+                        {#if !readonly}
                           {@render actions(flight)}
-                        </div>
-                      {/if}
+                        {/if}
+                      </div>
                     </Card>
                   </div>
                 {/each}

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -4,6 +4,7 @@
 
   import type { FlightListYear } from './flight-list-groups';
   import FlightCard from './FlightCard.svelte';
+  import FlightIndicators from './FlightIndicators.svelte';
   import PastFlightsDivider from './PastFlightsDivider.svelte';
   import SwipeableFlightRow from './SwipeableFlightRow.svelte';
 
@@ -22,6 +23,7 @@
     onEdit,
     onDelete,
     onShowOnMap,
+    trackedFlightIds,
     readonly = false,
   }: {
     flightsByYear: FlightListYear<Flight>[];
@@ -30,6 +32,7 @@
     onEdit?: (flight: FlightData) => void;
     onDelete?: (flight: FlightData) => void;
     onShowOnMap?: (flight: FlightData) => void;
+    trackedFlightIds?: Set<number>;
     readonly?: boolean;
   } = $props();
 
@@ -104,7 +107,16 @@
                     <FlightCard
                       {flight}
                       passengerLabels={flight.passengerLabels}
-                    />
+                    >
+                      {#snippet indicators()}
+                        <FlightIndicators
+                          {flight}
+                          hasTrack={trackedFlightIds?.has(flight.id) ?? false}
+                          size={15}
+                          tooltips={false}
+                        />
+                      {/snippet}
+                    </FlightCard>
                   </button>
                 {/snippet}
               </SwipeableFlightRow>

--- a/src/lib/components/modals/list-flights/MobileFlightList.svelte
+++ b/src/lib/components/modals/list-flights/MobileFlightList.svelte
@@ -24,6 +24,7 @@
     onDelete,
     onShowOnMap,
     trackedFlightIds,
+    viewerId = null,
     readonly = false,
   }: {
     flightsByYear: FlightListYear<Flight>[];
@@ -33,6 +34,7 @@
     onDelete?: (flight: FlightData) => void;
     onShowOnMap?: (flight: FlightData) => void;
     trackedFlightIds?: Set<number>;
+    viewerId?: string | null;
     readonly?: boolean;
   } = $props();
 
@@ -112,6 +114,7 @@
                         <FlightIndicators
                           {flight}
                           hasTrack={trackedFlightIds?.has(flight.id) ?? false}
+                          {viewerId}
                           size={15}
                           tooltips={false}
                         />

--- a/src/lib/components/modals/list-flights/flight-indicators.test.ts
+++ b/src/lib/components/modals/list-flights/flight-indicators.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFlightIndicators } from './flight-indicators';
+
+import type { Airport, Flight } from '$lib/db/types';
+import { prepareFlightData } from '$lib/utils';
+
+const airport = (id: number): Airport =>
+  ({ id, tz: 'UTC', lon: 0, lat: 0 }) as Airport;
+
+const CDG = airport(1);
+const JFK = airport(2);
+
+const flight = (overrides: Partial<Flight> = {}) =>
+  prepareFlightData([
+    {
+      id: 1,
+      from: CDG,
+      to: JFK,
+      date: '2026-03-12',
+      datePrecision: 'day',
+      departure: null,
+      arrival: null,
+      duration: null,
+      departureScheduled: null,
+      arrivalScheduled: null,
+      takeoffScheduled: null,
+      takeoffActual: null,
+      landingScheduled: null,
+      landingActual: null,
+      note: null,
+      ...overrides,
+    } as Flight,
+  ])[0]!;
+
+const keys = (...args: Parameters<typeof buildFlightIndicators>) =>
+  buildFlightIndicators(...args).map((indicator) => indicator.key);
+
+const labelFor = (
+  key: string,
+  ...args: Parameters<typeof buildFlightIndicators>
+) => buildFlightIndicators(...args).find((i) => i.key === key)?.label;
+
+describe('buildFlightIndicators', () => {
+  it('returns nothing for a flight with only a date', () => {
+    expect(keys(flight())).toEqual([]);
+  });
+
+  it('flags a recorded track only when the flight has one', () => {
+    expect(keys(flight(), { hasTrack: true })).toEqual(['track']);
+    expect(keys(flight(), { hasTrack: false })).toEqual([]);
+  });
+
+  it('ignores scheduled-only times', () => {
+    const scheduled = flight({
+      departureScheduled: '2026-03-12T10:00:00.000Z',
+      arrivalScheduled: '2026-03-12T18:00:00.000Z',
+    });
+    expect(keys(scheduled)).toEqual([]);
+  });
+
+  it('describes which actual times are recorded', () => {
+    expect(
+      labelFor(
+        'actualTimes',
+        flight({ departure: '2026-03-12T10:04:00.000Z' }),
+      ),
+    ).toBe('Actual departure time recorded');
+    expect(
+      labelFor(
+        'actualTimes',
+        flight({ landingActual: '2026-03-12T18:12:00.000Z' }),
+      ),
+    ).toBe('Actual arrival time recorded');
+    expect(
+      labelFor(
+        'actualTimes',
+        flight({
+          departure: '2026-03-12T10:04:00.000Z',
+          arrival: '2026-03-12T18:12:00.000Z',
+        }),
+      ),
+    ).toBe('Actual departure and arrival times recorded');
+  });
+
+  it('previews the note and truncates long ones', () => {
+    expect(labelFor('note', flight({ note: '  Upgraded to J  ' }))).toBe(
+      'Note: Upgraded to J',
+    );
+    expect(labelFor('note', flight({ note: '   ' }))).toBeUndefined();
+
+    const long = 'a'.repeat(200);
+    const label = labelFor('note', flight({ note: long }))!;
+    expect(label).toBe(`Note: ${'a'.repeat(160)}…`);
+  });
+
+  it('keeps a stable order across all indicators', () => {
+    const full = flight({
+      departure: '2026-03-12T10:04:00.000Z',
+      note: 'Window seat',
+    });
+    expect(keys(full, { hasTrack: true })).toEqual([
+      'track',
+      'actualTimes',
+      'note',
+    ]);
+  });
+});

--- a/src/lib/components/modals/list-flights/flight-indicators.test.ts
+++ b/src/lib/components/modals/list-flights/flight-indicators.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { buildFlightIndicators } from './flight-indicators';
 
-import type { Airport, Flight } from '$lib/db/types';
+import type { Airport, Flight, FlightPassenger } from '$lib/db/types';
 import { prepareFlightData } from '$lib/utils';
 
 const airport = (id: number): Airport =>
@@ -10,6 +10,15 @@ const airport = (id: number): Airport =>
 
 const CDG = airport(1);
 const JFK = airport(2);
+
+const me = (displayName = 'Me'): FlightPassenger =>
+  ({ userId: 'me', user: { id: 'me', displayName } }) as FlightPassenger;
+
+const member = (id: string, displayName: string): FlightPassenger =>
+  ({ userId: id, user: { id, displayName } }) as FlightPassenger;
+
+const guest = (guestName: string | null): FlightPassenger =>
+  ({ userId: null, guestName, user: null }) as FlightPassenger;
 
 const flight = (overrides: Partial<Flight> = {}) =>
   prepareFlightData([
@@ -29,8 +38,9 @@ const flight = (overrides: Partial<Flight> = {}) =>
       landingScheduled: null,
       landingActual: null,
       note: null,
+      passengers: [],
       ...overrides,
-    } as Flight,
+    } as unknown as Flight,
   ])[0]!;
 
 const keys = (...args: Parameters<typeof buildFlightIndicators>) =>
@@ -83,6 +93,39 @@ describe('buildFlightIndicators', () => {
     ).toBe('Actual departure and arrival times recorded');
   });
 
+  it('stays quiet when the viewer is the only passenger', () => {
+    expect(keys(flight({ passengers: [me()] }), { viewerId: 'me' })).toEqual(
+      [],
+    );
+    expect(keys(flight({ passengers: [] }), { viewerId: 'me' })).toEqual([]);
+  });
+
+  it('names the companions travelling with the viewer', () => {
+    const shared = flight({
+      passengers: [me(), member('bob', 'Bob'), guest('Charlie')],
+    });
+    expect(labelFor('passengers', shared, { viewerId: 'me' })).toBe(
+      'Also on board: Bob, Charlie',
+    );
+  });
+
+  it('falls back to a count when companions have no name', () => {
+    const shared = flight({ passengers: [me(), guest(null), guest(null)] });
+    expect(labelFor('passengers', shared, { viewerId: 'me' })).toBe(
+      '2 passengers recorded',
+    );
+  });
+
+  it('needs a real group when there is no viewer to exclude', () => {
+    const solo = flight({ passengers: [member('bob', 'Bob')] });
+    expect(keys(solo)).toEqual([]);
+
+    const group = flight({
+      passengers: [member('bob', 'Bob'), guest('Charlie')],
+    });
+    expect(labelFor('passengers', group)).toBe('Passengers: Bob, Charlie');
+  });
+
   it('previews the note and truncates long ones', () => {
     expect(labelFor('note', flight({ note: '  Upgraded to J  ' }))).toBe(
       'Note: Upgraded to J',
@@ -97,11 +140,13 @@ describe('buildFlightIndicators', () => {
   it('keeps a stable order across all indicators', () => {
     const full = flight({
       departure: '2026-03-12T10:04:00.000Z',
+      passengers: [me(), member('bob', 'Bob')],
       note: 'Window seat',
     });
-    expect(keys(full, { hasTrack: true })).toEqual([
+    expect(keys(full, { hasTrack: true, viewerId: 'me' })).toEqual([
       'track',
       'actualTimes',
+      'passengers',
       'note',
     ]);
   });

--- a/src/lib/components/modals/list-flights/flight-indicators.ts
+++ b/src/lib/components/modals/list-flights/flight-indicators.ts
@@ -1,6 +1,7 @@
-import type { FlightData } from '$lib/utils';
+import { getFlightPassengerLabel, type FlightData } from '$lib/utils';
 
-export type FlightIndicatorKey = 'track' | 'actualTimes' | 'note';
+export type FlightIndicatorKey =
+  'track' | 'actualTimes' | 'passengers' | 'note';
 
 export type FlightIndicator = {
   key: FlightIndicatorKey;
@@ -9,9 +10,19 @@ export type FlightIndicator = {
 
 const NOTE_PREVIEW_LENGTH = 160;
 
+const companionsOf = (flight: FlightData, viewerId: string | null) => {
+  if (!viewerId) {
+    return flight.passengers.length > 1 ? flight.passengers : [];
+  }
+  return flight.passengers.filter((passenger) => passenger.userId !== viewerId);
+};
+
 export const buildFlightIndicators = (
   flight: FlightData,
-  { hasTrack = false }: { hasTrack?: boolean } = {},
+  {
+    hasTrack = false,
+    viewerId = null,
+  }: { hasTrack?: boolean; viewerId?: string | null } = {},
 ): FlightIndicator[] => {
   const indicators: FlightIndicator[] = [];
 
@@ -31,6 +42,20 @@ export const buildFlightIndicators = (
           ? 'departure time'
           : 'arrival time';
     indicators.push({ key: 'actualTimes', label: `Actual ${what} recorded` });
+  }
+
+  const companions = companionsOf(flight, viewerId);
+  if (companions.length) {
+    const names = companions
+      .map((passenger) => getFlightPassengerLabel(passenger))
+      .filter((name): name is string => Boolean(name));
+    const who = viewerId ? 'Also on board' : 'Passengers';
+    indicators.push({
+      key: 'passengers',
+      label: names.length
+        ? `${who}: ${names.join(', ')}`
+        : `${companions.length} passenger${companions.length > 1 ? 's' : ''} recorded`,
+    });
   }
 
   const note = flight.note?.trim();

--- a/src/lib/components/modals/list-flights/flight-indicators.ts
+++ b/src/lib/components/modals/list-flights/flight-indicators.ts
@@ -1,0 +1,46 @@
+import type { FlightData } from '$lib/utils';
+
+export type FlightIndicatorKey = 'track' | 'actualTimes' | 'note';
+
+export type FlightIndicator = {
+  key: FlightIndicatorKey;
+  label: string;
+};
+
+const NOTE_PREVIEW_LENGTH = 160;
+
+export const buildFlightIndicators = (
+  flight: FlightData,
+  { hasTrack = false }: { hasTrack?: boolean } = {},
+): FlightIndicator[] => {
+  const indicators: FlightIndicator[] = [];
+
+  if (hasTrack) {
+    indicators.push({ key: 'track', label: 'Flight track recorded' });
+  }
+
+  const hasActualDeparture = Boolean(
+    flight.departure ?? flight.raw.takeoffActual,
+  );
+  const hasActualArrival = Boolean(flight.arrival ?? flight.raw.landingActual);
+  if (hasActualDeparture || hasActualArrival) {
+    const what =
+      hasActualDeparture && hasActualArrival
+        ? 'departure and arrival times'
+        : hasActualDeparture
+          ? 'departure time'
+          : 'arrival time';
+    indicators.push({ key: 'actualTimes', label: `Actual ${what} recorded` });
+  }
+
+  const note = flight.note?.trim();
+  if (note) {
+    const preview =
+      note.length > NOTE_PREVIEW_LENGTH
+        ? `${note.slice(0, NOTE_PREVIEW_LENGTH).trimEnd()}…`
+        : note;
+    indicators.push({ key: 'note', label: `Note: ${preview}` });
+  }
+
+  return indicators;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,6 +83,10 @@
     return data;
   });
 
+  const trackedFlightIds = $derived(
+    new Set(flightTracks.map((track) => track.flightId)),
+  );
+
   let filters: FlightFilters = $state(createDefaultFilters());
   let tempFilters: TempFilters = $state(createDefaultTempFilters());
 
@@ -194,6 +198,7 @@
   {deleteFlight}
   seatUserId={effectiveSeatUserId}
   {showPassengerDetails}
+  {trackedFlightIds}
   onNavigate={navigateFlights}
 />
 <StatisticsModal

--- a/src/routes/share/[slug]/+page.svelte
+++ b/src/routes/share/[slug]/+page.svelte
@@ -85,6 +85,10 @@
     );
   });
 
+  const trackedFlightIds = $derived(
+    new Set(flightTracks.map((track) => track.flightId)),
+  );
+
   let showFlightList = $state(false);
   let showStatistics = $state(false);
   let filters: FlightFilters = $state(createDefaultFilters());
@@ -175,6 +179,7 @@
       bind:open={showFlightList}
       {flights}
       filteredFlights={flights}
+      {trackedFlightIds}
       readonly={true}
     />
   {/if}


### PR DESCRIPTION
### Description

This adds 3 possible icons on the flight list : 
- Track icon: the flight as a recorded flight track
- Clock icon: the flight as the actual flight times recorded
- Passengers icon: if the flight has extra passengers
- Note icon: a note is recorded; additionally on mouseover, the note is displayed

<img width="591" height="299" alt="image" src="https://github.com/user-attachments/assets/003d428c-48a9-4e59-aafe-1aa76305501e" />
<img width="285" height="150" alt="image" src="https://github.com/user-attachments/assets/76807fd3-b151-4c38-88c4-5773e85f7879" />

Note: replaces #709 and solves #670

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Add flight detail indicators to desktop and mobile lists
> - Shows indicators for recorded tracks, actual times, additional passengers, and notes.
> - Provides contextual labels and note previews for each indicator.
> - Propagates tracked-flight and viewer context through personal and shared flight lists.
>
> <sup>AirTrail Helper summarized 4155e72 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
