### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ If you find an issue, please report it on the [issue tracker](https://github.com
 
 ## Star History
 
-<a href="https://star-history.com/#johanohly/AirTrail&Date">
+<a href="https://star-history.dera.page/#johanohly/AirTrail&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=johanohly/AirTrail&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=johanohly/AirTrail&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=johanohly/AirTrail&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=johanohly/AirTrail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=johanohly/AirTrail&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=johanohly/AirTrail&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README no longer renders because the previous provider is broken due to GitHub stargazer API restrictions. This change points the chart at an alternative that works without an API token, so the chart is visible again in the project overview.

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Restore the README star history chart
> Replace the broken Star History provider links with the token-free star-history.dera.page service for both color schemes and the fallback image.
>
> <sup>AirTrail Helper summarized 1a7ae70 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
