### PR TITLE
feat: expose flight tracks over the API-key REST endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -195,6 +195,121 @@ paths:
           '$ref': '#/components/responses/500'
       security:
         - bearerAuth: []
+  /flight/track/get/{id}:
+    get:
+      tags:
+        - 'Flight'
+      summary: 'Get a flight track'
+      description: 'Get the uploaded GPS track for a specific flight by ID, if one was uploaded. Returns `track: null` if the flight has no uploaded track.'
+      operationId: 'get-flight-track'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: 'The ID of the flight whose track should be retrieved.'
+          schema:
+            type: number
+        - name: reduce
+          in: query
+          required: false
+          description: 'Whether to simplify the track for map rendering (fewer points, capped length). Defaults to `true`. Pass `false` to receive every stored point.'
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          description: 'Flight track, or null if none was uploaded'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  track:
+                    oneOf:
+                      - $ref: '#/components/schemas/FlightTrack'
+                      - type: 'null'
+        '400':
+          description: 'Invalid request'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Flight id is not a number'
+        '401':
+          '$ref': '#/components/responses/401'
+        '403':
+          '$ref': '#/components/responses/403'
+        '500':
+          '$ref': '#/components/responses/500'
+      security:
+        - bearerAuth: []
+  /flight/track/list:
+    get:
+      tags:
+        - 'Flight'
+      summary: 'List flight tracks'
+      description: "List uploaded GPS tracks visible to the authenticated API key, simplified for map rendering. Regular users can only list their own tracks. Admins and owners can also request a specific user's tracks or all tracks. Flights without an uploaded track are omitted."
+      operationId: 'list-flight-tracks'
+      parameters:
+        - name: scope
+          in: query
+          required: false
+          description: 'Which tracks to return. `mine` is the default. `user` and `all` require an admin or owner API key.'
+          schema:
+            type: string
+            enum:
+              - 'mine'
+              - 'user'
+              - 'all'
+            default: 'mine'
+        - name: userId
+          in: query
+          required: false
+          description: 'The user ID whose tracks should be returned when `scope=user`.'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'A list of flight tracks'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tracks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FlightTrack'
+        '400':
+          description: 'Invalid query parameters'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Invalid scope'
+        '401':
+          '$ref': '#/components/responses/401'
+        '403':
+          '$ref': '#/components/responses/403'
+        '500':
+          '$ref': '#/components/responses/500'
+      security:
+        - bearerAuth: []
   /flight/save:
     post:
       tags:
@@ -965,6 +1080,67 @@ components:
           type: integer
           description: 'Number of times this route has been flown.'
           example: 5
+    FlightTrack:
+      type: object
+      required:
+        - flightId
+        - coordinates
+        - sourceFormat
+        - sourceName
+        - pointCount
+      properties:
+        flightId:
+          type: integer
+          example: 42
+        coordinates:
+          type: array
+          description: 'Track points as `[longitude, latitude]` or `[longitude, latitude, altitude]` tuples, ordered chronologically. Long tracks are simplified for map rendering unless `reduce=false` is passed to the single-flight endpoint.'
+          items:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 3
+        times:
+          type: [array, 'null']
+          description: 'Unix timestamp (seconds) for each coordinate, when known.'
+          items:
+            type: integer
+        groundSpeedKt:
+          type: [array, 'null']
+          description: 'Ground speed in knots for each coordinate, when known.'
+          items:
+            type: number
+        trackDeg:
+          type: [array, 'null']
+          description: 'Track heading in degrees for each coordinate, when known.'
+          items:
+            type: number
+        ground:
+          type: [array, 'null']
+          description: 'Whether the aircraft was on the ground at each coordinate, when known.'
+          items:
+            type: boolean
+        estimated:
+          type: [array, 'null']
+          description: 'Whether the segment leading into each coordinate was estimated (e.g. interpolated across a signal gap) rather than directly observed.'
+          items:
+            type: boolean
+        sourceFormat:
+          type: string
+          description: 'The format the track was originally uploaded in.'
+          enum:
+            - 'gpx'
+            - 'kml'
+            - 'csv'
+            - 'readsb'
+        sourceName:
+          type: [string, 'null']
+          description: 'The original filename the track was uploaded from, if any.'
+        pointCount:
+          type: integer
+          description: 'Number of points in the originally uploaded track, before any map-rendering simplification.'
+          example: 842
   responses:
     200:
       description: 'Success'

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -376,6 +376,49 @@ export const deleteFlightTrackPrimitiveWithConnection = async (
   await db.deleteFrom('flightTrack').where('flightId', '=', flightId).execute();
 };
 
+const flightTrackRowColumns = [
+  'flightTrack.flightId',
+  'flightTrack.track',
+  'flightTrack.sourceFormat',
+  'flightTrack.sourceName',
+  'flightTrack.pointCount',
+] as const;
+
+export const getFlightTrackRowPrimitive = async (
+  db: Kysely<DB>,
+  flightId: number,
+) => {
+  return await db
+    .selectFrom('flightTrack')
+    .select(flightTrackRowColumns)
+    .where('flightId', '=', flightId)
+    .executeTakeFirst();
+};
+
+export const listFlightTrackRowsPrimitive = async (
+  db: Kysely<DB>,
+  userId?: string,
+) => {
+  let query = db
+    .selectFrom('flightTrack')
+    .innerJoin('flight', 'flight.id', 'flightTrack.flightId')
+    .select(flightTrackRowColumns);
+
+  if (userId) {
+    query = query.where((eb) =>
+      eb.exists(
+        eb
+          .selectFrom('flightPassenger')
+          .select('flightPassenger.id')
+          .whereRef('flightPassenger.flightId', '=', 'flight.id')
+          .where('flightPassenger.userId', '=', userId),
+      ),
+    );
+  }
+
+  return await query.execute();
+};
+
 export const createManyFlightsPrimitive = async (
   db: Kysely<DB>,
   data: CreateFlight[],

--- a/src/lib/server/routes/flight-track.ts
+++ b/src/lib/server/routes/flight-track.ts
@@ -3,12 +3,11 @@ import { z } from 'zod';
 
 import { db } from '$lib/db';
 import { authedProcedure, router } from '$lib/server/trpc';
-import { reduceFlightTrackForMap } from '$lib/track/render';
 import {
-  flightTrackPayloadSchema,
-  type FlightTrackRow,
-  type FlightTrackSourceFormat,
-} from '$lib/track/schema';
+  getFlightTrack,
+  listAllFlightTracks,
+  listFlightTracks,
+} from '$lib/server/utils/flight-track';
 
 const flightTrackListInput = z
   .object({
@@ -17,75 +16,32 @@ const flightTrackListInput = z
   })
   .optional();
 
-const parseTrackRow = (
-  row: {
-    flightId: number;
-    track: unknown;
-    sourceFormat: FlightTrackSourceFormat;
-    sourceName: string | null;
-    pointCount: number;
-  },
-  reduceForMap = false,
-): FlightTrackRow => {
-  const track = flightTrackPayloadSchema.parse(row.track);
-  return {
-    flightId: row.flightId,
-    ...(reduceForMap ? reduceFlightTrackForMap(track) : track),
-    sourceFormat: row.sourceFormat,
-    sourceName: row.sourceName,
-    pointCount: row.pointCount,
-  };
-};
-
 export const flightTrackRouter = router({
   list: authedProcedure
     .input(flightTrackListInput)
     .query(async ({ ctx: { user }, input }) => {
       const scope = input?.scope ?? 'mine';
 
-      if (user.role === 'user' && scope !== 'mine') {
+      if (scope === 'mine') {
+        return await listFlightTracks(user.id, { reduceForMap: true });
+      }
+
+      if (user.role === 'user') {
         throw new TRPCError({ code: 'FORBIDDEN' });
       }
 
-      if (scope === 'user' && !input?.userId) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'A user is required for this scope',
-        });
+      if (scope === 'user') {
+        if (!input?.userId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'A user is required for this scope',
+          });
+        }
+
+        return await listFlightTracks(input.userId, { reduceForMap: true });
       }
 
-      let query = db
-        .selectFrom('flightTrack')
-        .innerJoin('flight', 'flight.id', 'flightTrack.flightId')
-        .select([
-          'flightTrack.flightId',
-          'flightTrack.track',
-          'flightTrack.sourceFormat',
-          'flightTrack.sourceName',
-          'flightTrack.pointCount',
-        ]);
-
-      let scopedUserId: string | null | undefined = null;
-      if (scope === 'mine') {
-        scopedUserId = user.id;
-      } else if (scope === 'user') {
-        scopedUserId = input?.userId;
-      }
-
-      if (scopedUserId) {
-        query = query.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('flightPassenger')
-              .select('flightPassenger.id')
-              .whereRef('flightPassenger.flightId', '=', 'flight.id')
-              .where('flightPassenger.userId', '=', scopedUserId),
-          ),
-        );
-      }
-
-      const rows = await query.execute();
-      return rows.map((row) => parseTrackRow(row, true));
+      return await listAllFlightTracks({ reduceForMap: true });
     }),
   get: authedProcedure
     .input(z.number())
@@ -111,18 +67,6 @@ export const flightTrackRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND' });
       }
 
-      const row = await db
-        .selectFrom('flightTrack')
-        .select([
-          'flightTrack.flightId',
-          'flightTrack.track',
-          'flightTrack.sourceFormat',
-          'flightTrack.sourceName',
-          'flightTrack.pointCount',
-        ])
-        .where('flightId', '=', input)
-        .executeTakeFirst();
-
-      return row ? parseTrackRow(row) : null;
+      return await getFlightTrack(input);
     }),
 });

--- a/src/lib/server/utils/flight-track.ts
+++ b/src/lib/server/utils/flight-track.ts
@@ -1,0 +1,56 @@
+import { db } from '$lib/db';
+import {
+  getFlightTrackRowPrimitive,
+  listFlightTrackRowsPrimitive,
+} from '$lib/db/queries';
+import { reduceFlightTrackForMap } from '$lib/track/render';
+import {
+  flightTrackPayloadSchema,
+  type FlightTrackRow,
+  type FlightTrackSourceFormat,
+} from '$lib/track/schema';
+
+type FlightTrackRowSource = {
+  flightId: number;
+  track: unknown;
+  sourceFormat: FlightTrackSourceFormat;
+  sourceName: string | null;
+  pointCount: number;
+};
+
+const parseTrackRow = (
+  row: FlightTrackRowSource,
+  reduceForMap = false,
+): FlightTrackRow => {
+  const track = flightTrackPayloadSchema.parse(row.track);
+  return {
+    flightId: row.flightId,
+    ...(reduceForMap ? reduceFlightTrackForMap(track) : track),
+    sourceFormat: row.sourceFormat,
+    sourceName: row.sourceName,
+    pointCount: row.pointCount,
+  };
+};
+
+export const getFlightTrack = async (
+  flightId: number,
+  { reduceForMap = false }: { reduceForMap?: boolean } = {},
+): Promise<FlightTrackRow | null> => {
+  const row = await getFlightTrackRowPrimitive(db, flightId);
+  return row ? parseTrackRow(row, reduceForMap) : null;
+};
+
+export const listFlightTracks = async (
+  userId: string,
+  { reduceForMap = false }: { reduceForMap?: boolean } = {},
+): Promise<FlightTrackRow[]> => {
+  const rows = await listFlightTrackRowsPrimitive(db, userId);
+  return rows.map((row) => parseTrackRow(row, reduceForMap));
+};
+
+export const listAllFlightTracks = async (
+  { reduceForMap = false }: { reduceForMap?: boolean } = {},
+): Promise<FlightTrackRow[]> => {
+  const rows = await listFlightTrackRowsPrimitive(db);
+  return rows.map((row) => parseTrackRow(row, reduceForMap));
+};

--- a/src/lib/server/utils/flight-track.ts
+++ b/src/lib/server/utils/flight-track.ts
@@ -48,9 +48,9 @@ export const listFlightTracks = async (
   return rows.map((row) => parseTrackRow(row, reduceForMap));
 };
 
-export const listAllFlightTracks = async (
-  { reduceForMap = false }: { reduceForMap?: boolean } = {},
-): Promise<FlightTrackRow[]> => {
+export const listAllFlightTracks = async ({
+  reduceForMap = false,
+}: { reduceForMap?: boolean } = {}): Promise<FlightTrackRow[]> => {
   const rows = await listFlightTrackRowsPrimitive(db);
   return rows.map((row) => parseTrackRow(row, reduceForMap));
 };

--- a/src/routes/api/flight/track/get/[id]/+server.ts
+++ b/src/routes/api/flight/track/get/[id]/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+import { apiError, unauthorized, validateApiKey } from '$lib/server/utils/api';
+import { getFlight } from '$lib/server/utils/flight';
+import { getFlightTrack } from '$lib/server/utils/flight-track';
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const user = await validateApiKey(request);
+  if (!user) {
+    return unauthorized();
+  }
+
+  const id = +params.id;
+  if (isNaN(id)) {
+    return apiError('Flight id is not a number', 400);
+  }
+
+  const flight = await getFlight(id);
+  if (!flight) {
+    return apiError('Flight not found', 404);
+  }
+  if (
+    user.role === 'user' &&
+    !flight.passengers.some((passenger) => passenger.userId === user.id)
+  ) {
+    return apiError('You are not a passenger on this flight', 403);
+  }
+
+  const reduceForMap = url.searchParams.get('reduce') !== 'false';
+  const track = await getFlightTrack(id, { reduceForMap });
+
+  return json({ success: true, track });
+};

--- a/src/routes/api/flight/track/list/+server.ts
+++ b/src/routes/api/flight/track/list/+server.ts
@@ -1,0 +1,47 @@
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+import { apiError, unauthorized, validateApiKey } from '$lib/server/utils/api';
+import {
+  listAllFlightTracks,
+  listFlightTracks,
+} from '$lib/server/utils/flight-track';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+  const user = await validateApiKey(request);
+  if (!user) {
+    return unauthorized();
+  }
+
+  const scope = url.searchParams.get('scope') ?? 'mine';
+
+  if (scope === 'mine') {
+    const tracks = await listFlightTracks(user.id, { reduceForMap: true });
+    return json({ success: true, tracks });
+  }
+
+  if (user.role === 'user') {
+    return apiError('Forbidden', 403);
+  }
+
+  if (scope === 'user') {
+    const userId = url.searchParams.get('userId');
+    if (!userId) {
+      return apiError(
+        'A userId query parameter is required for user scope',
+        400,
+      );
+    }
+
+    const tracks = await listFlightTracks(userId, { reduceForMap: true });
+    return json({ success: true, tracks });
+  }
+
+  if (scope === 'all') {
+    const tracks = await listAllFlightTracks({ reduceForMap: true });
+    return json({ success: true, tracks });
+  }
+
+  return apiError('Invalid scope', 400);
+};


### PR DESCRIPTION
Uploaded GPS tracks were only reachable via the cookie-authenticated tRPC router, so external API clients had no way to fetch them. Adds GET /api/flight/track/get/{id} and /api/flight/track/list alongside the existing /api/flight/* routes, backed by a shared utils layer also used by the tRPC router.

Implements https://github.com/johanohly/AirTrail/discussions/720

<!-- airtrail-ai-summary:start -->
<!-- AirTrail AI only edits content between these markers. -->
> [!NOTE]
> ### Expose uploaded flight tracks through API-key REST endpoints
> - Adds API-key-authenticated endpoints to retrieve an individual flight track and list tracks by access scope.
> - Shares flight-track querying, parsing, and map reduction between the REST endpoints and the existing tRPC router.
> - Documents the new endpoints, query parameters, responses, and flight-track schema in OpenAPI.
>
> <sup>AirTrail Helper summarized fa13c79 · AI-generated summary; verify important details.</sup>
<!-- airtrail-ai-summary:end -->
